### PR TITLE
[FE] feat: 편의점 PB 상품 아이템 컴포넌트 추가

### DIFF
--- a/frontend/src/components/Product/PBProductItem/PBProductItem.stories.tsx
+++ b/frontend/src/components/Product/PBProductItem/PBProductItem.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import PBProductItem from './PBProductItem';
+
+import pbProducts from '@/mocks/data/pbProducts.json';
+
+const meta: Meta<typeof PBProductItem> = {
+  title: 'product/PBProductItem',
+  component: PBProductItem,
+  args: {
+    pbProduct: pbProducts[0],
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PBProductItem>;
+
+export const Default: Story = {};

--- a/frontend/src/components/Product/PBProductItem/PBProductItem.tsx
+++ b/frontend/src/components/Product/PBProductItem/PBProductItem.tsx
@@ -16,7 +16,7 @@ const PBProductItem = ({ pbProduct }: PBProductItemProps) => {
       <PBProductImage src={image} alt={name} />
       <PBProductInfoWrapper>
         <PBProductName weight="bold">{name}</PBProductName>
-        <PBProductDetailInfoWrapper>
+        <PBProductReviewWrapper>
           <RatingWrapper>
             <SvgIcon variant="star" color={theme.colors.secondary} width={18} height={18} />
             <Text as="span" size="sm" weight="bold" color={theme.textColors.info}>
@@ -26,7 +26,7 @@ const PBProductItem = ({ pbProduct }: PBProductItemProps) => {
           <Text as="span" size="sm" color={theme.textColors.info}>
             {price.toLocaleString('ko-KR')}원
           </Text>
-        </PBProductDetailInfoWrapper>
+        </PBProductReviewWrapper>
       </PBProductInfoWrapper>
     </PBProductItemContainer>
   );
@@ -59,7 +59,7 @@ const PBProductName = styled(Text)`
   overflow: hidden;
 `;
 
-const PBProductDetailInfoWrapper = styled.div`
+const PBProductReviewWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/frontend/src/components/Product/PBProductItem/PBProductItem.tsx
+++ b/frontend/src/components/Product/PBProductItem/PBProductItem.tsx
@@ -1,0 +1,72 @@
+import { Text, theme } from '@fun-eat/design-system';
+import styled from 'styled-components';
+
+import { SvgIcon } from '@/components/Common';
+import type { PBProduct } from '@/types/product';
+
+interface PBProductItemProps {
+  pbProduct: PBProduct;
+}
+
+const PBProductItem = ({ pbProduct }: PBProductItemProps) => {
+  const { name, price, image, averageRating } = pbProduct;
+
+  return (
+    <PBProductItemContainer>
+      <PBProductImage src={image} alt={name} />
+      <PBProductInfoWrapper>
+        <PBProductName weight="bold">{name}</PBProductName>
+        <PBProductDetailInfoWrapper>
+          <RatingWrapper>
+            <SvgIcon variant="star" color={theme.colors.secondary} width={18} height={18} />
+            <Text as="span" size="sm" weight="bold" color={theme.textColors.info}>
+              {averageRating}
+            </Text>
+          </RatingWrapper>
+          <Text as="span" size="sm" color={theme.textColors.info}>
+            {price.toLocaleString('ko-KR')}원
+          </Text>
+        </PBProductDetailInfoWrapper>
+      </PBProductInfoWrapper>
+    </PBProductItemContainer>
+  );
+};
+
+export default PBProductItem;
+
+const PBProductItemContainer = styled.div`
+  width: 110px;
+  height: 220px;
+  margin: 0 20px;
+`;
+
+const PBProductImage = styled.img`
+  width: 100%;
+  height: 50%;
+  object-fit: cover;
+`;
+
+const PBProductInfoWrapper = styled.div`
+  height: 50%;
+  margin-top: 10px;
+`;
+
+const PBProductName = styled(Text)`
+  display: inline-block;
+  width: 100%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+`;
+
+const PBProductDetailInfoWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 5px 0;
+`;
+
+const RatingWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;

--- a/frontend/src/components/Product/PBProductItem/PBProductItem.tsx
+++ b/frontend/src/components/Product/PBProductItem/PBProductItem.tsx
@@ -13,7 +13,7 @@ const PBProductItem = ({ pbProduct }: PBProductItemProps) => {
 
   return (
     <PBProductItemContainer>
-      <PBProductImage src={image} alt={name} />
+      <PBProductImage src={image} alt={name} width={110} height={110} />
       <PBProductInfoWrapper>
         <PBProductName weight="bold">{name}</PBProductName>
         <PBProductReviewWrapper>
@@ -37,12 +37,9 @@ export default PBProductItem;
 const PBProductItemContainer = styled.div`
   width: 110px;
   height: 220px;
-  margin: 0 20px;
 `;
 
 const PBProductImage = styled.img`
-  width: 100%;
-  height: 50%;
   object-fit: cover;
 `;
 
@@ -69,4 +66,9 @@ const PBProductReviewWrapper = styled.div`
 const RatingWrapper = styled.div`
   display: flex;
   align-items: center;
+  column-gap: 4px;
+
+  & > svg {
+    padding-bottom: 2px;
+  }
 `;

--- a/frontend/src/components/Product/PBProductList/PBProductList.stories.tsx
+++ b/frontend/src/components/Product/PBProductList/PBProductList.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import PBProductList from './PBProductList';
+
+const meta: Meta<typeof PBProductList> = {
+  title: 'product/PBProductList',
+  component: PBProductList,
+};
+
+export default meta;
+type Story = StoryObj<typeof PBProductList>;
+
+export const Default: Story = {};

--- a/frontend/src/components/Product/PBProductList/PBProductList.tsx
+++ b/frontend/src/components/Product/PBProductList/PBProductList.tsx
@@ -22,6 +22,7 @@ const PBProductListContainer = styled.ul`
   display: flex;
   overflow-x: auto;
   overflow-y: hidden;
+  gap: 40px;
 
   &::-webkit-scrollbar {
     display: none;

--- a/frontend/src/components/Product/PBProductList/PBProductList.tsx
+++ b/frontend/src/components/Product/PBProductList/PBProductList.tsx
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 import PBProductItem from '../PBProductItem/PBProductItem';
 

--- a/frontend/src/components/Product/PBProductList/PBProductList.tsx
+++ b/frontend/src/components/Product/PBProductList/PBProductList.tsx
@@ -1,0 +1,29 @@
+import { styled } from 'styled-components';
+
+import PBProductItem from '../PBProductItem/PBProductItem';
+
+import pbProducts from '@/mocks/data/pbProducts.json';
+
+const PBProductList = () => {
+  return (
+    <PBProductListContainer>
+      {pbProducts.map((pbProduct) => (
+        <li key={pbProduct.id}>
+          <PBProductItem pbProduct={pbProduct} />
+        </li>
+      ))}
+    </PBProductListContainer>
+  );
+};
+
+export default PBProductList;
+
+const PBProductListContainer = styled.ul`
+  display: flex;
+  overflow-x: auto;
+  overflow-y: hidden;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;

--- a/frontend/src/mocks/data/pbProducts.json
+++ b/frontend/src/mocks/data/pbProducts.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": 1,
+    "name": "꼬북칩",
+    "price": 1500,
+    "image": "https://t3.ftcdn.net/jpg/06/06/91/70/240_F_606917032_4ujrrMV8nspZDX8nTgGrTpJ69N9JNxOL.jpg",
+    "averageRating": 4.5
+  },
+  {
+    "id": 2,
+    "name": "새우깡",
+    "price": 1000,
+    "image": "https://cdn.pixabay.com/photo/2016/03/23/15/00/ice-cream-1274894_1280.jpg",
+    "averageRating": 4.0
+  },
+  {
+    "id": 3,
+    "name": "감자깡",
+    "price": 1200,
+    "image": "https://t3.ftcdn.net/jpg/06/06/91/70/240_F_606917032_4ujrrMV8nspZDX8nTgGrTpJ69N9JNxOL.jpg",
+    "averageRating": 3.0
+  }
+]

--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -18,3 +18,11 @@ export interface ProductDetail {
   averageRating: number;
   tags: Tag[];
 }
+
+export interface PBProduct {
+  id: number;
+  name: string;
+  price: number;
+  image: string;
+  averageRating: number;
+}


### PR DESCRIPTION
## Issue

- close #72

## ✨ 구현한 기능

- 편의점 PB 상품 아이템 컴포넌트 추가하였습니다.

## 📢 논의하고 싶은 내용

웁스...진짜 길게 적었는데 잘못 눌러서 꺼졌어요...ㅠ 
일단 기억나는대로 다시 적어보겠습니다.

먼저, 아래 코드와 같이 작성했는데요.

```js
  <Text
    as="span"
    size="sm"
    weight="bold"
    color={theme.textColors.info}
    css={`
      margin-left: 5px;
    `}
   >
```

css만 적으면 앞에 size나 color가 적용이 안됩니다.
처음에는 color만 적용 안되더니 나중엔 적용되고, 이젠 size가 작동이 안되고 후...
왜 이런지 아는분 계신가요??
그냥 css 부분 다 지워버리고 styled로 처리해버렸습니다.
그래서 약간 지저분해졌는데 불필요한 부분 있으면 말씀해주세요!

별점과 가격을 포함하고 있는 div의 이름을 추천해주세요...
 도~~저히 생각이 안나서 `PBProductDetailInfoWrapper`로 했는데 더 좋은 이름이 있다면 추천바랍니당

컴포넌트 사이즈는 제가 임의로 작성했습니다.
레이아웃 나오고 페이지에 붙였을 때 아마 다시 사이즈 수정해야할 거 같아요!

일단 제목은 두줄에서 한줄로 수정했습니다.
이 컴포넌트가 한 아이템이 차지할 수 있는 width가 좁은데 두줄로 하니까 상품명이 애매하게 끊기더라구요.
그래서 한줄로 바꾸고 말줄임표 처리하였습니다.
피그마대로 만들었는데 디자인도 조금 수정해야할 거 같습니다.
혹시 좋은 디자인 아이디어가 있다면 적극 반영하겠습니다~~


## 🎸 기타

x

## 📸 사진
- PBProductItem
<img width="167" alt="스크린샷 2023-07-19 오후 10 59 16" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/80464961/2e432cf5-40dc-47d4-8538-510e32560ec8">

- PBProductList
<img width="470" alt="스크린샷 2023-07-19 오후 10 59 10" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/80464961/6511868b-4921-4c3d-9010-50c5e45117f8">


![화면 기록 2023-07-19 오후 10 58 50](https://github.com/woowacourse-teams/2023-fun-eat/assets/80464961/07216f17-603a-4f6a-b422-939ad3af9d0a)


## ⏰ 일정

- 추정 시간 : 3시간
- 걸린 시간 : 4시간
