### PR TITLE
[FE] feat: 상품 리스트 페이지 마크업

### DIFF
--- a/frontend/src/components/Common/Title/Title.tsx
+++ b/frontend/src/components/Common/Title/Title.tsx
@@ -13,10 +13,10 @@ const Title = ({ headingTitle }: TitleProps) => {
     <TitleContainer>
       <Link as={RouterLink} to=".." relative="path">
         <SvgIconWrapper>
-          <SvgIcon variant="arrow" color={theme.colors.gray5} width={15} height={15} />
+          <SvgIcon variant="arrow" color={theme.colors.gray5} width={20} height={20} />
         </SvgIconWrapper>
       </Link>
-      <Heading weight="bold" css="font-size:2.4rem">
+      <Heading as="h2" weight="bold">
         {headingTitle}
       </Heading>
     </TitleContainer>
@@ -28,12 +28,12 @@ export default Title;
 const TitleContainer = styled.div`
   display: flex;
   flex-direction: row;
-  align-items: center;
   justify-content: center;
   position: relative;
 `;
 
 const SvgIconWrapper = styled.button`
   position: absolute;
+  top: 8px;
   left: 0;
 `;

--- a/frontend/src/components/Common/index.ts
+++ b/frontend/src/components/Common/index.ts
@@ -1,7 +1,11 @@
 export { default as CategoryMenu } from './CategoryMenu/CategoryMenu';
+export { default as Header } from './Header/Header';
+export { default as Layout } from './Layout/Layout';
+export { default as NavigationBar } from './NavigationBar/NavigationBar';
+export { default as SortButton } from './SortButton/SortButton';
+export { default as SortOptionList } from './SortOptionList/SortOptionList';
 export { default as SvgSprite } from './Svg/SvgSprite';
 export { default as SvgIcon } from './Svg/SvgIcon';
+export { default as TabMenu } from './TabMenu/TabMenu';
 export { default as TagList } from './TagList/TagList';
-export { default as Header } from './Header/Header';
-export { default as NavigationBar } from './NavigationBar/NavigationBar';
-export { default as Layout } from './Layout/Layout';
+export { default as Title } from './Title/Title';

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -1,7 +1,7 @@
 export const PATH = {
   HOME: '/',
   SEARCH: '/search',
-  PRODUCT_LIST: '/product-list',
+  PRODUCT_LIST: '/products',
   PROFILE: '/profile',
   RECIPE: '/recipe',
 } as const;

--- a/frontend/src/pages/ProductList.tsx
+++ b/frontend/src/pages/ProductList.tsx
@@ -1,5 +1,0 @@
-const ProductListPage = () => {
-  return <></>;
-};
-
-export default ProductListPage;

--- a/frontend/src/pages/ProductListPage.tsx
+++ b/frontend/src/pages/ProductListPage.tsx
@@ -1,0 +1,29 @@
+import { Spacing } from '@fun-eat/design-system';
+import styled from 'styled-components';
+
+import { CategoryMenu } from '@/components/Common';
+import SortButton from '@/components/Common/SortButton/SortButton';
+import Title from '@/components/Common/Title/Title';
+import { ProductList } from '@/components/Product';
+import foodCategory from '@/mocks/data/foodCategory.json';
+
+const ProductListPage = () => {
+  return (
+    <section>
+      <Title headingTitle="공통 상품" />
+      <Spacing size={30} />
+      <CategoryMenu menuList={foodCategory} menuVariant="food" />
+      <SortButtonWrapper>
+        <SortButton />
+      </SortButtonWrapper>
+      <ProductList />
+    </section>
+  );
+};
+
+export default ProductListPage;
+
+const SortButtonWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -3,7 +3,7 @@ import { createBrowserRouter } from 'react-router-dom';
 import App from '@/App';
 import { PATH } from '@/constants/path';
 import HomePage from '@/pages/HomePage';
-import ProductListPage from '@/pages/ProductList';
+import ProductListPage from '@/pages/ProductListPage';
 import ProfilePage from '@/pages/ProfilePage';
 import RecipePage from '@/pages/RecipePage';
 import SearchPage from '@/pages/SearchPage';


### PR DESCRIPTION
## Issue

- close #64 

## ✨ 구현한 기능

- productList의 path를 변경하였습니다.
- Title의 크기를 변경하였습니다.
- 상품 리스트 페이지를 마크업 하였습니다.

마크업에만 중점을 맞춰서 따로 정렬이나 카테고리 기능은 구현하지 않았습니다.

## 📢 논의하고 싶은 내용

바텀시트가 전체 넓이의 100%로 적용이 됩니다.

<img width="1439" alt="스크린샷 2023-07-20 오후 9 32 11" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/80464961/58057eb9-c8b5-4ab9-bf98-1fd3557c0824">


아래가 완성된 페이지입니다.
높은 가격순 버튼 아래에 상품 리스트가 있습니다.
혹시 버튼과 상품 리스트 간의 간격을 더 좁히고 싶으면 따로 말씀해주세요.
지금은 따로 spacing 같은 간격은 없고 li 태그 자체 padding만 존재합니다.

<img width="647" alt="스크린샷 2023-07-20 오후 9 32 03" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/80464961/0cd30a7b-b53f-4b1e-b242-3423291b164b">


## 🎸 기타

Title 컴포넌트에 css를 작성했습니다.
근데 지금보니 적용이 안되네요...ㅠ
그래서 어쩔 수 없이 Title의 as를 h2로 바꾸었습니다.
(css는 font-size였는데 삭제함...)

## ⏰ 일정

- 추정 시간 : 1시간
- 걸린 시간 : 1시간
