### PR TITLE
[FE] feat: 리뷰 작성 컴포넌트 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@fun-eat/design-system": "^0.2.2",
+    "@fun-eat/design-system": "^0.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.2",

--- a/frontend/src/components/Review/ReviewTextarea/ReviewTextarea.stories.tsx
+++ b/frontend/src/components/Review/ReviewTextarea/ReviewTextarea.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ReviewTextarea from './ReviewTextarea';
+
+const meta: Meta<typeof ReviewTextarea> = {
+  title: 'review/ReviewTextarea',
+  component: ReviewTextarea,
+};
+
+export default meta;
+type Story = StoryObj<typeof ReviewTextarea>;
+
+export const Default: Story = {};

--- a/frontend/src/components/Review/ReviewTextarea/ReviewTextarea.tsx
+++ b/frontend/src/components/Review/ReviewTextarea/ReviewTextarea.tsx
@@ -1,0 +1,49 @@
+import { Heading, Spacing, Text, Textarea, useTheme } from '@fun-eat/design-system';
+import type { ChangeEventHandler } from 'react';
+import { useState } from 'react';
+import styled from 'styled-components';
+
+const MAX_LENGTH = 200;
+
+const ReviewTextarea = () => {
+  const [reviewValue, setReviewValue] = useState('');
+  const theme = useTheme();
+
+  const handleReviewInput: ChangeEventHandler<HTMLTextAreaElement> = (event) => {
+    setReviewValue(event.currentTarget.value);
+  };
+
+  return (
+    <ReviewTextareaContainer>
+      <Heading as="h2" size="xl">
+        리뷰를 작성해주세요. (200자)
+      </Heading>
+      <Spacing size={16} />
+      <Textarea
+        rows={5}
+        resize="vertical"
+        placeholder=""
+        maxLength={MAX_LENGTH}
+        value={reviewValue}
+        onChange={handleReviewInput}
+      />
+      <Spacing size={16} />
+      <ReviewWritingStatusText color={theme.textColors.info}>
+        작성한 글자 수: {reviewValue.length} / {MAX_LENGTH}
+      </ReviewWritingStatusText>
+    </ReviewTextareaContainer>
+  );
+};
+
+export default ReviewTextarea;
+
+const ReviewTextareaContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+`;
+
+const ReviewWritingStatusText = styled(Text)`
+  margin-left: auto;
+`;

--- a/frontend/src/components/Review/ReviewTextarea/ReviewTextarea.tsx
+++ b/frontend/src/components/Review/ReviewTextarea/ReviewTextarea.tsx
@@ -22,7 +22,7 @@ const ReviewTextarea = () => {
       <Textarea
         rows={5}
         resize="vertical"
-        placeholder=""
+        placeholder="솔직한 리뷰를 써주세요 😊"
         maxLength={MAX_LENGTH}
         value={reviewValue}
         onChange={handleReviewInput}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1565,10 +1565,10 @@
   resolved "https://registry.yarnpkg.com/@fal-works/esbuild-plugin-global-externals/-/esbuild-plugin-global-externals-2.1.2.tgz#c05ed35ad82df8e6ac616c68b92c2282bd083ba4"
   integrity sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==
 
-"@fun-eat/design-system@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@fun-eat/design-system/-/design-system-0.2.2.tgz#a0c6803cf42570b72ab56263c9e086e83e0a6c33"
-  integrity sha512-8xWLDUbps0nuJoCR4RgmaRaUrHkOOe4Yr2UZBDiDKgxZpCp8TzpDI9ZHO7Q96KKEgf2AUxtGJvwxamONcHJ3+Q==
+"@fun-eat/design-system@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@fun-eat/design-system/-/design-system-0.3.0.tgz#29c212cef447ffa7b9d70a94d6fd210147c4af21"
+  integrity sha512-NR3v1KRMB9wqXBDOFeI8XkYepfEjh8yiTyMRL5HsWTOIOwG6e5Nksh03Mrs9IGdVzaadfwtbNdNwxR4BK12ubg==
 
 "@humanwhocodes/config-array@^0.11.10":
   version "0.11.10"


### PR DESCRIPTION
## Issue

- close #109 

## ✨ 구현한 기능

- 리뷰 작성 컴포넌트 구현

## 📢 논의하고 싶은 내용

x

## 🎸 기타

- 텍스트 value는 추후 폼에 추가하면서 바뀔 듯 합니다.
- Textarea의 크기는 컨테이너에 맞춰 잡힙니다.

<img width="607" alt="스크린샷 2023-07-25 오후 12 54 00" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/78616893/83468534-bc16-494d-9032-ac34973302f1">

## ⏰ 일정

- 추정 시간 : 1시간
- 걸린 시간 : 0.5시간
