### PR TITLE
[BE] feat: 특정 상품의 리뷰 목록 조회 기능 추가 

### DIFF
--- a/backend/src/main/java/com/funeat/member/domain/Member.java
+++ b/backend/src/main/java/com/funeat/member/domain/Member.java
@@ -58,4 +58,40 @@ public class Member {
     public Long getId() {
         return id;
     }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getProfileImage() {
+        return profileImage;
+    }
+
+    public Integer getAge() {
+        return age;
+    }
+
+    public Gender getGender() {
+        return gender;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public List<ReviewFavorite> getReviewFavorites() {
+        return reviewFavorites;
+    }
+
+    public List<RecipeFavorite> getRecipeFavorites() {
+        return recipeFavorites;
+    }
+
+    public List<ProductBookmark> getProductBookmarks() {
+        return productBookmarks;
+    }
+
+    public List<RecipeBookmark> getRecipeBookmarks() {
+        return recipeBookmarks;
+    }
 }

--- a/backend/src/main/java/com/funeat/member/domain/favorite/ReviewFavorite.java
+++ b/backend/src/main/java/com/funeat/member/domain/favorite/ReviewFavorite.java
@@ -26,6 +26,15 @@ public class ReviewFavorite {
 
     private Boolean checked;
 
+    protected ReviewFavorite() {
+    }
+
+    public ReviewFavorite(final Member member, final Review review, final Boolean checked) {
+        this.member = member;
+        this.review = review;
+        this.checked = checked;
+    }
+
     public Long getId() {
         return id;
     }

--- a/backend/src/main/java/com/funeat/member/domain/favorite/ReviewFavorite.java
+++ b/backend/src/main/java/com/funeat/member/domain/favorite/ReviewFavorite.java
@@ -25,4 +25,20 @@ public class ReviewFavorite {
     private Review review;
 
     private Boolean checked;
+
+    public Long getId() {
+        return id;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public Review getReview() {
+        return review;
+    }
+
+    public Boolean getChecked() {
+        return checked;
+    }
 }

--- a/backend/src/main/java/com/funeat/review/application/ReviewService.java
+++ b/backend/src/main/java/com/funeat/review/application/ReviewService.java
@@ -93,7 +93,7 @@ public class ReviewService {
         final List<Review> sortingReviews = reviewRepository.findReviewsByProductOrderByFavoriteCountDesc(pageable, product);
 
         return sortingReviews.stream()
-                .map(review -> SortingReviewDto.toDto(review))
+                .map(SortingReviewDto::toDto)
                 .collect(Collectors.toList());
     }
 

--- a/backend/src/main/java/com/funeat/review/application/ReviewService.java
+++ b/backend/src/main/java/com/funeat/review/application/ReviewService.java
@@ -16,15 +16,10 @@ import com.funeat.tag.domain.Tag;
 import com.funeat.tag.persistence.TagRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/backend/src/main/java/com/funeat/review/application/ReviewService.java
+++ b/backend/src/main/java/com/funeat/review/application/ReviewService.java
@@ -9,13 +9,22 @@ import com.funeat.review.domain.ReviewTag;
 import com.funeat.review.persistence.ReviewRepository;
 import com.funeat.review.persistence.ReviewTagRepository;
 import com.funeat.review.presentation.dto.ReviewCreateRequest;
+import com.funeat.review.presentation.dto.SortingReviewDto;
+import com.funeat.review.presentation.dto.SortingReviewsPageDto;
 import com.funeat.tag.domain.Tag;
 import com.funeat.tag.persistence.TagRepository;
-import java.util.List;
-import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -26,25 +35,23 @@ public class ReviewService {
     private final ReviewTagRepository reviewTagRepository;
     private final MemberRepository memberRepository;
     private final ProductRepository productRepository;
-    private final ImageService imageService;
 
     public ReviewService(final ReviewRepository reviewRepository, final TagRepository tagRepository,
                          final ReviewTagRepository reviewTagRepository, final MemberRepository memberRepository,
-                         final ProductRepository productRepository, final ImageService imageService) {
+                         final ProductRepository productRepository) {
         this.reviewRepository = reviewRepository;
         this.tagRepository = tagRepository;
         this.reviewTagRepository = reviewTagRepository;
         this.memberRepository = memberRepository;
         this.productRepository = productRepository;
-        this.imageService = imageService;
     }
 
     @Transactional
-    public void create(final Long productId, final MultipartFile image, final ReviewCreateRequest reviewRequest) {
-        final Member findMember = memberRepository.findById(reviewRequest.getMemberId())
-                .orElseThrow(IllegalArgumentException::new);
-        final Product findProduct = productRepository.findById(productId)
-                .orElseThrow(IllegalArgumentException::new);
+    public void create(final Long productId, final MultipartFile image,
+                       final ReviewCreateRequest reviewRequest) {
+        final Member findMember = memberRepository.findById(reviewRequest.getMemberId()).get();
+        final Product findProduct = productRepository.findById(productId).get();
+        writeImage(image);
 
         final Review savedReview = reviewRepository.save(
                 new Review(findMember, findProduct, image.getOriginalFilename(), reviewRequest.getRating(),
@@ -53,10 +60,49 @@ public class ReviewService {
         final List<Tag> findTags = tagRepository.findTagsByIdIn(reviewRequest.getTagIds());
 
         final List<ReviewTag> reviewTags = findTags.stream()
-                .map(findTag -> ReviewTag.createReviewTag(savedReview, findTag))
+                .map(findTag -> new ReviewTag(savedReview, findTag))
                 .collect(Collectors.toList());
 
-        imageService.upload(image);
         reviewTagRepository.saveAll(reviewTags);
+    }
+
+    private void writeImage(final MultipartFile image) {
+        final String originalImageName = image.getOriginalFilename();
+        final Path path = Paths.get("/Users/wugawuga/fun-eat/review/images/" + originalImageName);
+        try {
+            Files.write(path, image.getBytes());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public List<SortingReviewDto> sortingReviews(final Long productId,
+                                                 final Pageable pageable,
+                                                 final String sort) {
+        if (sort.equals("favorite")) {
+            return sortingReviewsByFavoriteCount(productId, pageable);
+        }
+        return List.of();
+    }
+
+    private List<SortingReviewDto> sortingReviewsByFavoriteCount(final Long productId,
+                                                                 final Pageable pageable) {
+        final Product product = productRepository.findById(productId)
+                .orElseThrow(IllegalArgumentException::new);
+
+        final List<Review> sortingReviews = reviewRepository.findReviewsByProductOrderByFavoriteCountDesc(pageable, product);
+
+        return sortingReviews.stream()
+                .map(review -> SortingReviewDto.toDto(review))
+                .collect(Collectors.toList());
+    }
+
+    public SortingReviewsPageDto computePageInfo(final Pageable pageable,
+                                                 final Long productId) {
+        final Product product = productRepository.findById(productId)
+                .orElseThrow(IllegalArgumentException::new);
+        final Page<Review> reviewsPage = reviewRepository.findReviewsByProduct(pageable, product);
+
+        return SortingReviewsPageDto.toDto(reviewsPage);
     }
 }

--- a/backend/src/main/java/com/funeat/review/domain/Review.java
+++ b/backend/src/main/java/com/funeat/review/domain/Review.java
@@ -3,8 +3,7 @@ package com.funeat.review.domain;
 import com.funeat.member.domain.Member;
 import com.funeat.member.domain.favorite.ReviewFavorite;
 import com.funeat.product.domain.Product;
-import java.util.ArrayList;
-import java.util.List;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -12,6 +11,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import java.util.List;
 
 @Entity
 public class Review {
@@ -37,7 +37,7 @@ public class Review {
     private Member member;
 
     @OneToMany(mappedBy = "review")
-    private List<ReviewTag> reviewTags = new ArrayList<>();
+    private List<ReviewTag> reviewTags;
 
     @OneToMany(mappedBy = "review")
     private List<ReviewFavorite> reviewFavorites;
@@ -45,10 +45,12 @@ public class Review {
     private Long favoriteCount = 0L;
 
     protected Review() {
+
     }
 
     public Review(final Member member, final Product findProduct, final String image, final Double rating,
-                  final String content, final Boolean reBuy) {
+                  final String content,
+                  final Boolean reBuy) {
         this.member = member;
         this.product = findProduct;
         this.image = image;

--- a/backend/src/main/java/com/funeat/review/domain/Review.java
+++ b/backend/src/main/java/com/funeat/review/domain/Review.java
@@ -45,7 +45,6 @@ public class Review {
     private Long favoriteCount = 0L;
 
     protected Review() {
-
     }
 
     public Review(final Member member, final Product findProduct, final String image, final Double rating,
@@ -60,7 +59,9 @@ public class Review {
     }
 
     public Review(final Member member, final Product findProduct, final String image, final Double rating,
-                  final String content, final Boolean reBuy, final Long favoriteCount) {
+                  final String content,
+                  final Boolean reBuy,
+                  final Long favoriteCount) {
         this.member = member;
         this.product = findProduct;
         this.image = image;

--- a/backend/src/main/java/com/funeat/review/domain/Review.java
+++ b/backend/src/main/java/com/funeat/review/domain/Review.java
@@ -11,6 +11,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -37,7 +38,7 @@ public class Review {
     private Member member;
 
     @OneToMany(mappedBy = "review")
-    private List<ReviewTag> reviewTags;
+    private List<ReviewTag> reviewTags = new ArrayList<>();
 
     @OneToMany(mappedBy = "review")
     private List<ReviewFavorite> reviewFavorites;
@@ -48,8 +49,7 @@ public class Review {
     }
 
     public Review(final Member member, final Product findProduct, final String image, final Double rating,
-                  final String content,
-                  final Boolean reBuy) {
+                  final String content, final Boolean reBuy) {
         this.member = member;
         this.product = findProduct;
         this.image = image;
@@ -59,9 +59,7 @@ public class Review {
     }
 
     public Review(final Member member, final Product findProduct, final String image, final Double rating,
-                  final String content,
-                  final Boolean reBuy,
-                  final Long favoriteCount) {
+                  final String content, final Boolean reBuy, final Long favoriteCount) {
         this.member = member;
         this.product = findProduct;
         this.image = image;

--- a/backend/src/main/java/com/funeat/review/domain/ReviewTag.java
+++ b/backend/src/main/java/com/funeat/review/domain/ReviewTag.java
@@ -2,8 +2,8 @@ package com.funeat.review.domain;
 
 import com.funeat.tag.domain.Tag;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -17,18 +17,18 @@ public class ReviewTag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(cascade = CascadeType.PERSIST)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id")
     private Review review;
 
-    @ManyToOne(cascade = CascadeType.PERSIST)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tag_id")
     private Tag tag;
 
     protected ReviewTag() {
     }
 
-    public ReviewTag(final Review review, final Tag tag) {
+    private ReviewTag(final Review review, final Tag tag) {
         this.review = review;
         this.tag = tag;
     }

--- a/backend/src/main/java/com/funeat/review/domain/ReviewTag.java
+++ b/backend/src/main/java/com/funeat/review/domain/ReviewTag.java
@@ -1,8 +1,9 @@
 package com.funeat.review.domain;
 
 import com.funeat.tag.domain.Tag;
+
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -16,18 +17,18 @@ public class ReviewTag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "review_id")
     private Review review;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "tag_id")
     private Tag tag;
 
     protected ReviewTag() {
     }
 
-    private ReviewTag(final Review review, final Tag tag) {
+    public ReviewTag(final Review review, final Tag tag) {
         this.review = review;
         this.tag = tag;
     }
@@ -36,5 +37,17 @@ public class ReviewTag {
         final ReviewTag reviewTag = new ReviewTag(review, tag);
         review.getReviewTags().add(reviewTag);
         return reviewTag;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Review getReview() {
+        return review;
+    }
+
+    public Tag getTag() {
+        return tag;
     }
 }

--- a/backend/src/main/java/com/funeat/review/persistence/ReviewRepository.java
+++ b/backend/src/main/java/com/funeat/review/persistence/ReviewRepository.java
@@ -6,8 +6,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     Page<Review> findReviewsByProduct(final Pageable pageable, final Product product);

--- a/backend/src/main/java/com/funeat/review/persistence/ReviewRepository.java
+++ b/backend/src/main/java/com/funeat/review/persistence/ReviewRepository.java
@@ -11,6 +11,4 @@ import java.util.List;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     Page<Review> findReviewsByProduct(final Pageable pageable, final Product product);
-
-    List<Review> findReviewsByProductOrderByFavoriteCountDesc(final Pageable pageable, final Product product);
 }

--- a/backend/src/main/java/com/funeat/review/persistence/ReviewRepository.java
+++ b/backend/src/main/java/com/funeat/review/persistence/ReviewRepository.java
@@ -2,10 +2,11 @@ package com.funeat.review.persistence;
 
 import com.funeat.product.domain.Product;
 import com.funeat.review.domain.Review;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 

--- a/backend/src/main/java/com/funeat/review/presentation/ReviewController.java
+++ b/backend/src/main/java/com/funeat/review/presentation/ReviewController.java
@@ -13,17 +13,10 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.funeat.review.application.ReviewService;
-import com.funeat.review.presentation.dto.SortingReviewDto;
-import com.funeat.review.presentation.dto.SortingReviewsPageDto;
 import com.funeat.review.presentation.dto.SortingReviewsResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 

--- a/backend/src/main/java/com/funeat/review/presentation/ReviewController.java
+++ b/backend/src/main/java/com/funeat/review/presentation/ReviewController.java
@@ -49,9 +49,7 @@ public class ReviewController {
     @GetMapping(value = "/api/products/{productId}/reviews")
     public ResponseEntity<SortingReviewsResponse> getSortingReviews(@PathVariable Long productId,
                                                                     @PageableDefault Pageable pageable) {
-        final SortingReviewsPageDto sortingReviewsPageDto = reviewService.computePageInfo(pageable, productId);
-        final List<SortingReviewDto> reviews = reviewService.sortingReviews(productId, pageable);
-        final SortingReviewsResponse response = new SortingReviewsResponse(sortingReviewsPageDto, reviews);
+        final SortingReviewsResponse response = reviewService.sortingReviews(productId, pageable);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/funeat/review/presentation/ReviewController.java
+++ b/backend/src/main/java/com/funeat/review/presentation/ReviewController.java
@@ -38,8 +38,7 @@ public class ReviewController {
 
     @PostMapping(value = "/api/products/{productId}/reviews", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
             MediaType.APPLICATION_JSON_VALUE})
-    public ResponseEntity<Void> writeReview(@PathVariable Long productId,
-                                            @RequestPart MultipartFile image,
+    public ResponseEntity<Void> writeReview(@PathVariable Long productId, @RequestPart MultipartFile image,
                                             @RequestPart ReviewCreateRequest reviewRequest) {
         reviewService.create(productId, image, reviewRequest);
 

--- a/backend/src/main/java/com/funeat/review/presentation/ReviewController.java
+++ b/backend/src/main/java/com/funeat/review/presentation/ReviewController.java
@@ -48,10 +48,9 @@ public class ReviewController {
 
     @GetMapping(value = "/api/products/{productId}/reviews")
     public ResponseEntity<SortingReviewsResponse> getSortingReviews(@PathVariable Long productId,
-                                                                    @RequestParam String option,
                                                                     @PageableDefault Pageable pageable) {
         final SortingReviewsPageDto sortingReviewsPageDto = reviewService.computePageInfo(pageable, productId);
-        final List<SortingReviewDto> reviews = reviewService.sortingReviews(productId, pageable, option);
+        final List<SortingReviewDto> reviews = reviewService.sortingReviews(productId, pageable);
         final SortingReviewsResponse response = new SortingReviewsResponse(sortingReviewsPageDto, reviews);
 
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/com/funeat/review/presentation/ReviewController.java
+++ b/backend/src/main/java/com/funeat/review/presentation/ReviewController.java
@@ -2,7 +2,9 @@ package com.funeat.review.presentation;
 
 import com.funeat.review.application.ReviewService;
 import com.funeat.review.presentation.dto.ReviewCreateRequest;
+
 import java.net.URI;
+
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,6 +12,20 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import com.funeat.review.application.ReviewService;
+import com.funeat.review.presentation.dto.SortingReviewDto;
+import com.funeat.review.presentation.dto.SortingReviewsPageDto;
+import com.funeat.review.presentation.dto.SortingReviewsResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 public class ReviewController {
@@ -22,10 +38,22 @@ public class ReviewController {
 
     @PostMapping(value = "/api/products/{productId}/reviews", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
             MediaType.APPLICATION_JSON_VALUE})
-    public ResponseEntity<Void> writeReview(@PathVariable Long productId, @RequestPart MultipartFile image,
+    public ResponseEntity<Void> writeReview(@PathVariable Long productId,
+                                            @RequestPart MultipartFile image,
                                             @RequestPart ReviewCreateRequest reviewRequest) {
         reviewService.create(productId, image, reviewRequest);
 
         return ResponseEntity.created(URI.create("/api/products/" + productId)).build();
+    }
+
+    @GetMapping(value = "/api/products/{productId}/reviews")
+    public ResponseEntity<SortingReviewsResponse> getSortingReviews(@PathVariable Long productId,
+                                                                    @RequestParam String option,
+                                                                    @PageableDefault Pageable pageable) {
+        final SortingReviewsPageDto sortingReviewsPageDto = reviewService.computePageInfo(pageable, productId);
+        final List<SortingReviewDto> reviews = reviewService.sortingReviews(productId, pageable, option);
+        final SortingReviewsResponse response = new SortingReviewsResponse(sortingReviewsPageDto, reviews);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewDto.java
+++ b/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewDto.java
@@ -1,0 +1,121 @@
+package com.funeat.review.presentation.dto;
+
+import com.funeat.member.domain.favorite.ReviewFavorite;
+import com.funeat.review.domain.Review;
+import com.funeat.review.domain.ReviewTag;
+import com.funeat.tag.domain.Tag;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class SortingReviewDto {
+
+    private Long id;
+    private String userName;
+    private String profileImage;
+    private String image;
+    private Double rating;
+    private List<Tag> tags;
+    private String content;
+    private boolean rebuy;
+    private Long favoriteCount;
+    private boolean favorite;
+
+    public SortingReviewDto(final Long id,
+                            final String userName,
+                            final String profileImage,
+                            final String image,
+                            final Double rating,
+                            final List<Tag> tags,
+                            final String content,
+                            final boolean rebuy,
+                            final Long favoriteCount,
+                            final boolean favorite) {
+        this.id = id;
+        this.userName = userName;
+        this.profileImage = profileImage;
+        this.image = image;
+        this.rating = rating;
+        this.tags = tags;
+        this.content = content;
+        this.rebuy = rebuy;
+        this.favoriteCount = favoriteCount;
+        this.favorite = favorite;
+    }
+
+    public static SortingReviewDto toDto(final Review review) {
+        return new SortingReviewDto(
+                review.getId(),
+                review.getMember().getNickname(),
+                review.getMember().getProfileImage(),
+                review.getImage(),
+                review.getRating(),
+                findTags(review),
+                review.getContent(),
+                review.getReBuy(),
+                review.getFavoriteCount(),
+                findReviewFavoriteChecked(review)
+        );
+    }
+
+    private static List<Tag> findTags(final Review review) {
+        return Optional.ofNullable(review.getReviewTags())
+                .orElse(Collections.emptyList())
+                .stream()
+                .map(ReviewTag::getTag)
+                .collect(Collectors.toList());
+    }
+
+    private static boolean findReviewFavoriteChecked(final Review review) {
+        return Optional.ofNullable(review.getReviewFavorites())
+                .orElse(Collections.emptyList())
+                .stream()
+                .filter(reviewFavorite -> reviewFavorite.getReview().equals(review))
+                .filter(reviewFavorite -> reviewFavorite.getMember().equals(review.getMember()))
+                .findFirst()
+                .map(ReviewFavorite::getChecked)
+                .orElse(false);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public String getProfileImage() {
+        return profileImage;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public Double getRating() {
+        return rating;
+    }
+
+    public List<Tag> getTags() {
+        return tags;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public boolean isRebuy() {
+        return rebuy;
+    }
+
+    public Long getFavoriteCount() {
+        return favoriteCount;
+    }
+
+    public boolean isFavorite() {
+        return favorite;
+    }
+}

--- a/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewDto.java
+++ b/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewDto.java
@@ -12,16 +12,16 @@ import java.util.stream.Collectors;
 
 public class SortingReviewDto {
 
-    private Long id;
-    private String userName;
-    private String profileImage;
-    private String image;
-    private Double rating;
-    private List<Tag> tags;
-    private String content;
-    private boolean rebuy;
-    private Long favoriteCount;
-    private boolean favorite;
+    private final Long id;
+    private final String userName;
+    private final String profileImage;
+    private final String image;
+    private final Double rating;
+    private final List<Tag> tags;
+    private final String content;
+    private final boolean rebuy;
+    private final Long favoriteCount;
+    private final boolean favorite;
 
     public SortingReviewDto(final Long id,
                             final String userName,

--- a/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewDto.java
+++ b/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewDto.java
@@ -5,9 +5,7 @@ import com.funeat.review.domain.Review;
 import com.funeat.review.domain.ReviewTag;
 import com.funeat.tag.domain.Tag;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class SortingReviewDto {
@@ -61,16 +59,14 @@ public class SortingReviewDto {
     }
 
     private static List<Tag> findTags(final Review review) {
-        return Optional.ofNullable(review.getReviewTags())
-                .orElse(Collections.emptyList())
+        return review.getReviewTags()
                 .stream()
                 .map(ReviewTag::getTag)
                 .collect(Collectors.toList());
     }
 
     private static boolean findReviewFavoriteChecked(final Review review) {
-        return Optional.ofNullable(review.getReviewFavorites())
-                .orElse(Collections.emptyList())
+        return review.getReviewFavorites()
                 .stream()
                 .filter(reviewFavorite -> reviewFavorite.getReview().equals(review))
                 .filter(reviewFavorite -> reviewFavorite.getMember().equals(review.getMember()))

--- a/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewsPageDto.java
+++ b/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewsPageDto.java
@@ -7,12 +7,12 @@ import org.springframework.data.domain.Page;
 
 public class SortingReviewsPageDto {
 
-    private Long totalDataCount;
-    private Long totalPages;
-    private boolean isFirstPage;
-    private boolean isLastPage;
-    private Long requestPage;
-    private Long requestSize;
+    private final Long totalDataCount;
+    private final Long totalPages;
+    private final boolean isFirstPage;
+    private final boolean isLastPage;
+    private final Long requestPage;
+    private final Long requestSize;
 
     @JsonCreator
     public SortingReviewsPageDto(final Long totalDataCount,

--- a/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewsPageDto.java
+++ b/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewsPageDto.java
@@ -1,0 +1,66 @@
+package com.funeat.review.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.funeat.review.domain.Review;
+import org.springframework.data.domain.Page;
+
+public class SortingReviewsPageDto {
+
+    private Long totalDataCount;
+    private Long totalPages;
+    private boolean isFirstPage;
+    private boolean isLastPage;
+    private Long requestPage;
+    private Long requestSize;
+
+    @JsonCreator
+    public SortingReviewsPageDto(final Long totalDataCount,
+                                 final Long totalPages,
+                                 @JsonProperty(value = "firstPage") final boolean isFirstPage,
+                                 @JsonProperty(value = "lastPage") final boolean isLastPage,
+                                 final Long requestPage,
+                                 final Long requestSize) {
+        this.totalDataCount = totalDataCount;
+        this.totalPages = totalPages;
+        this.isFirstPage = isFirstPage;
+        this.isLastPage = isLastPage;
+        this.requestPage = requestPage;
+        this.requestSize = requestSize;
+    }
+
+    public static SortingReviewsPageDto toDto(final Page<Review> page) {
+        return new SortingReviewsPageDto(
+                page.getTotalElements(),
+                Long.valueOf(page.getTotalPages()),
+                page.isFirst(),
+                page.isLast(),
+                Long.valueOf(page.getNumber()),
+                Long.valueOf(page.getSize())
+        );
+    }
+
+    public Long getTotalDataCount() {
+        return totalDataCount;
+    }
+
+    public Long getTotalPages() {
+        return totalPages;
+    }
+
+    public boolean isFirstPage() {
+        return isFirstPage;
+    }
+
+    public boolean isLastPage() {
+        return isLastPage;
+    }
+
+    public Long getRequestPage() {
+        return requestPage;
+    }
+
+    public Long getRequestSize() {
+        return requestSize;
+    }
+}

--- a/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewsPageDto.java
+++ b/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewsPageDto.java
@@ -1,7 +1,5 @@
 package com.funeat.review.presentation.dto;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.funeat.review.domain.Review;
 import org.springframework.data.domain.Page;
 
@@ -9,22 +7,21 @@ public class SortingReviewsPageDto {
 
     private final Long totalDataCount;
     private final Long totalPages;
-    private final boolean isFirstPage;
-    private final boolean isLastPage;
+    private final boolean firstPage;
+    private final boolean lastPage;
     private final Long requestPage;
     private final Long requestSize;
 
-    @JsonCreator
     public SortingReviewsPageDto(final Long totalDataCount,
                                  final Long totalPages,
-                                 @JsonProperty(value = "firstPage") final boolean isFirstPage,
-                                 @JsonProperty(value = "lastPage") final boolean isLastPage,
+                                 final boolean firstPage,
+                                 final boolean lastPage,
                                  final Long requestPage,
                                  final Long requestSize) {
         this.totalDataCount = totalDataCount;
         this.totalPages = totalPages;
-        this.isFirstPage = isFirstPage;
-        this.isLastPage = isLastPage;
+        this.firstPage = firstPage;
+        this.lastPage = lastPage;
         this.requestPage = requestPage;
         this.requestSize = requestSize;
     }
@@ -49,11 +46,11 @@ public class SortingReviewsPageDto {
     }
 
     public boolean isFirstPage() {
-        return isFirstPage;
+        return firstPage;
     }
 
     public boolean isLastPage() {
-        return isLastPage;
+        return lastPage;
     }
 
     public Long getRequestPage() {

--- a/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewsResponse.java
+++ b/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewsResponse.java
@@ -1,0 +1,23 @@
+package com.funeat.review.presentation.dto;
+
+import java.util.List;
+
+public class SortingReviewsResponse {
+
+    private SortingReviewsPageDto page;
+    private List<SortingReviewDto> reviews;
+
+    public SortingReviewsResponse(final SortingReviewsPageDto page,
+                                  final List<SortingReviewDto> reviews) {
+        this.page = page;
+        this.reviews = reviews;
+    }
+
+    public SortingReviewsPageDto getPage() {
+        return page;
+    }
+
+    public List<SortingReviewDto> getReviews() {
+        return reviews;
+    }
+}

--- a/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewsResponse.java
+++ b/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewsResponse.java
@@ -13,6 +13,11 @@ public class SortingReviewsResponse {
         this.reviews = reviews;
     }
 
+    public static SortingReviewsResponse toResponse(final SortingReviewsPageDto page,
+                                                    final List<SortingReviewDto> reviews) {
+        return new SortingReviewsResponse(page, reviews);
+    }
+
     public SortingReviewsPageDto getPage() {
         return page;
     }

--- a/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewsResponse.java
+++ b/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewsResponse.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 public class SortingReviewsResponse {
 
-    private SortingReviewsPageDto page;
-    private List<SortingReviewDto> reviews;
+    private final SortingReviewsPageDto page;
+    private final List<SortingReviewDto> reviews;
 
     public SortingReviewsResponse(final SortingReviewsPageDto page,
                                   final List<SortingReviewDto> reviews) {

--- a/backend/src/test/java/com/funeat/acceptance/common/AcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/common/AcceptanceTest.java
@@ -1,7 +1,11 @@
 package com.funeat.acceptance.common;
 
+import com.funeat.member.persistence.MemberRepository;
 import com.funeat.product.persistence.CategoryRepository;
 import com.funeat.product.persistence.ProductRepository;
+import com.funeat.review.persistence.ReviewRepository;
+import com.funeat.review.persistence.ReviewTagRepository;
+import com.funeat.tag.persistence.TagRepository;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -24,6 +28,18 @@ public abstract class AcceptanceTest {
 
     @Autowired
     public CategoryRepository categoryRepository;
+
+    @Autowired
+    public MemberRepository memberRepository;
+
+    @Autowired
+    public ReviewRepository reviewRepository;
+
+    @Autowired
+    public TagRepository tagRepository;
+
+    @Autowired
+    public ReviewTagRepository reviewTagRepository;
 
     @BeforeEach
     void setUp() {

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -128,7 +128,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
         final List<Review> sortingReviews = List.of(review2, review3, review1);
 
         // when
-        final var response = 좋아요_기준_리뷰_목록_조회_요청(productId, "favorite", 0);
+        final var response = 좋아요_기준_리뷰_목록_조회_요청(productId, "favoriteCount,desc", 0);
 
         // then
         STATUS_CODE를_검증한다(response, 정상_처리);
@@ -152,10 +152,10 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     }
 
     private ExtractableResponse<Response> 좋아요_기준_리뷰_목록_조회_요청(final Long productId,
-                                                             final String sortOrderType,
+                                                             final String sort,
                                                              final Integer page) {
         return given()
-                .queryParam("option", sortOrderType)
+                .queryParam("sort", sort)
                 .queryParam("page", page)
                 .when()
                 .get("/api/products/{product_id}/reviews", productId)

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -1,17 +1,16 @@
 package com.funeat.acceptance.review;
 
-import static com.funeat.acceptance.common.CommonSteps.STATUS_CODE를_검증한다;
-import static com.funeat.acceptance.common.CommonSteps.정상_생성;
-import static io.restassured.RestAssured.given;
-
 import com.funeat.acceptance.common.AcceptanceTest;
 import com.funeat.member.domain.Gender;
 import com.funeat.member.domain.Member;
 import com.funeat.member.persistence.MemberRepository;
+import com.funeat.product.domain.Category;
+import com.funeat.product.domain.CategoryType;
 import com.funeat.product.domain.Product;
+import com.funeat.product.persistence.CategoryRepository;
 import com.funeat.product.persistence.ProductRepository;
+import com.funeat.review.domain.Review;
 import com.funeat.review.persistence.ReviewRepository;
-import com.funeat.review.persistence.ReviewTagRepository;
 import com.funeat.review.presentation.dto.ReviewCreateRequest;
 import com.funeat.tag.domain.Tag;
 import com.funeat.tag.persistence.TagRepository;
@@ -19,10 +18,17 @@ import io.restassured.builder.MultiPartSpecBuilder;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.MultiPartSpecification;
-import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.funeat.acceptance.common.CommonSteps.STATUS_CODE를_검증한다;
+import static com.funeat.acceptance.common.CommonSteps.정상_생성;
+import static com.funeat.acceptance.common.CommonSteps.정상_처리;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("NonAsciiCharacters")
 class ReviewAcceptanceTest extends AcceptanceTest {
@@ -34,22 +40,13 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     private ProductRepository productRepository;
 
     @Autowired
-    private TagRepository tagRepository;
-
-    @Autowired
     private ReviewRepository reviewRepository;
 
     @Autowired
-    private ReviewTagRepository reviewTagRepository;
+    private TagRepository tagRepository;
 
-    @BeforeEach
-    void init() {
-        reviewTagRepository.deleteAll();
-        memberRepository.deleteAll();
-        productRepository.deleteAll();
-        tagRepository.deleteAll();
-        reviewRepository.deleteAll();
-    }
+    @Autowired
+    private CategoryRepository categoryRepository;
 
     @Test
     void 리뷰를_작성한다() {
@@ -105,5 +102,87 @@ class ReviewAcceptanceTest extends AcceptanceTest {
                 new Member("test", "image.png", 27, Gender.FEMALE, "01036551086"));
 
         return testMember.getId();
+    }
+
+    @Test
+    void 좋아요_기준_내림차순된_리뷰_목록을_조회한다() {
+        // given
+        final Category category = new Category("간편식사", CategoryType.FOOD);
+        카테고리_추가_요청(category);
+
+        final Member member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
+        final Member member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");
+        final Member member3 = new Member("test3", "test3.png", 9, Gender.MALE, "010-9876-4321");
+        final List<Member> members = List.of(member1, member2, member3);
+        복수_유저_추가_요청(members);
+
+        final Product product = new Product("삼각김밥1", 1000L, "image.png", "김밥", category);
+        final Long productId = 상품_추가_요청(product);
+
+        final Review review1 = new Review(member1, product, "review1.jpg", 3.0, "이 김밥은 재밌습니다", true, 5L);
+        final Review review2 = new Review(member2, product, "review2.jpg", 4.5, "역삼역", true, 351L);
+        final Review review3 = new Review(member3, product, "review3.jpg", 3.5, "ㅇㅇ", false, 130L);
+        final List<Review> reviews = List.of(review1, review2, review3);
+        복수_리뷰_추가(reviews);
+
+        final List<Review> sortingReviews = List.of(review2, review3, review1);
+
+        // when
+        final var response = 좋아요_기준_리뷰_목록_조회_요청(productId, "favorite", 0);
+
+        // then
+        STATUS_CODE를_검증한다(response, 정상_처리);
+        좋아요_기준_리뷰_목록_조회_결과를_검증한다(response, sortingReviews);
+    }
+
+    private void 카테고리_추가_요청(final Category category) {
+        categoryRepository.save(category);
+    }
+
+    private void 복수_유저_추가_요청(final List<Member> members) {
+        memberRepository.saveAll(members);
+    }
+
+    private Long 상품_추가_요청(final Product product) {
+        return productRepository.save(product).getId();
+    }
+
+    private void 복수_리뷰_추가(final List<Review> reviews) {
+        reviewRepository.saveAll(reviews);
+    }
+
+    private ExtractableResponse<Response> 좋아요_기준_리뷰_목록_조회_요청(final Long productId,
+                                                             final String sortOrderType,
+                                                             final Integer page) {
+        return given()
+                .queryParam("option", sortOrderType)
+                .queryParam("page", page)
+                .when()
+                .get("/api/products/{product_id}/reviews", productId)
+                .then()
+                .extract();
+    }
+
+    private void 좋아요_기준_리뷰_목록_조회_결과를_검증한다(final ExtractableResponse<Response> response,
+                                          final List<Review> reviews) {
+        페이지를_검증한다(response);
+        리뷰_목록을_검증한다(response, reviews);
+    }
+
+    private void 페이지를_검증한다(final ExtractableResponse<Response> response) {
+        final SortingReviewsPageDto expectedPage = new SortingReviewsPageDto(3L, 1L, true, true, 0L, 10L);
+        final SortingReviewsPageDto actualPage = response.jsonPath().getObject("page", SortingReviewsPageDto.class);
+        assertThat(actualPage).usingRecursiveComparison().isEqualTo(expectedPage);
+    }
+
+    private void 리뷰_목록을_검증한다(final ExtractableResponse<Response> response,
+                             final List<Review> reviews) {
+        final List<SortingReviewDto> expectedReviews = reviews.stream()
+                .map(SortingReviewDto::toDto)
+                .collect(Collectors.toList());
+        final List<SortingReviewDto> actualReviews = response.jsonPath().getList("reviews", SortingReviewDto.class);
+        assertThat(actualReviews).usingRecursiveComparison()
+                .ignoringFields("id")
+                .isEqualTo(expectedReviews);
     }
 }

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -98,25 +98,25 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     @Test
     void 좋아요_기준_내림차순된_리뷰_목록을_조회한다() {
         // given
-        final Category category = new Category("간편식사", CategoryType.FOOD);
+        final var category = new Category("간편식사", CategoryType.FOOD);
         카테고리_추가_요청(category);
 
-        final Member member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
-        final Member member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");
-        final Member member3 = new Member("test3", "test3.png", 9, Gender.MALE, "010-9876-4321");
-        final List<Member> members = List.of(member1, member2, member3);
+        final var member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
+        final var member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");
+        final var member3 = new Member("test3", "test3.png", 9, Gender.MALE, "010-9876-4321");
+        final var members = List.of(member1, member2, member3);
         복수_유저_추가_요청(members);
 
-        final Product product = new Product("삼각김밥1", 1000L, "image.png", "김밥", category);
-        final Long productId = 상품_추가_요청(product);
+        final var product = new Product("삼각김밥1", 1000L, "image.png", "김밥", category);
+        final var productId = 상품_추가_요청(product);
 
-        final Review review1 = new Review(member1, product, "review1.jpg", 3.0, "이 김밥은 재밌습니다", true, 5L);
-        final Review review2 = new Review(member2, product, "review2.jpg", 4.5, "역삼역", true, 351L);
-        final Review review3 = new Review(member3, product, "review3.jpg", 3.5, "ㅇㅇ", false, 130L);
-        final List<Review> reviews = List.of(review1, review2, review3);
+        final var review1 = new Review(member1, product, "review1.jpg", 3.0, "이 김밥은 재밌습니다", true, 5L);
+        final var review2 = new Review(member2, product, "review2.jpg", 4.5, "역삼역", true, 351L);
+        final var review3 = new Review(member3, product, "review3.jpg", 3.5, "ㅇㅇ", false, 130L);
+        final var reviews = List.of(review1, review2, review3);
         복수_리뷰_추가(reviews);
 
-        final List<Review> sortingReviews = List.of(review2, review3, review1);
+        final var sortingReviews = List.of(review2, review3, review1);
 
         // when
         final var response = 좋아요_기준_리뷰_목록_조회_요청(productId, "favoriteCount,desc", 0);
@@ -161,19 +161,19 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     }
 
     private void 페이지를_검증한다(final ExtractableResponse<Response> response) {
-        final SortingReviewsPageDto expectedPage = new SortingReviewsPageDto(3L, 1L, true, true, 0L, 10L);
-        final SortingReviewsPageDto actualPage = response.jsonPath().getObject("page", SortingReviewsPageDto.class);
-        assertThat(actualPage).usingRecursiveComparison().isEqualTo(expectedPage);
+        final var expected = new SortingReviewsPageDto(3L, 1L, true, true, 0L, 10L);
+        final var actual = response.jsonPath().getObject("page", SortingReviewsPageDto.class);
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
     }
 
     private void 리뷰_목록을_검증한다(final ExtractableResponse<Response> response,
                              final List<Review> reviews) {
-        final List<SortingReviewDto> expectedReviews = reviews.stream()
+        final List<SortingReviewDto> expected = reviews.stream()
                 .map(SortingReviewDto::toDto)
                 .collect(Collectors.toList());
-        final List<SortingReviewDto> actualReviews = response.jsonPath().getList("reviews", SortingReviewDto.class);
-        assertThat(actualReviews).usingRecursiveComparison()
+        final List<SortingReviewDto> actual = response.jsonPath().getList("reviews", SortingReviewDto.class);
+        assertThat(actual).usingRecursiveComparison()
                 .ignoringFields("id")
-                .isEqualTo(expectedReviews);
+                .isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -3,23 +3,20 @@ package com.funeat.acceptance.review;
 import com.funeat.acceptance.common.AcceptanceTest;
 import com.funeat.member.domain.Gender;
 import com.funeat.member.domain.Member;
-import com.funeat.member.persistence.MemberRepository;
 import com.funeat.product.domain.Category;
 import com.funeat.product.domain.CategoryType;
 import com.funeat.product.domain.Product;
-import com.funeat.product.persistence.CategoryRepository;
-import com.funeat.product.persistence.ProductRepository;
 import com.funeat.review.domain.Review;
-import com.funeat.review.persistence.ReviewRepository;
 import com.funeat.review.presentation.dto.ReviewCreateRequest;
+import com.funeat.review.presentation.dto.SortingReviewDto;
+import com.funeat.review.presentation.dto.SortingReviewsPageDto;
 import com.funeat.tag.domain.Tag;
-import com.funeat.tag.persistence.TagRepository;
 import io.restassured.builder.MultiPartSpecBuilder;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.MultiPartSpecification;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -33,20 +30,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SuppressWarnings("NonAsciiCharacters")
 class ReviewAcceptanceTest extends AcceptanceTest {
 
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private ProductRepository productRepository;
-
-    @Autowired
-    private ReviewRepository reviewRepository;
-
-    @Autowired
-    private TagRepository tagRepository;
-
-    @Autowired
-    private CategoryRepository categoryRepository;
+    @BeforeEach
+    void init() {
+        reviewTagRepository.deleteAll();
+        memberRepository.deleteAll();
+        productRepository.deleteAll();
+        tagRepository.deleteAll();
+        reviewRepository.deleteAll();
+    }
 
     @Test
     void 리뷰를_작성한다() {

--- a/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -115,28 +115,28 @@ class ReviewServiceTest {
         @Test
         void 좋아요_기준으로_내림차순_정렬이_되는지_확인한다() {
             // given
-            final Member member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
-            final Member member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");
-            final Member member3 = new Member("test3", "test3.png", 9, Gender.MALE, "010-9876-4321");
-            final List<Member> members = List.of(member1, member2, member3);
+            final var member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
+            final var member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");
+            final var member3 = new Member("test3", "test3.png", 9, Gender.MALE, "010-9876-4321");
+            final var members = List.of(member1, member2, member3);
             복수_유저_추가(members);
 
-            final Product product = new Product("김밥", 1000L, "kimbap.png", "우영우가 먹은 그 김밥", null);
+            final var product = new Product("김밥", 1000L, "kimbap.png", "우영우가 먹은 그 김밥", null);
             상품_추가(product);
 
-            final Review review1 = new Review(member1, product, "review1.jpg", 3.0, "이 김밥은 재밌습니다", true, 351L);
-            final Review review2 = new Review(member2, product, "review2.jpg", 4.5, "역삼역", true, 24L);
-            final Review review3 = new Review(member3, product, "review3.jpg", 3.5, "ㅇㅇ", false, 130L);
-            final List<Review> reviews = List.of(review1, review2, review3);
+            final var review1 = new Review(member1, product, "review1.jpg", 3.0, "이 김밥은 재밌습니다", true, 351L);
+            final var review2 = new Review(member2, product, "review2.jpg", 4.5, "역삼역", true, 24L);
+            final var review3 = new Review(member3, product, "review3.jpg", 3.5, "ㅇㅇ", false, 130L);
+            final var reviews = List.of(review1, review2, review3);
             복수_리뷰_추가(reviews);
 
-            final Pageable pageable = PageRequest.of(0, 2, Sort.by("favoriteCount").descending());
-            final List<SortingReviewDto> expected = Stream.of(review1, review3)
+            final var pageable = PageRequest.of(0, 2, Sort.by("favoriteCount").descending());
+            final var expected = Stream.of(review1, review3)
                     .map(SortingReviewDto::toDto)
                     .collect(Collectors.toList());
 
             // when
-            final List<SortingReviewDto> actual = reviewService.sortingReviews(product.getId(), pageable)
+            final var actual = reviewService.sortingReviews(product.getId(), pageable)
                     .getReviews();
 
             // then

--- a/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -136,7 +136,8 @@ class ReviewServiceTest {
                     .collect(Collectors.toList());
 
             // when
-            final List<SortingReviewDto> actual = reviewService.sortingReviews(product.getId(), pageable);
+            final List<SortingReviewDto> actual = reviewService.sortingReviews(product.getId(), pageable)
+                    .getReviews();
 
             // then
             assertThat(actual).usingRecursiveComparison().isEqualTo(expected);

--- a/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -1,7 +1,5 @@
 package com.funeat.review.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.funeat.member.domain.Gender;
 import com.funeat.member.domain.Member;
 import com.funeat.member.persistence.MemberRepository;
@@ -11,21 +9,26 @@ import com.funeat.review.domain.Review;
 import com.funeat.review.persistence.ReviewRepository;
 import com.funeat.review.persistence.ReviewTagRepository;
 import com.funeat.review.presentation.dto.ReviewCreateRequest;
+import com.funeat.review.presentation.dto.SortingReviewDto;
 import com.funeat.tag.domain.Tag;
 import com.funeat.tag.persistence.TagRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.mock.web.MockMultipartFile;
 
-@SpringBootTest
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
 @SuppressWarnings("NonAsciiCharacters")
-@DisplayNameGeneration(ReplaceUnderscores.class)
 class ReviewServiceTest {
 
     @Autowired
@@ -98,5 +101,53 @@ class ReviewServiceTest {
     private Member 멤버_추가_요청() {
         return memberRepository.save(
                 new Member("test", "image.png", 27, Gender.FEMALE, "01036551086"));
+    }
+
+    @Nested
+    class sortingReviews_페이징_테스트 {
+
+        @Nested
+        class 좋아요_기준으로_내림차순_정렬을_하는데 {
+
+            @Test
+            void 페이징된_리뷰_목록이_나오는지_확인한다() {
+                // given
+                final Member member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
+                final Member member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");
+                final Member member3 = new Member("test3", "test3.png", 9, Gender.MALE, "010-9876-4321");
+                final List<Member> members = List.of(member1, member2, member3);
+                복수_유저_추가(members);
+
+                final Product product = new Product("김밥", 1000L, "kimbap.png", "우영우가 먹은 그 김밥", null);
+                상품_추가(product);
+
+                final Review review1 = new Review(member1, product, "review1.jpg", 3.0, "이 김밥은 재밌습니다", true, 351L);
+                final Review review2 = new Review(member2, product, "review2.jpg", 4.5, "역삼역", true, 24L);
+                final Review review3 = new Review(member3, product, "review3.jpg", 3.5, "ㅇㅇ", false, 130L);
+                final List<Review> reviews = List.of(review1, review2, review3);
+                복수_리뷰_추가(reviews);
+
+                final Pageable pageable = PageRequest.of(0, 2);
+                final List<Review> expected = List.of(review1, review3);
+
+                // when
+                final List<SortingReviewDto> actual = reviewService.sortingReviews(product.getId(), pageable, "favorite");
+
+                // then
+                assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+            }
+        }
+    }
+
+    private void 복수_유저_추가(final List<Member> members) {
+        memberRepository.saveAll(members);
+    }
+
+    private void 상품_추가(final Product product) {
+        productRepository.save(product);
+    }
+
+    private void 복수_리뷰_추가(final List<Review> reviews) {
+        reviewRepository.saveAll(reviews);
     }
 }

--- a/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -13,22 +13,28 @@ import com.funeat.review.presentation.dto.SortingReviewDto;
 import com.funeat.tag.domain.Tag;
 import com.funeat.tag.persistence.TagRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 
-@ExtendWith(SpringExtension.class)
+@Transactional
+@SpringBootTest
 @SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
 class ReviewServiceTest {
 
     @Autowired
@@ -106,36 +112,34 @@ class ReviewServiceTest {
     @Nested
     class sortingReviews_페이징_테스트 {
 
-        @Nested
-        class 좋아요_기준으로_내림차순_정렬을_하는데 {
+        @Test
+        void 좋아요_기준으로_내림차순_정렬이_되는지_확인한다() {
+            // given
+            final Member member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
+            final Member member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");
+            final Member member3 = new Member("test3", "test3.png", 9, Gender.MALE, "010-9876-4321");
+            final List<Member> members = List.of(member1, member2, member3);
+            복수_유저_추가(members);
 
-            @Test
-            void 페이징된_리뷰_목록이_나오는지_확인한다() {
-                // given
-                final Member member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
-                final Member member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");
-                final Member member3 = new Member("test3", "test3.png", 9, Gender.MALE, "010-9876-4321");
-                final List<Member> members = List.of(member1, member2, member3);
-                복수_유저_추가(members);
+            final Product product = new Product("김밥", 1000L, "kimbap.png", "우영우가 먹은 그 김밥", null);
+            상품_추가(product);
 
-                final Product product = new Product("김밥", 1000L, "kimbap.png", "우영우가 먹은 그 김밥", null);
-                상품_추가(product);
+            final Review review1 = new Review(member1, product, "review1.jpg", 3.0, "이 김밥은 재밌습니다", true, 351L);
+            final Review review2 = new Review(member2, product, "review2.jpg", 4.5, "역삼역", true, 24L);
+            final Review review3 = new Review(member3, product, "review3.jpg", 3.5, "ㅇㅇ", false, 130L);
+            final List<Review> reviews = List.of(review1, review2, review3);
+            복수_리뷰_추가(reviews);
 
-                final Review review1 = new Review(member1, product, "review1.jpg", 3.0, "이 김밥은 재밌습니다", true, 351L);
-                final Review review2 = new Review(member2, product, "review2.jpg", 4.5, "역삼역", true, 24L);
-                final Review review3 = new Review(member3, product, "review3.jpg", 3.5, "ㅇㅇ", false, 130L);
-                final List<Review> reviews = List.of(review1, review2, review3);
-                복수_리뷰_추가(reviews);
+            final Pageable pageable = PageRequest.of(0, 2, Sort.by("favoriteCount").descending());
+            final List<SortingReviewDto> expected = Stream.of(review1, review3)
+                    .map(SortingReviewDto::toDto)
+                    .collect(Collectors.toList());
 
-                final Pageable pageable = PageRequest.of(0, 2);
-                final List<Review> expected = List.of(review1, review3);
+            // when
+            final List<SortingReviewDto> actual = reviewService.sortingReviews(product.getId(), pageable);
 
-                // when
-                final List<SortingReviewDto> actual = reviewService.sortingReviews(product.getId(), pageable, "favorite");
-
-                // then
-                assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
-            }
+            // then
+            assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
         }
     }
 


### PR DESCRIPTION

## Issue

- close #22 

## ✨ 구현한 기능

- 특정 상품에 대한 리뷰 목록을 좋아요 기준 내림차순으로 페이징하여 반환하는 API 제공

## 📢 논의하고 싶은 내용

- sort가 `RequestParam`의 `sort`에 매핑되는 것뿐만 아니라 `Pageable`의 `sort`에도 매핑되어 다른 네이밍이 필요합니다
- 리뷰 엔티티에 좋아요 개수 필드를 추가했습니다
- 페이징을 할 때 시작 페이지가 0입니다
- 다음주엔 도메인 생성자, getter, 리포지토리를 전부 추가해두고 나머지 개발을 시작하는게 좋아보입니다

## 🎸 기타

- 어제 코드가 다 날아가서 ㅠㅠ 다시 시작하기 전에 우가랑 겹치는 코드가 많은 것 같아 우가 코드 베이스로 만들었습니다
커밋 메시지들은 다음주에 수정할게요!