### PR TITLE
[FE] feat: 리뷰 사진 업로드 컴포넌트 추가

### DIFF
--- a/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.stories.tsx
+++ b/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ReviewImageUploader from './ReviewImageUploader';
+
+const meta: Meta<typeof ReviewImageUploader> = {
+  title: 'review/ReviewImageUploader',
+  component: ReviewImageUploader,
+};
+
+export default meta;
+type Story = StoryObj<typeof ReviewImageUploader>;
+
+export const Default: Story = {};

--- a/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
+++ b/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
@@ -30,7 +30,7 @@ const ReviewImageUploader = () => {
       <Spacing size={20} />
       {reviewImage ? (
         <ReviewImageButtonWrapper>
-          <img src={reviewImage} alt={'업로드한 리뷰 사진'} />
+          <img src={reviewImage} alt={'업로드한 리뷰 사진'} width={200} />
           <Button variant="filled" color="primary" size="sm" onClick={deleteReviewImage}>
             삭제하기
           </Button>

--- a/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
+++ b/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
@@ -18,7 +18,9 @@ const ReviewImageUploader = () => {
 
   return (
     <ReviewImageUploaderContainer>
-      <UploadText as="h2">구매한 상품 사진이 있다면 올려주세요.</UploadText>
+      <Heading as="h2" size="lg">
+        구매한 상품 사진이 있다면 올려주세요.
+      </Heading>
       <Text size="sm" color={theme.textColors.disabled}>
         사진은 1장까지 업로드 가능합니다.
       </Text>
@@ -52,10 +54,6 @@ const ReviewImageUploaderContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-`;
-
-const UploadText = styled(Heading)`
-  font-size: 1.8rem;
 `;
 
 const ImageUploadLabel = styled.label`

--- a/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
+++ b/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
@@ -1,13 +1,16 @@
-import { Button, Heading, Spacing, Text } from '@fun-eat/design-system';
-import React, { useState } from 'react';
-import styled, { useTheme } from 'styled-components';
+import { Button, Heading, Spacing, Text, useTheme } from '@fun-eat/design-system';
+import type { ChangeEventHandler } from 'react';
+import { useState } from 'react';
+import styled from 'styled-components';
 
 const ReviewImageUploader = () => {
   const [reviewImage, setReviewImage] = useState('');
   const theme = useTheme();
 
-  const uploadReviewImage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (!event.target.files) return;
+  const uploadReviewImage: ChangeEventHandler<HTMLInputElement> = (event) => {
+    if (!event.target.files) {
+      return;
+    }
     setReviewImage(URL.createObjectURL(event.target.files[0]));
   };
 

--- a/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
+++ b/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
@@ -30,7 +30,7 @@ const ReviewImageUploader = () => {
       <Spacing size={20} />
       {reviewImage ? (
         <ReviewImageButtonWrapper>
-          <img src={reviewImage} alt={'업로드한 리뷰 사진'} width={200} />
+          <img src={reviewImage} alt="업로드한 리뷰 사진" width={200} />
           <Button variant="filled" color="primary" size="sm" onClick={deleteReviewImage}>
             삭제하기
           </Button>

--- a/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
+++ b/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
@@ -4,11 +4,43 @@ import styled from 'styled-components';
 
 const ReviewImageUploader = () => {
   const imageUploadInputRef = useRef<HTMLInputElement>(null);
+  const [reviewImage, setReviewImage] = useState('');
+
+  const uploadReviewImage = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (!imageUploadInputRef.current) return;
+    imageUploadInputRef.current.click();
+    if (!event.target.files) return;
+    setReviewImage(URL.createObjectURL(event.target.files[0]));
+  };
+
+  const deleteReviewImage = () => {
+    URL.revokeObjectURL(reviewImage);
+    setReviewImage('');
+  };
+
   return (
     <ReviewImageUploaderContainer>
       <UploadText as="h2">사진이 있다면 올려주세요.</UploadText>
-      <ImageUploadLabel htmlFor="review-image">+</ImageUploadLabel>
-      <input id="review-image" type="file" accept="image/*" ref={imageUploadInputRef} style={{ display: 'none' }} />
+      {reviewImage ? (
+        <ReviewImageButtonWrapper>
+          <img src={reviewImage} />
+          <Button variant="filled" color="primary" size="sm" onClick={deleteReviewImage}>
+            삭제하기
+          </Button>
+        </ReviewImageButtonWrapper>
+      ) : (
+        <>
+          <ImageUploadLabel htmlFor="review-image">+</ImageUploadLabel>
+          <input
+            id="review-image"
+            type="file"
+            accept="image/*"
+            ref={imageUploadInputRef}
+            onChange={uploadReviewImage}
+            style={{ display: 'none' }}
+          />
+        </>
+      )}
     </ReviewImageUploaderContainer>
   );
 };

--- a/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
+++ b/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
@@ -27,7 +27,7 @@ const ReviewImageUploader = () => {
       <Spacing size={20} />
       {reviewImage ? (
         <ReviewImageButtonWrapper>
-          <img src={reviewImage} />
+          <img src={reviewImage} alt={'업로드한 리뷰 사진'} />
           <Button variant="filled" color="primary" size="sm" onClick={deleteReviewImage}>
             삭제하기
           </Button>

--- a/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
+++ b/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
@@ -1,0 +1,46 @@
+import { Button, Heading } from '@fun-eat/design-system';
+import React, { useRef, useState } from 'react';
+import styled from 'styled-components';
+
+const ReviewImageUploader = () => {
+  const imageUploadInputRef = useRef<HTMLInputElement>(null);
+  return (
+    <ReviewImageUploaderContainer>
+      <UploadText as="h2">사진이 있다면 올려주세요.</UploadText>
+      <ImageUploadLabel htmlFor="review-image">+</ImageUploadLabel>
+      <input id="review-image" type="file" accept="image/*" ref={imageUploadInputRef} style={{ display: 'none' }} />
+    </ReviewImageUploaderContainer>
+  );
+};
+
+export default ReviewImageUploader;
+
+const ReviewImageUploaderContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+`;
+
+const UploadText = styled(Heading)`
+  font-size: 1.8rem;
+`;
+
+const ImageUploadLabel = styled.label`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 92px;
+  height: 95px;
+  background: ${({ theme }) => theme.colors.gray1};
+  border: 1px solid ${({ theme }) => theme.borderColors.disabled};
+  border-radius: ${({ theme }) => theme.borderRadius.xs};
+  cursor: pointer;
+`;
+
+const ReviewImageButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+`;

--- a/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
+++ b/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
@@ -1,14 +1,12 @@
-import { Button, Heading } from '@fun-eat/design-system';
-import React, { useRef, useState } from 'react';
-import styled from 'styled-components';
+import { Button, Heading, Spacing, Text } from '@fun-eat/design-system';
+import React, { useState } from 'react';
+import styled, { useTheme } from 'styled-components';
 
 const ReviewImageUploader = () => {
-  const imageUploadInputRef = useRef<HTMLInputElement>(null);
   const [reviewImage, setReviewImage] = useState('');
+  const theme = useTheme();
 
   const uploadReviewImage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (!imageUploadInputRef.current) return;
-    imageUploadInputRef.current.click();
     if (!event.target.files) return;
     setReviewImage(URL.createObjectURL(event.target.files[0]));
   };
@@ -20,7 +18,11 @@ const ReviewImageUploader = () => {
 
   return (
     <ReviewImageUploaderContainer>
-      <UploadText as="h2">사진이 있다면 올려주세요.</UploadText>
+      <UploadText as="h2">구매한 상품 사진이 있다면 올려주세요.</UploadText>
+      <Text size="sm" color={theme.textColors.disabled}>
+        사진은 1장까지 업로드 가능합니다.
+      </Text>
+      <Spacing size={20} />
       {reviewImage ? (
         <ReviewImageButtonWrapper>
           <img src={reviewImage} />
@@ -35,7 +37,6 @@ const ReviewImageUploader = () => {
             id="review-image"
             type="file"
             accept="image/*"
-            ref={imageUploadInputRef}
             onChange={uploadReviewImage}
             style={{ display: 'none' }}
           />
@@ -51,7 +52,6 @@ const ReviewImageUploaderContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 20px;
 `;
 
 const UploadText = styled(Heading)`

--- a/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
+++ b/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
@@ -36,16 +36,10 @@ const ReviewImageUploader = () => {
           </Button>
         </ReviewImageButtonWrapper>
       ) : (
-        <>
-          <ImageUploadLabel htmlFor="review-image">+</ImageUploadLabel>
-          <input
-            id="review-image"
-            type="file"
-            accept="image/*"
-            onChange={uploadReviewImage}
-            style={{ display: 'none' }}
-          />
-        </>
+        <ImageUploadLabel>
+          +
+          <input type="file" accept="image/*" onChange={uploadReviewImage} />
+        </ImageUploadLabel>
       )}
     </ReviewImageUploaderContainer>
   );
@@ -69,6 +63,10 @@ const ImageUploadLabel = styled.label`
   border: 1px solid ${({ theme }) => theme.borderColors.disabled};
   border-radius: ${({ theme }) => theme.borderRadius.xs};
   cursor: pointer;
+
+  & > input {
+    display: none;
+  }
 `;
 
 const ReviewImageButtonWrapper = styled.div`


### PR DESCRIPTION
## Issue

- close #106 

## ✨ 구현한 기능
- 리뷰 사진을 1장까지 업로드 할 수 있습니다.
- 사진을 업로드하고 사진을 삭제할 수 있습니다.

## 📢 논의하고 싶은 내용

- 이미지 미리보기 기능도 넣었는데 어떤가요? 그리고 이미지 미리보기의 경우 사이즈를 고정해야할 것 같은데 몇으로 하면 좋을까요?

## 🎸 기타

- 사진을 어떻게 보낼지에 따라 저장하는 state의 타입이 달라질 것 같네요

## ⏰ 일정

- 추정 시간 : 2시간
- 걸린 시간 : 2시간

## 캡처 

업로드 전
<img width="488" alt="스크린샷 2023-07-23 오후 2 07 05" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/55427367/37340a22-e0ab-4e27-9ec8-fea0a2e30fe6">

업로드 후
<img width="492" alt="스크린샷 2023-07-23 오후 2 07 18" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/55427367/d9424fe9-481b-440d-a09a-a09820d84e9d">
