### PR TITLE
[BE] test: 특정 상품에서 평점순으로 리뷰 목록을 조회하는 테스트 추가

### DIFF
--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -29,21 +29,10 @@ import io.restassured.response.Response;
 import io.restassured.specification.MultiPartSpecification;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("NonAsciiCharacters")
 class ReviewAcceptanceTest extends AcceptanceTest {
-
-    @BeforeEach
-    void init() {
-        reviewTagRepository.deleteAll();
-        reviewFavoriteRepository.deleteAll();
-        reviewRepository.deleteAll();
-        memberRepository.deleteAll();
-        productRepository.deleteAll();
-        tagRepository.deleteAll();
-    }
 
     @Test
     void 리뷰를_작성한다() {
@@ -136,7 +125,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 좋아요_기준_내림차순된_리뷰_목록을_조회한다() {
+    void 좋아요_기준_내림차순으로_리뷰_목록을_조회한다() {
         // given
         final var category = new Category("간편식사", CategoryType.FOOD);
         카테고리_추가_요청(category);
@@ -200,7 +189,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 평점_기준_내림차순된_리뷰_목록을_조회한다() {
+    void 평점_기준_내림차순으로_리뷰_목록을_조회한다() {
         // given
         final var category = new Category("간편식사", CategoryType.FOOD);
         카테고리_추가_요청(category);

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -125,7 +125,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 좋아요_기준_내림차순으로_리뷰_목록을_조회한다() {
+    void 좋아요_기준_내림차순으로_리뷰_목록을_조회할_수_있다() {
         // given
         final var category = new Category("간편식사", CategoryType.FOOD);
         카테고리_추가_요청(category);
@@ -153,11 +153,11 @@ class ReviewAcceptanceTest extends AcceptanceTest {
 
         // then
         STATUS_CODE를_검증한다(response, 정상_처리);
-        좋아요_기준_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, pageDto);
+        정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, pageDto);
     }
 
     @Test
-    void 평점_기준_오름차순으로_리뷰_목록을_조회한다() {
+    void 평점_기준_오름차순으로_리뷰_목록을_조회할_수_있다() {
         // given
         final var category = new Category("간편식사", CategoryType.FOOD);
         카테고리_추가_요청(category);
@@ -185,11 +185,11 @@ class ReviewAcceptanceTest extends AcceptanceTest {
 
         // then
         STATUS_CODE를_검증한다(response, 정상_처리);
-        좋아요_기준_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
+        정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
     }
 
     @Test
-    void 평점_기준_내림차순으로_리뷰_목록을_조회한다() {
+    void 평점_기준_내림차순으로_리뷰_목록을_조회할_수_있다() {
         // given
         final var category = new Category("간편식사", CategoryType.FOOD);
         카테고리_추가_요청(category);
@@ -217,7 +217,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
 
         // then
         STATUS_CODE를_검증한다(response, 정상_처리);
-        좋아요_기준_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
+        정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
     }
 
     @Test
@@ -295,9 +295,9 @@ class ReviewAcceptanceTest extends AcceptanceTest {
                 .extract();
     }
 
-    private void 좋아요_기준_리뷰_목록_조회_결과를_검증한다(final ExtractableResponse<Response> response,
-                                          final List<Review> reviews,
-                                          final SortingReviewsPageDto pageDto) {
+    private void 정렬된_리뷰_목록_조회_결과를_검증한다(final ExtractableResponse<Response> response,
+                                       final List<Review> reviews,
+                                       final SortingReviewsPageDto pageDto) {
         페이지를_검증한다(response, pageDto);
         리뷰_목록을_검증한다(response, reviews);
     }

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -200,6 +200,38 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    void 평점_기준_내림차순된_리뷰_목록을_조회한다() {
+        // given
+        final var category = new Category("간편식사", CategoryType.FOOD);
+        카테고리_추가_요청(category);
+
+        final var member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
+        final var member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");
+        final var member3 = new Member("test3", "test3.png", 9, Gender.MALE, "010-9876-4321");
+        final var members = List.of(member1, member2, member3);
+        복수_유저_추가_요청(members);
+
+        final var product = new Product("삼각김밥1", 1000L, "image.png", "김밥", category);
+        final var productId = 상품_추가_요청(product);
+
+        final var review1 = new Review(member1, product, "review1.jpg", 3.0, "이 김밥은 재밌습니다", true, 5L);
+        final var review2 = new Review(member2, product, "review2.jpg", 4.5, "역삼역", true, 351L);
+        final var review3 = new Review(member3, product, "review3.jpg", 3.5, "ㅇㅇ", false, 130L);
+        final var reviews = List.of(review1, review2, review3);
+        복수_리뷰_추가(reviews);
+
+        final var sortingReviews = List.of(review2, review3, review1);
+        final var page = new SortingReviewsPageDto(3L, 1L, true, true, 0L, 10L);
+
+        // when
+        final var response = 정렬된_리뷰_목록_조회_요청(productId, "rating,desc", 0);
+
+        // then
+        STATUS_CODE를_검증한다(response, 정상_처리);
+        좋아요_기준_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
+    }
+
+    @Test
     void 리뷰_랭킹을_조회하다() {
         // given
         final var category = new Category("간편식사", CategoryType.FOOD);

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -157,13 +157,46 @@ class ReviewAcceptanceTest extends AcceptanceTest {
         복수_리뷰_추가(reviews);
 
         final var sortingReviews = List.of(review2, review3, review1);
+        final var pageDto = new SortingReviewsPageDto(3L, 1L, true, true, 0L, 10L);
 
         // when
-        final var response = 좋아요_기준_리뷰_목록_조회_요청(productId, "favoriteCount,desc", 0);
+        final var response = 정렬된_리뷰_목록_조회_요청(productId, "favoriteCount,desc", 0);
 
         // then
         STATUS_CODE를_검증한다(response, 정상_처리);
-        좋아요_기준_리뷰_목록_조회_결과를_검증한다(response, sortingReviews);
+        좋아요_기준_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, pageDto);
+    }
+
+    @Test
+    void 평점_기준_오름차순으로_리뷰_목록을_조회한다() {
+        // given
+        final var category = new Category("간편식사", CategoryType.FOOD);
+        카테고리_추가_요청(category);
+
+        final var member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
+        final var member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");
+        final var member3 = new Member("test3", "test3.png", 9, Gender.MALE, "010-9876-4321");
+        final var members = List.of(member1, member2, member3);
+        복수_유저_추가_요청(members);
+
+        final var product = new Product("삼각김밥1", 1000L, "image.png", "김밥", category);
+        final var productId = 상품_추가_요청(product);
+
+        final var review1 = new Review(member1, product, "review1.jpg", 3.0, "이 김밥은 재밌습니다", true, 5L);
+        final var review2 = new Review(member2, product, "review2.jpg", 4.5, "역삼역", true, 351L);
+        final var review3 = new Review(member3, product, "review3.jpg", 3.5, "ㅇㅇ", false, 130L);
+        final var reviews = List.of(review1, review2, review3);
+        복수_리뷰_추가(reviews);
+
+        final var sortingReviews = List.of(review1, review3, review2);
+
+        // when
+        final var response = 정렬된_리뷰_목록_조회_요청(productId, "rating,asc", 0);
+        final var page = new SortingReviewsPageDto(3L, 1L, true, true, 0L, 10L);
+
+        // then
+        STATUS_CODE를_검증한다(response, 정상_처리);
+        좋아요_기준_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
     }
 
     @Test
@@ -221,9 +254,9 @@ class ReviewAcceptanceTest extends AcceptanceTest {
         reviewRepository.saveAll(reviews);
     }
 
-    private ExtractableResponse<Response> 좋아요_기준_리뷰_목록_조회_요청(final Long productId,
-                                                             final String sort,
-                                                             final Integer page) {
+    private ExtractableResponse<Response> 정렬된_리뷰_목록_조회_요청(final Long productId,
+                                                          final String sort,
+                                                          final Integer page) {
         return given()
                 .queryParam("sort", sort)
                 .queryParam("page", page)
@@ -242,13 +275,14 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     }
 
     private void 좋아요_기준_리뷰_목록_조회_결과를_검증한다(final ExtractableResponse<Response> response,
-                                          final List<Review> reviews) {
-        페이지를_검증한다(response);
+                                          final List<Review> reviews,
+                                          final SortingReviewsPageDto pageDto) {
+        페이지를_검증한다(response, pageDto);
         리뷰_목록을_검증한다(response, reviews);
     }
 
-    private void 페이지를_검증한다(final ExtractableResponse<Response> response) {
-        final var expected = new SortingReviewsPageDto(3L, 1L, true, true, 0L, 10L);
+    private void 페이지를_검증한다(final ExtractableResponse<Response> response,
+                           final SortingReviewsPageDto expected) {
         final var actual = response.jsonPath().getObject("page", SortingReviewsPageDto.class);
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
     }

--- a/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -182,7 +182,7 @@ class ReviewServiceTest {
     class sortingReviews_페이징_테스트 {
 
         @Test
-        void 좋아요_기준으로_내림차순_정렬이_되는지_확인한다() {
+        void 좋아요_기준으로_내림차순_정렬을_할_수_있다() {
             // given
             final var member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
             final var member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");
@@ -213,7 +213,7 @@ class ReviewServiceTest {
         }
 
         @Test
-        void 평점_기준으로_오름차순_정렬이_되는지_확인한다() {
+        void 평점_기준으로_오름차순_정렬을_할_수_있다() {
             // given
             final var member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
             final var member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");
@@ -244,7 +244,7 @@ class ReviewServiceTest {
         }
 
         @Test
-        void 평점_기준으로_내림차순_정렬이_되는지_확인한다() {
+        void 평점_기준으로_내림차순_정렬을_할_수_있다() {
             // given
             final var member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
             final var member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");

--- a/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -243,6 +243,37 @@ class ReviewServiceTest {
             // then
             assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
         }
+
+        @Test
+        void 평점_기준으로_내림차순_정렬이_되는지_확인한다() {
+            // given
+            final var member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
+            final var member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");
+            final var member3 = new Member("test3", "test3.png", 9, Gender.MALE, "010-9876-4321");
+            final var members = List.of(member1, member2, member3);
+            복수_유저_추가(members);
+
+            final var product = new Product("김밥", 1000L, "kimbap.png", "우영우가 먹은 그 김밥", null);
+            상품_추가(product);
+
+            final var review1 = new Review(member1, product, "review1.jpg", 3.0, "이 김밥은 재밌습니다", true, 351L);
+            final var review2 = new Review(member2, product, "review2.jpg", 4.5, "역삼역", true, 24L);
+            final var review3 = new Review(member3, product, "review3.jpg", 3.5, "ㅇㅇ", false, 130L);
+            final var reviews = List.of(review1, review2, review3);
+            복수_리뷰_추가(reviews);
+
+            final var pageable = PageRequest.of(0, 2, Sort.by("rating").descending());
+            final var expected = Stream.of(review2, review3)
+                    .map(SortingReviewDto::toDto)
+                    .collect(Collectors.toList());
+
+            // when
+            final var actual = reviewService.sortingReviews(product.getId(), pageable)
+                    .getReviews();
+
+            // then
+            assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+        }
     }
 
     private void 복수_유저_추가(final List<Member> members) {

--- a/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -18,6 +18,9 @@ import com.funeat.review.presentation.dto.ReviewFavoriteRequest;
 import com.funeat.review.presentation.dto.SortingReviewDto;
 import com.funeat.tag.domain.Tag;
 import com.funeat.tag.persistence.TagRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Nested;
@@ -25,13 +28,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Transactional
 @SpringBootTest

--- a/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -212,6 +212,37 @@ class ReviewServiceTest {
             // then
             assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
         }
+
+        @Test
+        void 평점_기준으로_오름차순_정렬이_되는지_확인한다() {
+            // given
+            final var member1 = new Member("test1", "test1.png", 20, Gender.MALE, "010-1234-1234");
+            final var member2 = new Member("test2", "test2.png", 41, Gender.FEMALE, "010-1357-2468");
+            final var member3 = new Member("test3", "test3.png", 9, Gender.MALE, "010-9876-4321");
+            final var members = List.of(member1, member2, member3);
+            복수_유저_추가(members);
+
+            final var product = new Product("김밥", 1000L, "kimbap.png", "우영우가 먹은 그 김밥", null);
+            상품_추가(product);
+
+            final var review1 = new Review(member1, product, "review1.jpg", 3.0, "이 김밥은 재밌습니다", true, 351L);
+            final var review2 = new Review(member2, product, "review2.jpg", 4.5, "역삼역", true, 24L);
+            final var review3 = new Review(member3, product, "review3.jpg", 3.5, "ㅇㅇ", false, 130L);
+            final var reviews = List.of(review1, review2, review3);
+            복수_리뷰_추가(reviews);
+
+            final var pageable = PageRequest.of(0, 2, Sort.by("rating").ascending());
+            final var expected = Stream.of(review1, review3)
+                    .map(SortingReviewDto::toDto)
+                    .collect(Collectors.toList());
+
+            // when
+            final var actual = reviewService.sortingReviews(product.getId(), pageable)
+                    .getReviews();
+
+            // then
+            assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+        }
     }
 
     private void 복수_유저_추가(final List<Member> members) {


### PR DESCRIPTION
## Issue

- close #103 

## ✨ 구현한 기능

- 특정 상품에서 평점 기준 오름차순으로 리뷰 목록을 조회하는 인수 테스트, 서비스 테스트 추가
- 특정 상품에서 평점 기준 내림차순으로 리뷰 목록을 조회하는 인수 테스트, 서비스 테스트 추가

## 📢 논의하고 싶은 내용

- 테스트를 작성하다보니 만약 정렬하는 값이 같은 이후를 생각해보지 못한 것 같아요. 그래서 담주에 이야기 해보면 좋을 것 같습니다.
- 참고: #116 

## 🎸 기타

- 나머지 기능은 이미 구현되어 있어서 테스트만 추가했습니다.

## ⏰ 일정

- 추정 시간 : 1
- 걸린 시간 : 0.5
