### PR TITLE
[BE] feat: 사용자 리뷰 정렬 기능 사용시 후순위 정렬 옵션을 구현

### DIFF
--- a/backend/src/main/java/com/funeat/common/CustomPageableHandlerMethodArgumentResolver.java
+++ b/backend/src/main/java/com/funeat/common/CustomPageableHandlerMethodArgumentResolver.java
@@ -1,0 +1,26 @@
+package com.funeat.common;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CustomPageableHandlerMethodArgumentResolver extends PageableHandlerMethodArgumentResolver {
+
+    @Override
+    public Pageable resolveArgument(MethodParameter methodParameter, ModelAndViewContainer mavContainer,
+                                    NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        final Pageable pageable = super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+
+        final Sort lastPrioritySort = Sort.by("id").descending();
+
+        return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                pageable.getSort().and(lastPrioritySort));
+    }
+}

--- a/backend/src/main/java/com/funeat/common/WebConfig.java
+++ b/backend/src/main/java/com/funeat/common/WebConfig.java
@@ -1,14 +1,27 @@
 package com.funeat.common;
 
+import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    private final CustomPageableHandlerMethodArgumentResolver customPageableHandlerMethodArgumentResolver;
+
+    public WebConfig(final CustomPageableHandlerMethodArgumentResolver customPageableHandlerMethodArgumentResolver) {
+        this.customPageableHandlerMethodArgumentResolver = customPageableHandlerMethodArgumentResolver;
+    }
+
     @Override
     public void addFormatters(final FormatterRegistry registry) {
         registry.addConverter(new StringToCategoryTypeConverter());
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(customPageableHandlerMethodArgumentResolver);
     }
 }

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
@@ -29,6 +29,7 @@ import io.restassured.response.Response;
 import io.restassured.specification.MultiPartSpecification;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -36,64 +37,132 @@ class ProductAcceptanceTest extends AcceptanceTest {
 
     public static final int PAGE_SIZE = 10;
 
-    @Test
-    void 카테고리별_상품_목록을_가격낮은순으로_조회한다() {
-        // given
-        final Long categoryId = 카테고리_추가_요청(간편식사);
-        final Product product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 간편식사);
-        final Product product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 간편식사);
-        final Product product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 간편식사);
-        final Product product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", 간편식사);
-        final Product product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", 간편식사);
-        final Product product6 = new Product("삼각김밥6", 1700L, "image.png", "맛있는 삼각김밥6", 간편식사);
-        final Product product7 = new Product("삼각김밥7", 1800L, "image.png", "맛있는 삼각김밥7", 간편식사);
-        final Product product8 = new Product("삼각김밥8", 800L, "image.png", "맛있는 삼각김밥8", 간편식사);
-        final Product product9 = new Product("삼각김밥9", 3100L, "image.png", "맛있는 삼각김밥9", 간편식사);
-        final Product product10 = new Product("삼각김밥10", 2700L, "image.png", "맛있는 삼각김밥10", 간편식사);
-        final Product product11 = new Product("삼각김밥11", 300L, "image.png", "맛있는 삼각김밥11", 간편식사);
-        final List<Product> products = List.of(product1, product2, product3, product4, product5, product6, product7,
-                product8, product9, product10, product11);
-        복수_상품_추가_요청(products);
+    @Nested
+    class 가격_기준_내림차순으로_카테고리별_상품_목록_조회 {
 
-        // when
-        final var response = 카테고리별_상품_목록_조회_요청(categoryId, "price", "asc", 0);
+        @Test
+        void 상품_가격이_서로_다르면_가격_기준_내림차순으로_정렬할_수_있다() {
+            // given
+            final Long categoryId = 카테고리_추가_요청(간편식사);
+            final Product product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 간편식사);
+            final Product product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 간편식사);
+            final Product product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 간편식사);
+            final Product product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", 간편식사);
+            final Product product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", 간편식사);
+            final Product product6 = new Product("삼각김밥6", 1700L, "image.png", "맛있는 삼각김밥6", 간편식사);
+            final Product product7 = new Product("삼각김밥7", 1800L, "image.png", "맛있는 삼각김밥7", 간편식사);
+            final Product product8 = new Product("삼각김밥8", 800L, "image.png", "맛있는 삼각김밥8", 간편식사);
+            final Product product9 = new Product("삼각김밥9", 3100L, "image.png", "맛있는 삼각김밥9", 간편식사);
+            final Product product10 = new Product("삼각김밥10", 2700L, "image.png", "맛있는 삼각김밥10", 간편식사);
+            final Product product11 = new Product("삼각김밥11", 300L, "image.png", "맛있는 삼각김밥11", 간편식사);
+            final List<Product> products = List.of(product1, product2, product3, product4, product5, product6, product7,
+                    product8, product9, product10, product11);
+            복수_상품_추가_요청(products);
 
-        // then
-        STATUS_CODE를_검증한다(response, 정상_처리);
-        페이지를_검증한다(response, (long) products.size(), 0L);
-        카테고리별_상품_목록_조회_결과를_검증한다(response,
-                List.of(product11, product8, product1, product4, product3, product6, product7, product2, product5,
-                        product10));
+            // when
+            final var response = 카테고리별_상품_목록_조회_요청(categoryId, "price", "asc", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            페이지를_검증한다(response, (long) products.size(), 0L);
+            카테고리별_상품_목록_조회_결과를_검증한다(response,
+                    List.of(product11, product8, product1, product4, product3, product6, product7, product2, product5,
+                            product10));
+        }
+
+        @Test
+        void 상품_가격이_서로_같으면_ID_기준_내림차순으로_정렬할_수_있다() {
+            // given
+            final Long categoryId = 카테고리_추가_요청(간편식사);
+            final Product product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 간편식사);
+            final Product product2 = new Product("삼각김밥2", 1000L, "image.png", "맛있는 삼각김밥2", 간편식사);
+            final Product product3 = new Product("삼각김밥3", 1000L, "image.png", "맛있는 삼각김밥3", 간편식사);
+            final Product product4 = new Product("삼각김밥4", 1000L, "image.png", "맛있는 삼각김밥4", 간편식사);
+            final Product product5 = new Product("삼각김밥5", 1000L, "image.png", "맛있는 삼각김밥5", 간편식사);
+            final Product product6 = new Product("삼각김밥6", 1000L, "image.png", "맛있는 삼각김밥6", 간편식사);
+            final Product product7 = new Product("삼각김밥7", 1000L, "image.png", "맛있는 삼각김밥7", 간편식사);
+            final Product product8 = new Product("삼각김밥8", 1000L, "image.png", "맛있는 삼각김밥8", 간편식사);
+            final Product product9 = new Product("삼각김밥9", 1000L, "image.png", "맛있는 삼각김밥9", 간편식사);
+            final Product product10 = new Product("삼각김밥10", 1000L, "image.png", "맛있는 삼각김밥10", 간편식사);
+            final Product product11 = new Product("삼각김밥11", 1000L, "image.png", "맛있는 삼각김밥11", 간편식사);
+            final List<Product> products = List.of(product1, product2, product3, product4, product5, product6, product7,
+                    product8, product9, product10, product11);
+            복수_상품_추가_요청(products);
+
+            // when
+            final var response = 카테고리별_상품_목록_조회_요청(categoryId, "price", "asc", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            페이지를_검증한다(response, (long) products.size(), 0L);
+            카테고리별_상품_목록_조회_결과를_검증한다(response,
+                    List.of(product11, product10, product9, product8, product7, product6, product5, product4, product3,
+                            product2));
+        }
     }
 
-    @Test
-    void 카테고리별_상품_목록을_가격높은순으로_조회한다() {
-        // given
-        final Long categoryId = 카테고리_추가_요청(간편식사);
-        final Product product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 간편식사);
-        final Product product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 간편식사);
-        final Product product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 간편식사);
-        final Product product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", 간편식사);
-        final Product product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", 간편식사);
-        final Product product6 = new Product("삼각김밥6", 1700L, "image.png", "맛있는 삼각김밥6", 간편식사);
-        final Product product7 = new Product("삼각김밥7", 1800L, "image.png", "맛있는 삼각김밥7", 간편식사);
-        final Product product8 = new Product("삼각김밥8", 800L, "image.png", "맛있는 삼각김밥8", 간편식사);
-        final Product product9 = new Product("삼각김밥9", 3100L, "image.png", "맛있는 삼각김밥9", 간편식사);
-        final Product product10 = new Product("삼각김밥10", 2700L, "image.png", "맛있는 삼각김밥10", 간편식사);
-        final Product product11 = new Product("삼각김밥11", 300L, "image.png", "맛있는 삼각김밥11", 간편식사);
-        final List<Product> products = List.of(product1, product2, product3, product4, product5, product6, product7,
-                product8, product9, product10, product11);
-        복수_상품_추가_요청(products);
+    @Nested
+    class 가격_기준_오름차순으로_카테고리별_상품_목록_조회 {
 
-        // when
-        final var response = 카테고리별_상품_목록_조회_요청(categoryId, "price", "desc", 0);
+        @Test
+        void 상품_가격이_서로_다르면_가격_기준_오름차순으로_정렬할_수_있다() {
+            // given
+            final Long categoryId = 카테고리_추가_요청(간편식사);
+            final Product product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 간편식사);
+            final Product product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 간편식사);
+            final Product product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 간편식사);
+            final Product product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", 간편식사);
+            final Product product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", 간편식사);
+            final Product product6 = new Product("삼각김밥6", 1700L, "image.png", "맛있는 삼각김밥6", 간편식사);
+            final Product product7 = new Product("삼각김밥7", 1800L, "image.png", "맛있는 삼각김밥7", 간편식사);
+            final Product product8 = new Product("삼각김밥8", 800L, "image.png", "맛있는 삼각김밥8", 간편식사);
+            final Product product9 = new Product("삼각김밥9", 3100L, "image.png", "맛있는 삼각김밥9", 간편식사);
+            final Product product10 = new Product("삼각김밥10", 2700L, "image.png", "맛있는 삼각김밥10", 간편식사);
+            final Product product11 = new Product("삼각김밥11", 300L, "image.png", "맛있는 삼각김밥11", 간편식사);
+            final List<Product> products = List.of(product1, product2, product3, product4, product5, product6, product7,
+                    product8, product9, product10, product11);
+            복수_상품_추가_요청(products);
 
-        // then
-        STATUS_CODE를_검증한다(response, 정상_처리);
-        페이지를_검증한다(response, (long) products.size(), 0L);
-        카테고리별_상품_목록_조회_결과를_검증한다(response,
-                List.of(product9, product10, product5, product2, product7, product6, product3, product4, product1,
-                        product8));
+            // when
+            final var response = 카테고리별_상품_목록_조회_요청(categoryId, "price", "desc", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            페이지를_검증한다(response, (long) products.size(), 0L);
+            카테고리별_상품_목록_조회_결과를_검증한다(response,
+                    List.of(product9, product10, product5, product2, product7, product6, product3, product4, product1,
+                            product8));
+        }
+
+        @Test
+        void 상품_가격이_서로_같으면_ID_기준_내림차순으로_정렬할_수_있다() {
+            // given
+            final Long categoryId = 카테고리_추가_요청(간편식사);
+            final Product product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 간편식사);
+            final Product product2 = new Product("삼각김밥2", 1000L, "image.png", "맛있는 삼각김밥2", 간편식사);
+            final Product product3 = new Product("삼각김밥3", 1000L, "image.png", "맛있는 삼각김밥3", 간편식사);
+            final Product product4 = new Product("삼각김밥4", 1000L, "image.png", "맛있는 삼각김밥4", 간편식사);
+            final Product product5 = new Product("삼각김밥5", 1000L, "image.png", "맛있는 삼각김밥5", 간편식사);
+            final Product product6 = new Product("삼각김밥6", 1000L, "image.png", "맛있는 삼각김밥6", 간편식사);
+            final Product product7 = new Product("삼각김밥7", 1000L, "image.png", "맛있는 삼각김밥7", 간편식사);
+            final Product product8 = new Product("삼각김밥8", 1000L, "image.png", "맛있는 삼각김밥8", 간편식사);
+            final Product product9 = new Product("삼각김밥9", 1000L, "image.png", "맛있는 삼각김밥9", 간편식사);
+            final Product product10 = new Product("삼각김밥10", 1000L, "image.png", "맛있는 삼각김밥10", 간편식사);
+            final Product product11 = new Product("삼각김밥11", 1000L, "image.png", "맛있는 삼각김밥11", 간편식사);
+            final List<Product> products = List.of(product1, product2, product3, product4, product5, product6, product7,
+                    product8, product9, product10, product11);
+            복수_상품_추가_요청(products);
+
+            // when
+            final var response = 카테고리별_상품_목록_조회_요청(categoryId, "price", "desc", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            페이지를_검증한다(response, (long) products.size(), 0L);
+            카테고리별_상품_목록_조회_결과를_검증한다(response,
+                    List.of(product11, product10, product9, product8, product7, product6, product5, product4, product3,
+                            product2));
+        }
     }
 
     @Test

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductSteps.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductSteps.java
@@ -22,12 +22,10 @@ public class ProductSteps {
 
     public static ExtractableResponse<Response> 공통_상품_카테고리_목록_조회_요청() {
         return given()
-                .log().all()
                 .queryParam("type", "food")
                 .when()
                 .get("/api/categories")
                 .then()
-                .log().all()
                 .extract();
     }
 
@@ -35,23 +33,19 @@ public class ProductSteps {
                                                                   final String sortOrderType,
                                                                   final int page) {
         return given()
-                .log().all()
-                .queryParam("sort", sortType+","+sortOrderType)
+                .queryParam("sort", sortType + "," + sortOrderType)
                 .queryParam("page", page)
                 .when()
                 .get("/api/categories/{category_id}/products", categoryId)
                 .then()
-                .log().all()
                 .extract();
     }
 
     public static ExtractableResponse<Response> 상품_상세_조회_요청(final Long productId) {
         return given()
-                .log().all()
                 .when()
                 .get("/api/products/{product_id}", productId)
                 .then()
-                .log().all()
                 .extract();
     }
 }

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -28,6 +28,7 @@ import io.restassured.response.Response;
 import io.restassured.specification.MultiPartSpecification;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -122,100 +123,214 @@ class ReviewAcceptanceTest extends AcceptanceTest {
         return testMember.getId();
     }
 
-    @Test
-    void 좋아요_기준_내림차순으로_리뷰_목록을_조회할_수_있다() {
-        // given
-        final var category = new Category("간편식사", CategoryType.FOOD);
-        카테고리_추가_요청(category);
+    @Nested
+    class 좋아요_기준_내림차순으로_리뷰_목록_조회 {
 
-        final var member1 = new Member("test1", "test1.png");
-        final var member2 = new Member("test2", "test2.png");
-        final var member3 = new Member("test3", "test3.png");
-        final var members = List.of(member1, member2, member3);
-        복수_유저_추가_요청(members);
+        @Test
+        void 좋아요_수가_서로_다르면_좋아요_기준_내림차순으로_정렬할_수_있다() {
+            // given
+            final var category = new Category("간편식사", CategoryType.FOOD);
+            카테고리_추가_요청(category);
 
-        final var product = new Product("삼각김밥1", 1000L, "image.png", "김밥", category);
-        final var productId = 상품_추가_요청(product);
+            final var member1 = new Member("test1", "test1.png");
+            final var member2 = new Member("test2", "test2.png");
+            final var member3 = new Member("test3", "test3.png");
+            final var members = List.of(member1, member2, member3);
+            복수_유저_추가_요청(members);
 
-        final var review1 = new Review(member1, product, "review1.jpg", 3L, "이 김밥은 재밌습니다", true, 5L);
-        final var review2 = new Review(member2, product, "review2.jpg", 4L, "역삼역", true, 351L);
-        final var review3 = new Review(member3, product, "review3.jpg", 3L, "ㅇㅇ", false, 130L);
-        final var reviews = List.of(review1, review2, review3);
-        복수_리뷰_추가(reviews);
+            final var product = new Product("삼각김밥1", 1000L, "image.png", "김밥", category);
+            final var productId = 상품_추가_요청(product);
 
-        final var sortingReviews = List.of(review2, review3, review1);
-        final var pageDto = new SortingReviewsPageDto(3L, 1L, true, true, 0L, 10L);
+            final var review1 = new Review(member1, product, "review1.jpg", 3L, "이 김밥은 재밌습니다", true, 5L);
+            final var review2 = new Review(member2, product, "review2.jpg", 4L, "역삼역", true, 351L);
+            final var review3 = new Review(member3, product, "review3.jpg", 3L, "ㅇㅇ", false, 130L);
+            final var reviews = List.of(review1, review2, review3);
+            복수_리뷰_추가(reviews);
 
-        // when
-        final var response = 정렬된_리뷰_목록_조회_요청(productId, "favoriteCount,desc", 0);
+            final var sortingReviews = List.of(review2, review3, review1);
+            final var pageDto = new SortingReviewsPageDto(3L, 1L, true, true, 0L, 10L);
 
-        // then
-        STATUS_CODE를_검증한다(response, 정상_처리);
-        정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, pageDto);
+            // when
+            final var response = 정렬된_리뷰_목록_조회_요청(productId, "favoriteCount,desc", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, pageDto);
+        }
+
+        @Test
+        void 좋아요_수가_서로_같으면_ID_기준_내림차순으로_정렬할_수_있다() {
+            // given
+            final var category = new Category("간편식사", CategoryType.FOOD);
+            카테고리_추가_요청(category);
+
+            final var member1 = new Member("test1", "test1.png");
+            final var member2 = new Member("test2", "test2.png");
+            final var member3 = new Member("test3", "test3.png");
+            final var member4 = new Member("test4", "test4.png");
+            final var members = List.of(member1, member2, member3, member4);
+            복수_유저_추가_요청(members);
+
+            final var product = new Product("삼각김밥1", 1000L, "image.png", "김밥", category);
+            final var productId = 상품_추가_요청(product);
+
+            final var review1 = new Review(member1, product, "review1.jpg", 3L, "이 김밥은 재밌습니다", true, 130L);
+            final var review2 = new Review(member2, product, "review2.jpg", 4L, "역삼역", true, 130L);
+            final var review3 = new Review(member3, product, "review3.jpg", 3L, "토미토", false, 130L);
+            final var review4 = new Review(member4, product, "review4.jpg", 4L, "기러기", false, 130L);
+            final var reviews = List.of(review1, review2, review3, review4);
+            복수_리뷰_추가(reviews);
+
+            final var sortingReviews = List.of(review4, review3, review2, review1);
+            final var pageDto = new SortingReviewsPageDto(4L, 1L, true, true, 0L, 10L);
+
+            // when
+            final var response = 정렬된_리뷰_목록_조회_요청(productId, "favoriteCount,desc", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, pageDto);
+        }
     }
 
-    @Test
-    void 평점_기준_오름차순으로_리뷰_목록을_조회할_수_있다() {
-        // given
-        final var category = new Category("간편식사", CategoryType.FOOD);
-        카테고리_추가_요청(category);
+    @Nested
+    class 평점_기준_오름차순으로_리뷰_목록을_조회 {
 
-        final var member1 = new Member("test1", "test1.png");
-        final var member2 = new Member("test2", "test2.png");
-        final var member3 = new Member("test3", "test3.png");
-        final var members = List.of(member1, member2, member3);
-        복수_유저_추가_요청(members);
+        @Test
+        void 평점이_서로_다르면_평점_기준_오름차순으로_정렬할_수_있다() {
+            // given
+            final var category = new Category("간편식사", CategoryType.FOOD);
+            카테고리_추가_요청(category);
 
-        final var product = new Product("삼각김밥1", 1000L, "image.png", "김밥", category);
-        final var productId = 상품_추가_요청(product);
+            final var member1 = new Member("test1", "test1.png");
+            final var member2 = new Member("test2", "test2.png");
+            final var member3 = new Member("test3", "test3.png");
+            final var members = List.of(member1, member2, member3);
+            복수_유저_추가_요청(members);
 
-        final var review1 = new Review(member1, product, "review1.jpg", 3L, "이 김밥은 재밌습니다", true, 5L);
-        final var review2 = new Review(member2, product, "review2.jpg", 4L, "역삼역", true, 351L);
-        final var review3 = new Review(member3, product, "review3.jpg", 3L, "ㅇㅇ", false, 130L);
-        final var reviews = List.of(review1, review2, review3);
-        복수_리뷰_추가(reviews);
+            final var product = new Product("삼각김밥1", 1000L, "image.png", "김밥", category);
+            final var productId = 상품_추가_요청(product);
 
-        final var sortingReviews = List.of(review1, review3, review2);
+            final var review1 = new Review(member1, product, "review1.jpg", 2L, "이 김밥은 재밌습니다", true, 5L);
+            final var review2 = new Review(member2, product, "review2.jpg", 4L, "역삼역", true, 351L);
+            final var review3 = new Review(member3, product, "review3.jpg", 3L, "ㅇㅇ", false, 130L);
+            final var reviews = List.of(review1, review2, review3);
+            복수_리뷰_추가(reviews);
 
-        // when
-        final var response = 정렬된_리뷰_목록_조회_요청(productId, "rating,asc", 0);
-        final var page = new SortingReviewsPageDto(3L, 1L, true, true, 0L, 10L);
+            final var sortingReviews = List.of(review1, review3, review2);
 
-        // then
-        STATUS_CODE를_검증한다(response, 정상_처리);
-        정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
+            // when
+            final var response = 정렬된_리뷰_목록_조회_요청(productId, "rating,asc", 0);
+            final var page = new SortingReviewsPageDto(3L, 1L, true, true, 0L, 10L);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
+        }
+
+        @Test
+        void 평점이_서로_같으면_ID_기준_내림차순으로_정렬할_수_있다() {
+            // given
+            final var category = new Category("간편식사", CategoryType.FOOD);
+            카테고리_추가_요청(category);
+
+            final var member1 = new Member("test1", "test1.png");
+            final var member2 = new Member("test2", "test2.png");
+            final var member3 = new Member("test3", "test3.png");
+            final var member4 = new Member("test4", "test4.png");
+            final var members = List.of(member1, member2, member3, member4);
+            복수_유저_추가_요청(members);
+
+            final var product = new Product("삼각김밥1", 1000L, "image.png", "김밥", category);
+            final var productId = 상품_추가_요청(product);
+
+            final var review1 = new Review(member1, product, "review1.jpg", 3L, "이 김밥은 재밌습니다", true, 5L);
+            final var review2 = new Review(member2, product, "review2.jpg", 3L, "역삼역", true, 351L);
+            final var review3 = new Review(member3, product, "review3.jpg", 3L, "토마토", false, 130L);
+            final var review4 = new Review(member4, product, "review4.jpg", 3L, "기러기", false, 130L);
+            final var reviews = List.of(review1, review2, review3, review4);
+            복수_리뷰_추가(reviews);
+
+            final var sortingReviews = List.of(review4, review3, review2, review1);
+            final var page = new SortingReviewsPageDto(4L, 1L, true, true, 0L, 10L);
+
+            // when
+            final var response = 정렬된_리뷰_목록_조회_요청(productId, "rating,asc", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
+        }
     }
 
-    @Test
-    void 평점_기준_내림차순으로_리뷰_목록을_조회할_수_있다() {
-        // given
-        final var category = new Category("간편식사", CategoryType.FOOD);
-        카테고리_추가_요청(category);
+    @Nested
+    class 평점_기준_내림차순으로_리뷰_목록_조회 {
 
-        final var member1 = new Member("test1", "test1.png");
-        final var member2 = new Member("test2", "test2.png");
-        final var member3 = new Member("test3", "test3.png");
-        final var members = List.of(member1, member2, member3);
-        복수_유저_추가_요청(members);
+        @Test
+        void 평점이_서로_다르면_평점_기준_내림차순으로_정렬할_수_있다() {
+            // given
+            final var category = new Category("간편식사", CategoryType.FOOD);
+            카테고리_추가_요청(category);
 
-        final var product = new Product("삼각김밥1", 1000L, "image.png", "김밥", category);
-        final var productId = 상품_추가_요청(product);
+            final var member1 = new Member("test1", "test1.png");
+            final var member2 = new Member("test2", "test2.png");
+            final var member3 = new Member("test3", "test3.png");
+            final var members = List.of(member1, member2, member3);
+            복수_유저_추가_요청(members);
 
-        final var review1 = new Review(member1, product, "review1.jpg", 2L, "이 김밥은 재밌습니다", true, 5L);
-        final var review2 = new Review(member2, product, "review2.jpg", 4L, "역삼역", true, 351L);
-        final var review3 = new Review(member3, product, "review3.jpg", 3L, "ㅇㅇ", false, 130L);
-        final var reviews = List.of(review1, review2, review3);
-        복수_리뷰_추가(reviews);
+            final var product = new Product("삼각김밥1", 1000L, "image.png", "김밥", category);
+            final var productId = 상품_추가_요청(product);
 
-        final var sortingReviews = List.of(review2, review3, review1);
-        final var page = new SortingReviewsPageDto(3L, 1L, true, true, 0L, 10L);
+            final var review1 = new Review(member1, product, "review1.jpg", 2L, "이 김밥은 재밌습니다", true, 5L);
+            final var review2 = new Review(member2, product, "review2.jpg", 4L, "역삼역", true, 351L);
+            final var review3 = new Review(member3, product, "review3.jpg", 3L, "ㅇㅇ", false, 130L);
+            final var reviews = List.of(review1, review2, review3);
+            복수_리뷰_추가(reviews);
 
-        // when
-        final var response = 정렬된_리뷰_목록_조회_요청(productId, "rating,desc", 0);
+            final var sortingReviews = List.of(review2, review3, review1);
+            final var page = new SortingReviewsPageDto(3L, 1L, true, true, 0L, 10L);
 
-        // then
-        STATUS_CODE를_검증한다(response, 정상_처리);
-        정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
+            // when
+            final var response = 정렬된_리뷰_목록_조회_요청(productId, "rating,desc", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
+        }
+
+        @Test
+        void 평점이_서로_같으면_ID_기준_내림차순으로_정렬할_수_있다() {
+            // given
+            final var category = new Category("간편식사", CategoryType.FOOD);
+            카테고리_추가_요청(category);
+
+            final var member1 = new Member("test1", "test1.png");
+            final var member2 = new Member("test2", "test2.png");
+            final var member3 = new Member("test3", "test3.png");
+            final var member4 = new Member("test4", "test4.png");
+            final var members = List.of(member1, member2, member3, member4);
+            복수_유저_추가_요청(members);
+
+            final var product = new Product("삼각김밥1", 1000L, "image.png", "김밥", category);
+            final var productId = 상품_추가_요청(product);
+
+            final var review1 = new Review(member1, product, "review1.jpg", 3L, "이 김밥은 재밌습니다", true, 5L);
+            final var review2 = new Review(member2, product, "review2.jpg", 3L, "역삼역", true, 351L);
+            final var review3 = new Review(member3, product, "review3.jpg", 3L, "토마토", false, 130L);
+            final var review4 = new Review(member4, product, "review4.jpg", 3L, "기러기", false, 130L);
+            final var reviews = List.of(review1, review2, review3, review4);
+            복수_리뷰_추가(reviews);
+
+            final var sortingReviews = List.of(review4, review3, review2, review1);
+            final var page = new SortingReviewsPageDto(4L, 1L, true, true, 0L, 10L);
+
+            // when
+            final var response = 정렬된_리뷰_목록_조회_요청(productId, "rating,desc", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Issue

- close #116 

## ✨ 구현한 기능

- PageableHandlerMethodArgumentResolver를 사용하여 모든 페이징 요청시 자동으로 ID 기준 내림차순으로 정렬할 수 있도록 추가
  - HandlerMethodArgumentResolver란?
    - 컨트롤러에 특정 어노테이션, 클래스 같은게 들어오면 컨트롤러 로직이 실행되기 전에 특정 로직을 처리할 수 있는 인터페이스
    (ex. 로그인)
- 인수 테스트 실행시 RestAssured given, then을 콘솔에 로그를 찍어주는 것을 삭제

## 📢 논의하고 싶은 내용

x

## 🎸 기타

- 앞으로 페이징 요청이 들어올 경우, 후순위에 대한 테스트까지 만들어야 합니다.

## ⏰ 일정

- 추정 시간 : 0.5
- 걸린 시간 : 1
