### PR TITLE
[BE] feat: 좋아요 수를 기준으로 리뷰 랭킹 조회 기능 추가

### DIFF
--- a/backend/src/main/java/com/funeat/review/application/ReviewService.java
+++ b/backend/src/main/java/com/funeat/review/application/ReviewService.java
@@ -103,4 +103,8 @@ public class ReviewService {
 
         return SortingReviewsResponse.toResponse(pageDto, reviewDtos);
     }
+
+    public List<Review> computeRankingReviews() {
+        return reviewRepository.findTop3ByOrderByFavoriteCountDesc();
+    }
 }

--- a/backend/src/main/java/com/funeat/review/application/ReviewService.java
+++ b/backend/src/main/java/com/funeat/review/application/ReviewService.java
@@ -10,7 +10,10 @@ import com.funeat.review.domain.Review;
 import com.funeat.review.domain.ReviewTag;
 import com.funeat.review.persistence.ReviewRepository;
 import com.funeat.review.persistence.ReviewTagRepository;
+import com.funeat.review.presentation.dto.RankingReviewDto;
+import com.funeat.review.presentation.dto.RankingReviewsResponse;
 import com.funeat.review.presentation.dto.ReviewCreateRequest;
+import com.funeat.review.presentation.dto.ReviewFavoriteRequest;
 import com.funeat.review.presentation.dto.SortingReviewDto;
 import com.funeat.review.presentation.dto.SortingReviewsPageDto;
 import com.funeat.review.presentation.dto.SortingReviewsResponse;
@@ -104,7 +107,13 @@ public class ReviewService {
         return SortingReviewsResponse.toResponse(pageDto, reviewDtos);
     }
 
-    public List<Review> computeRankingReviews() {
-        return reviewRepository.findTop3ByOrderByFavoriteCountDesc();
+    public RankingReviewsResponse getTopReviews() {
+        final List<Review> rankingReviews = reviewRepository.findTop3ByOrderByFavoriteCountDesc();
+
+        final List<RankingReviewDto> dtos = rankingReviews.stream()
+                .map(RankingReviewDto::toDto)
+                .collect(Collectors.toList());
+
+        return RankingReviewsResponse.toResponse(dtos);
     }
 }

--- a/backend/src/main/java/com/funeat/review/persistence/ReviewRepository.java
+++ b/backend/src/main/java/com/funeat/review/persistence/ReviewRepository.java
@@ -6,7 +6,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     Page<Review> findReviewsByProduct(final Pageable pageable, final Product product);
+
+    List<Review> findTop3ByOrderByFavoriteCountDesc();
 }

--- a/backend/src/main/java/com/funeat/review/presentation/ReviewController.java
+++ b/backend/src/main/java/com/funeat/review/presentation/ReviewController.java
@@ -1,12 +1,17 @@
 package com.funeat.review.presentation;
 
 import com.funeat.review.application.ReviewService;
+import com.funeat.review.domain.Review;
+import com.funeat.review.presentation.dto.RankingReviewDto;
+import com.funeat.review.presentation.dto.RankingReviewsResponse;
 import com.funeat.review.presentation.dto.ReviewCreateRequest;
 import com.funeat.review.presentation.dto.ReviewFavoriteRequest;
-import java.net.URI;
-
+import com.funeat.review.presentation.dto.SortingReviewsResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,12 +20,9 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.funeat.review.presentation.dto.SortingReviewsResponse;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
-import org.springframework.web.bind.annotation.GetMapping;
-
+import java.net.URI;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 public class ReviewController {
@@ -47,10 +49,23 @@ public class ReviewController {
 
         return ResponseEntity.noContent().build();
 
+    }
+
     @GetMapping(value = "/api/products/{productId}/reviews")
     public ResponseEntity<SortingReviewsResponse> getSortingReviews(@PathVariable Long productId,
                                                                     @PageableDefault Pageable pageable) {
         final SortingReviewsResponse response = reviewService.sortingReviews(productId, pageable);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/api/ranks/reviews")
+    public ResponseEntity<RankingReviewsResponse> getRankingReviews() {
+        final List<Review> reviews = reviewService.computeRankingReviews();
+        final List<RankingReviewDto> dtos = reviews.stream()
+                .map(RankingReviewDto::toDto)
+                .collect(Collectors.toList());
+        final RankingReviewsResponse response = RankingReviewsResponse.toResponse(dtos);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/funeat/review/presentation/ReviewController.java
+++ b/backend/src/main/java/com/funeat/review/presentation/ReviewController.java
@@ -61,11 +61,7 @@ public class ReviewController {
 
     @GetMapping("/api/ranks/reviews")
     public ResponseEntity<RankingReviewsResponse> getRankingReviews() {
-        final List<Review> reviews = reviewService.computeRankingReviews();
-        final List<RankingReviewDto> dtos = reviews.stream()
-                .map(RankingReviewDto::toDto)
-                .collect(Collectors.toList());
-        final RankingReviewsResponse response = RankingReviewsResponse.toResponse(dtos);
+        final RankingReviewsResponse response = reviewService.getTopReviews();
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/funeat/review/presentation/dto/RankingReviewDto.java
+++ b/backend/src/main/java/com/funeat/review/presentation/dto/RankingReviewDto.java
@@ -1,0 +1,62 @@
+package com.funeat.review.presentation.dto;
+
+import com.funeat.review.domain.Review;
+
+public class RankingReviewDto {
+
+    private Long reviewId;
+    private Long productId;
+    private String productName;
+    private String content;
+    private Double rating;
+    private Long favoriteCount;
+
+    public RankingReviewDto(final Long reviewId,
+                            final Long productId,
+                            final String productName,
+                            final String content,
+                            final Double rating,
+                            final Long favoriteCount) {
+        this.reviewId = reviewId;
+        this.productId = productId;
+        this.productName = productName;
+        this.content = content;
+        this.rating = rating;
+        this.favoriteCount = favoriteCount;
+    }
+
+    public static RankingReviewDto toDto(final Review review) {
+        return new RankingReviewDto(
+                review.getId(),
+                review.getProduct().getId(),
+                review.getProduct().getName(),
+                review.getContent(),
+                review.getRating(),
+                review.getFavoriteCount()
+        );
+    }
+
+    public Long getReviewId() {
+        return reviewId;
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Double getRating() {
+        return rating;
+    }
+
+    public Long getFavoriteCount() {
+        return favoriteCount;
+    }
+}

--- a/backend/src/main/java/com/funeat/review/presentation/dto/RankingReviewDto.java
+++ b/backend/src/main/java/com/funeat/review/presentation/dto/RankingReviewDto.java
@@ -4,12 +4,12 @@ import com.funeat.review.domain.Review;
 
 public class RankingReviewDto {
 
-    private Long reviewId;
-    private Long productId;
-    private String productName;
-    private String content;
-    private Double rating;
-    private Long favoriteCount;
+    private final Long reviewId;
+    private final Long productId;
+    private final String productName;
+    private final String content;
+    private final Double rating;
+    private final Long favoriteCount;
 
     public RankingReviewDto(final Long reviewId,
                             final Long productId,

--- a/backend/src/main/java/com/funeat/review/presentation/dto/RankingReviewsResponse.java
+++ b/backend/src/main/java/com/funeat/review/presentation/dto/RankingReviewsResponse.java
@@ -1,19 +1,7 @@
 package com.funeat.review.presentation.dto;
 
-import com.funeat.review.domain.Review;
-
 import java.util.List;
 
-/**
- * {
- * 	    "reviewId": 1,
- * 			"productId": 5,
- * 	    "productName": "구운감자슬림명란마요",
- * 			"content": "할머니가 먹을 거 같은 맛입니다.",
- * 	    "rating": 4.0,
- * 			"favoriteCount": 1256
- *            }
- */
 public class RankingReviewsResponse {
 
     private List<RankingReviewDto> reviews;

--- a/backend/src/main/java/com/funeat/review/presentation/dto/RankingReviewsResponse.java
+++ b/backend/src/main/java/com/funeat/review/presentation/dto/RankingReviewsResponse.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public class RankingReviewsResponse {
 
-    private List<RankingReviewDto> reviews;
+    private final List<RankingReviewDto> reviews;
 
     public RankingReviewsResponse(final List<RankingReviewDto> reviews) {
         this.reviews = reviews;

--- a/backend/src/main/java/com/funeat/review/presentation/dto/RankingReviewsResponse.java
+++ b/backend/src/main/java/com/funeat/review/presentation/dto/RankingReviewsResponse.java
@@ -1,0 +1,32 @@
+package com.funeat.review.presentation.dto;
+
+import com.funeat.review.domain.Review;
+
+import java.util.List;
+
+/**
+ * {
+ * 	    "reviewId": 1,
+ * 			"productId": 5,
+ * 	    "productName": "구운감자슬림명란마요",
+ * 			"content": "할머니가 먹을 거 같은 맛입니다.",
+ * 	    "rating": 4.0,
+ * 			"favoriteCount": 1256
+ *            }
+ */
+public class RankingReviewsResponse {
+
+    private List<RankingReviewDto> reviews;
+
+    public RankingReviewsResponse(final List<RankingReviewDto> reviews) {
+        this.reviews = reviews;
+    }
+
+    public static RankingReviewsResponse toResponse(final List<RankingReviewDto> reviews) {
+        return new RankingReviewsResponse(reviews);
+    }
+
+    public List<RankingReviewDto> getReviews() {
+        return reviews;
+    }
+}

--- a/backend/src/test/java/com/funeat/acceptance/common/AcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/common/AcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.funeat.acceptance.common;
 
 import com.funeat.member.persistence.MemberRepository;
+import com.funeat.member.persistence.ReviewFavoriteRepository;
 import com.funeat.product.persistence.CategoryRepository;
 import com.funeat.product.persistence.ProductRepository;
 import com.funeat.review.persistence.ReviewRepository;
@@ -40,6 +41,9 @@ public abstract class AcceptanceTest {
 
     @Autowired
     public ReviewTagRepository reviewTagRepository;
+
+    @Autowired
+    public ReviewFavoriteRepository reviewFavoriteRepository;
 
     @BeforeEach
     void setUp() {

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -1,16 +1,9 @@
 package com.funeat.acceptance.review;
 
-import static com.funeat.acceptance.common.CommonSteps.STATUS_CODE를_검증한다;
-import static com.funeat.acceptance.common.CommonSteps.정상_생성;
-import static com.funeat.acceptance.common.CommonSteps.정상_처리_NO_CONTENT;
-import static io.restassured.RestAssured.given;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.funeat.acceptance.common.AcceptanceTest;
 import com.funeat.member.domain.Gender;
 import com.funeat.member.domain.Member;
 import com.funeat.member.domain.favorite.ReviewFavorite;
-import com.funeat.member.persistence.MemberRepository;
 import com.funeat.member.persistence.ReviewFavoriteRepository;
 import com.funeat.product.domain.Category;
 import com.funeat.product.domain.CategoryType;
@@ -34,13 +27,12 @@ import java.util.stream.Collectors;
 import static com.funeat.acceptance.common.CommonSteps.STATUS_CODE를_검증한다;
 import static com.funeat.acceptance.common.CommonSteps.정상_생성;
 import static com.funeat.acceptance.common.CommonSteps.정상_처리;
+import static com.funeat.acceptance.common.CommonSteps.정상_처리_NO_CONTENT;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("NonAsciiCharacters")
 class ReviewAcceptanceTest extends AcceptanceTest {
-
-    @Autowired
     private ReviewFavoriteRepository reviewFavoriteRepository;
 
     @BeforeEach
@@ -157,7 +149,6 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     private List<Long> 태그_추가_요청() {
         final Tag testTag1 = tagRepository.save(new Tag("testTag1"));
         final Tag testTag2 = tagRepository.save(new Tag("testTag2"));
-
         return List.of(testTag1.getId(), testTag2.getId());
     }
 
@@ -309,6 +300,6 @@ class ReviewAcceptanceTest extends AcceptanceTest {
                 .map(RankingReviewsResponse::toResponse)
                 .collect(Collectors.toList());
         final List<RankingReviewsResponse> actual = response.jsonPath().getList("reviews", RankingReviewsResponse.class);
-        assertThat(actual).usingRecursiveComparison() .isEqualTo(expected);
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -8,6 +8,7 @@ import com.funeat.product.domain.Category;
 import com.funeat.product.domain.CategoryType;
 import com.funeat.product.domain.Product;
 import com.funeat.review.domain.Review;
+import com.funeat.review.presentation.dto.RankingReviewDto;
 import com.funeat.review.presentation.dto.ReviewCreateRequest;
 import com.funeat.review.presentation.dto.ReviewFavoriteRequest;
 import com.funeat.review.presentation.dto.SortingReviewDto;
@@ -294,10 +295,10 @@ class ReviewAcceptanceTest extends AcceptanceTest {
 
     private void 리뷰_랭킹_조회_결과를_검증한다(final ExtractableResponse<Response> response,
                                    final List<Review> reviews) {
-        final List<RankingReviewsResponse> expected = reviews.stream()
-                .map(RankingReviewsResponse::toResponse)
+        final var expected = reviews.stream()
+                .map(RankingReviewDto::toDto)
                 .collect(Collectors.toList());
-        final List<RankingReviewDto> actual = response.jsonPath()
+        final var actual = response.jsonPath()
                 .getList("reviews", RankingReviewDto.class);
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
     }

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -4,7 +4,6 @@ import com.funeat.acceptance.common.AcceptanceTest;
 import com.funeat.member.domain.Gender;
 import com.funeat.member.domain.Member;
 import com.funeat.member.domain.favorite.ReviewFavorite;
-import com.funeat.member.persistence.ReviewFavoriteRepository;
 import com.funeat.product.domain.Category;
 import com.funeat.product.domain.CategoryType;
 import com.funeat.product.domain.Product;
@@ -33,7 +32,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("NonAsciiCharacters")
 class ReviewAcceptanceTest extends AcceptanceTest {
-    private ReviewFavoriteRepository reviewFavoriteRepository;
 
     @BeforeEach
     void init() {
@@ -299,7 +297,8 @@ class ReviewAcceptanceTest extends AcceptanceTest {
         final List<RankingReviewsResponse> expected = reviews.stream()
                 .map(RankingReviewsResponse::toResponse)
                 .collect(Collectors.toList());
-        final List<RankingReviewsResponse> actual = response.jsonPath().getList("reviews", RankingReviewsResponse.class);
+        final List<RankingReviewDto> actual = response.jsonPath()
+                .getList("reviews", RankingReviewDto.class);
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/com/funeat/review/persistence/ReviewRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/review/persistence/ReviewRepositoryTest.java
@@ -1,0 +1,96 @@
+package com.funeat.review.persistence;
+
+import com.funeat.member.domain.Gender;
+import com.funeat.member.domain.Member;
+import com.funeat.member.persistence.MemberRepository;
+import com.funeat.product.domain.Product;
+import com.funeat.product.persistence.ProductRepository;
+import com.funeat.review.domain.Review;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+
+@DataJpaTest
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+public class ReviewRepositoryTest {
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Test
+    void 특정_상품에_대한_좋아요_기준_내림차순으로_정렬한다() {
+        // given
+        final var member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
+        final var member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");
+        final var member3 = new Member("test3", "test3.png", 9, Gender.MALE, "010-9876-4321");
+        final var members = List.of(member1, member2, member3);
+        memberRepository.saveAll(members);
+
+        final var product = new Product("김밥", 1000L, "kimbap.png", "우영우가 먹은 그 김밥", null);
+        productRepository.save(product);
+
+        final var review1 = new Review(member1, product, "review1.jpg", 3.0, "이 김밥은 재밌습니다", true, 351L);
+        final var review2 = new Review(member2, product, "review2.jpg", 4.5, "역삼역", true, 24L);
+        final var review3 = new Review(member3, product, "review3.jpg", 3.5, "ㅇㅇ", false, 130L);
+        final var reviews = List.of(review1, review2, review3);
+        reviewRepository.saveAll(reviews);
+
+        final var expected = List.of(review1, review3);
+
+        final var page = PageRequest.of(0, 2, Sort.by("favoriteCount").descending());
+
+        // when
+        final List<Review> actual = reviewRepository.findReviewsByProduct(page, product)
+                .getContent();
+
+        // then
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void 전체_리뷰_목록에서_가장_좋아요가_높은_상위_3개의_리뷰를_가져온다() {
+        // given
+
+        final var member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
+        final var member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");
+        final var member3 = new Member("test3", "test3.png", 9, Gender.MALE, "010-9876-4321");
+        final var members = List.of(member1, member2, member3);
+        memberRepository.saveAll(members);
+
+        final var product1 = new Product("김밥", 1000L, "image.png", "김밥", null);
+        final var product2 = new Product("물", 500L, "water.jpg", "물", null);
+        final var products = List.of(product1, product2);
+        productRepository.saveAll(products);
+
+        final var review1 = new Review(member1, product1, "review1.jpg", 3.0, "이 김밥은 재밌습니다", true, 5L);
+        final var review2 = new Review(member2, product1, "review2.jpg", 4.5, "역삼역", true, 351L);
+        final var review3 = new Review(member3, product1, "review3.jpg", 3.5, "ㅇㅇ", false, 130L);
+        final var review4 = new Review(member2, product2, "review4.jpg", 5.0, "ㅁㅜㄹ", true, 247L);
+        final var review5 = new Review(member3, product2, "review5.jpg", 1.5, "ㄴㄴ", false, 83L);
+        final var reviews = List.of(review1, review2, review3, review4, review5);
+        reviewRepository.saveAll(reviews);
+
+        final var expected = List.of(review2, review4, review3);
+
+        // when
+        final var actual = reviewRepository.findTop3ByOrderByFavoriteCountDesc();
+
+        // then
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
## Issue

- close #41 

## ✨ 구현한 기능

- 좋아요를 기준으로 내림차순으로 상위 3개의 리뷰 정보를 반환하는 기능을 추가했습니다.

## 🎸 기타

- 이것도 favoriteCount를 가지고 동작합니다