### PR TITLE
[BE] feat : 카테고리별 상품 목록 조회시 정렬 조건 추가 (평점순 / 리뷰개수순)

### DIFF
--- a/backend/src/main/java/com/funeat/product/application/ProductService.java
+++ b/backend/src/main/java/com/funeat/product/application/ProductService.java
@@ -25,6 +25,7 @@ public class ProductService {
     private static final int THREE = 3;
     private static final int TOP = 0;
     public static final String REVIEW_COUNT = "reviewCount";
+
     private final CategoryRepository categoryRepository;
     private final ProductRepository productRepository;
     private final ReviewRepository reviewRepository;
@@ -53,7 +54,7 @@ public class ProductService {
 
     private Page<ProductInCategoryDto> getAllProductsInCategory(final Pageable pageable, final Category category) {
         if (pageable.getSort().getOrderFor(REVIEW_COUNT) != null) {
-            PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+            final PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
             return productRepository.findAllByCategoryOrderByReviewCountDesc(category, pageRequest);
         }
         return productRepository.findAllByCategory(category, pageable);

--- a/backend/src/main/java/com/funeat/product/application/ProductService.java
+++ b/backend/src/main/java/com/funeat/product/application/ProductService.java
@@ -24,6 +24,7 @@ public class ProductService {
 
     private static final int THREE = 3;
     private static final int TOP = 0;
+    public static final String REVIEW_COUNT = "reviewCount";
     private final CategoryRepository categoryRepository;
     private final ProductRepository productRepository;
     private final ReviewRepository reviewRepository;
@@ -42,18 +43,20 @@ public class ProductService {
         final Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(IllegalArgumentException::new);
 
-        final Page<ProductInCategoryDto> pages;
-        if (pageable.getSort().getOrderFor("reviewCount") == null) {
-            pages = productRepository.findAllByCategory(category, pageable);
-        } else {
-            PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-            pages = productRepository.findAllByCategoryOrderByReviewCountDesc(category, pageRequest);
-        }
+        final Page<ProductInCategoryDto> pages = getAllProductsInCategory(pageable, category);
 
         final ProductsInCategoryPageDto pageDto = ProductsInCategoryPageDto.toDto(pages);
         final List<ProductInCategoryDto> productDtos = pages.getContent();
 
         return ProductsInCategoryResponse.toResponse(pageDto, productDtos);
+    }
+
+    private Page<ProductInCategoryDto> getAllProductsInCategory(final Pageable pageable, final Category category) {
+        if (pageable.getSort().getOrderFor(REVIEW_COUNT) != null) {
+            PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+            return productRepository.findAllByCategoryOrderByReviewCountDesc(category, pageRequest);
+        }
+        return productRepository.findAllByCategory(category, pageable);
     }
 
     public ProductResponse findProductDetail(final Long productId) {

--- a/backend/src/main/java/com/funeat/product/application/ProductService.java
+++ b/backend/src/main/java/com/funeat/product/application/ProductService.java
@@ -44,11 +44,10 @@ public class ProductService {
                 .orElseThrow(IllegalArgumentException::new);
 
         final Page<Product> productPages = productRepository.findAllByCategory(category, pageable);
-
         final ProductsInCategoryPageDto pageDto = ProductsInCategoryPageDto.toDto(productPages);
         final List<ProductInCategoryDto> productDtos = productPages.getContent()
                 .stream()
-                .map(it -> ProductInCategoryDto.toDto(it, reviewRepository.countByProduct(it)))
+                .map(ProductInCategoryDto::toDto)
                 .collect(Collectors.toList());
 
         return ProductsInCategoryResponse.toResponse(pageDto, productDtos);

--- a/backend/src/main/java/com/funeat/product/domain/Product.java
+++ b/backend/src/main/java/com/funeat/product/domain/Product.java
@@ -54,8 +54,7 @@ public class Product {
     }
 
     public Product(final String name, final Long price, final String image, final String content,
-                   final Double averageRating,
-                   final Category category) {
+                   final Double averageRating, final Category category) {
         this.name = name;
         this.price = price;
         this.image = image;
@@ -65,7 +64,7 @@ public class Product {
     }
 
     public void updateAverageRating(final Long rating, final Long count) {
-        double calculatedRating = ((count - 1) * averageRating + rating) / count;
+        final double calculatedRating = ((count - 1) * averageRating + rating) / count;
         this.averageRating = Math.round(calculatedRating * 10.0) / 10.0;
     }
 

--- a/backend/src/main/java/com/funeat/product/domain/Product.java
+++ b/backend/src/main/java/com/funeat/product/domain/Product.java
@@ -9,6 +9,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import org.hibernate.annotations.Formula;
 
 @Entity
 public class Product {
@@ -26,6 +27,9 @@ public class Product {
     private String content;
 
     private Double averageRating = 0.0;
+
+    @Formula("SELECT count(1) FROM review r WHERE r.product_id = id")
+    private Long reviewCount;
 
     @ManyToOne
     @JoinColumn(name = "category_id")
@@ -92,5 +96,9 @@ public class Product {
 
     public Category getCategory() {
         return category;
+    }
+
+    public Long getReviewCount() {
+        return reviewCount;
     }
 }

--- a/backend/src/main/java/com/funeat/product/domain/Product.java
+++ b/backend/src/main/java/com/funeat/product/domain/Product.java
@@ -1,6 +1,7 @@
 package com.funeat.product.domain;
 
 import com.funeat.member.domain.bookmark.ProductBookmark;
+import com.funeat.review.domain.Review;
 import java.util.List;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -9,7 +10,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
-import org.hibernate.annotations.Formula;
 
 @Entity
 public class Product {
@@ -28,19 +28,18 @@ public class Product {
 
     private Double averageRating = 0.0;
 
-    @Formula("SELECT count(1) FROM review r WHERE r.product_id = id")
-    private Long reviewCount;
-
     @ManyToOne
     @JoinColumn(name = "category_id")
     private Category category;
+
+    @OneToMany(mappedBy = "product")
+    private List<Review> reviews;
 
     @OneToMany(mappedBy = "product")
     private List<ProductRecipe> productRecipes;
 
     @OneToMany(mappedBy = "product")
     private List<ProductBookmark> productBookmarks;
-
 
     protected Product() {
     }
@@ -96,9 +95,5 @@ public class Product {
 
     public Category getCategory() {
         return category;
-    }
-
-    public Long getReviewCount() {
-        return reviewCount;
     }
 }

--- a/backend/src/main/java/com/funeat/product/domain/Product.java
+++ b/backend/src/main/java/com/funeat/product/domain/Product.java
@@ -37,6 +37,7 @@ public class Product {
     @OneToMany(mappedBy = "product")
     private List<ProductBookmark> productBookmarks;
 
+
     protected Product() {
     }
 
@@ -46,6 +47,17 @@ public class Product {
         this.price = price;
         this.image = image;
         this.content = content;
+        this.category = category;
+    }
+
+    public Product(final String name, final Long price, final String image, final String content,
+                   final Double averageRating,
+                   final Category category) {
+        this.name = name;
+        this.price = price;
+        this.image = image;
+        this.content = content;
+        this.averageRating = averageRating;
         this.category = category;
     }
 

--- a/backend/src/main/java/com/funeat/product/dto/ProductInCategoryDto.java
+++ b/backend/src/main/java/com/funeat/product/dto/ProductInCategoryDto.java
@@ -49,16 +49,4 @@ public class ProductInCategoryDto {
     public Long getReviewCount() {
         return reviewCount;
     }
-
-    @Override
-    public String toString() {
-        return "ProductInCategoryDto{" +
-                "id=" + id +
-                ", name='" + name + '\'' +
-                ", price=" + price +
-                ", image='" + image + '\'' +
-                ", averageRating=" + averageRating +
-                ", reviewCount=" + reviewCount +
-                '}';
-    }
 }

--- a/backend/src/main/java/com/funeat/product/dto/ProductInCategoryDto.java
+++ b/backend/src/main/java/com/funeat/product/dto/ProductInCategoryDto.java
@@ -21,9 +21,9 @@ public class ProductInCategoryDto {
         this.reviewCount = reviewCount;
     }
 
-    public static ProductInCategoryDto toDto(final Product product, final Long reviewCount) {
+    public static ProductInCategoryDto toDto(final Product product) {
         return new ProductInCategoryDto(product.getId(), product.getName(), product.getPrice(), product.getImage(),
-                product.getAverageRating(), reviewCount);
+                product.getAverageRating(), product.getReviewCount());
     }
 
     public Long getId() {
@@ -49,5 +49,4 @@ public class ProductInCategoryDto {
     public Long getReviewCount() {
         return reviewCount;
     }
-
 }

--- a/backend/src/main/java/com/funeat/product/dto/ProductInCategoryDto.java
+++ b/backend/src/main/java/com/funeat/product/dto/ProductInCategoryDto.java
@@ -21,9 +21,9 @@ public class ProductInCategoryDto {
         this.reviewCount = reviewCount;
     }
 
-    public static ProductInCategoryDto toDto(final Product product) {
+    public static ProductInCategoryDto toDto(final Product product, final Long reviewCount) {
         return new ProductInCategoryDto(product.getId(), product.getName(), product.getPrice(), product.getImage(),
-                product.getAverageRating(), product.getReviewCount());
+                product.getAverageRating(), reviewCount);
     }
 
     public Long getId() {
@@ -48,5 +48,17 @@ public class ProductInCategoryDto {
 
     public Long getReviewCount() {
         return reviewCount;
+    }
+
+    @Override
+    public String toString() {
+        return "ProductInCategoryDto{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", price=" + price +
+                ", image='" + image + '\'' +
+                ", averageRating=" + averageRating +
+                ", reviewCount=" + reviewCount +
+                '}';
     }
 }

--- a/backend/src/main/java/com/funeat/product/dto/ProductsInCategoryPageDto.java
+++ b/backend/src/main/java/com/funeat/product/dto/ProductsInCategoryPageDto.java
@@ -21,7 +21,7 @@ public class ProductsInCategoryPageDto {
         this.requestSize = requestSize;
     }
 
-    public static ProductsInCategoryPageDto toDto(final Page<Product> page) {
+    public static ProductsInCategoryPageDto toDto(final Page<ProductInCategoryDto> page) {
         return new ProductsInCategoryPageDto(
                 page.getTotalElements(),
                 Long.valueOf(page.getTotalPages()),

--- a/backend/src/main/java/com/funeat/product/persistence/ProductRepository.java
+++ b/backend/src/main/java/com/funeat/product/persistence/ProductRepository.java
@@ -10,18 +10,20 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
-    @Query("SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, COUNT(r)) " +
+    @Query(value = "SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, COUNT(r)) " +
             "FROM Product p " +
             "LEFT JOIN p.reviews r " +
             "WHERE p.category = :category " +
-            "GROUP BY p ")
+            "GROUP BY p ",
+            countQuery = "SELECT COUNT(p) FROM Product p WHERE p.category = :category")
     Page<ProductInCategoryDto> findAllByCategory(final @Param("category") Category category, final Pageable pageable);
 
-    @Query("SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, COUNT(r)) " +
+    @Query(value = "SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, COUNT(r)) " +
             "FROM Product p " +
             "LEFT JOIN p.reviews r " +
             "WHERE p.category = :category " +
             "GROUP BY p " +
-            "ORDER BY COUNT(r) DESC, p.id DESC ")
+            "ORDER BY COUNT(r) DESC, p.id DESC ",
+            countQuery = "SELECT COUNT(p) FROM Product p WHERE p.category = :category")
     Page<ProductInCategoryDto> findAllByCategoryOrderByReviewCountDesc(final @Param("category") Category category, final Pageable pageable);
 }

--- a/backend/src/main/java/com/funeat/product/persistence/ProductRepository.java
+++ b/backend/src/main/java/com/funeat/product/persistence/ProductRepository.java
@@ -22,6 +22,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             "LEFT JOIN p.reviews r " +
             "WHERE p.category = :category " +
             "GROUP BY p " +
-            "ORDER BY COUNT(r) DESC, p.id ASC ")
+            "ORDER BY COUNT(r) DESC, p.id DESC ")
     Page<ProductInCategoryDto> findAllByCategoryOrderByReviewCountDesc(final @Param("category") Category category, final Pageable pageable);
 }

--- a/backend/src/main/java/com/funeat/product/persistence/ProductRepository.java
+++ b/backend/src/main/java/com/funeat/product/persistence/ProductRepository.java
@@ -16,7 +16,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             "WHERE p.category = :category " +
             "GROUP BY p ",
             countQuery = "SELECT COUNT(p) FROM Product p WHERE p.category = :category")
-    Page<ProductInCategoryDto> findAllByCategory(final @Param("category") Category category, final Pageable pageable);
+    Page<ProductInCategoryDto> findAllByCategory(@Param("category") final Category category, final Pageable pageable);
 
     @Query(value = "SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, COUNT(r)) " +
             "FROM Product p " +
@@ -25,5 +25,5 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             "GROUP BY p " +
             "ORDER BY COUNT(r) DESC, p.id DESC ",
             countQuery = "SELECT COUNT(p) FROM Product p WHERE p.category = :category")
-    Page<ProductInCategoryDto> findAllByCategoryOrderByReviewCountDesc(final @Param("category") Category category, final Pageable pageable);
+    Page<ProductInCategoryDto> findAllByCategoryOrderByReviewCountDesc(@Param("category") final Category category, final Pageable pageable);
 }

--- a/backend/src/main/java/com/funeat/product/persistence/ProductRepository.java
+++ b/backend/src/main/java/com/funeat/product/persistence/ProductRepository.java
@@ -2,11 +2,26 @@ package com.funeat.product.persistence;
 
 import com.funeat.product.domain.Category;
 import com.funeat.product.domain.Product;
+import com.funeat.product.dto.ProductInCategoryDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    @Query("SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, COUNT(r)) " +
+            "FROM Product p " +
+            "LEFT JOIN p.reviews r " +
+            "WHERE p.category = :category " +
+            "GROUP BY p ")
+    Page<ProductInCategoryDto> findAllByCategory(final @Param("category") Category category, final Pageable pageable);
 
-    Page<Product> findAllByCategory(final Category category, final Pageable pageable);
+    @Query("SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, COUNT(r)) " +
+            "FROM Product p " +
+            "LEFT JOIN p.reviews r " +
+            "WHERE p.category = :category " +
+            "GROUP BY p " +
+            "ORDER BY COUNT(r) DESC, p.id ASC ")
+    Page<ProductInCategoryDto> findAllByCategoryOrderByReviewCountDesc(final @Param("category") Category category, final Pageable pageable);
 }

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
@@ -166,6 +166,66 @@ class ProductAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    void 카테고리별_상품_목록을_평점높은순으로_조회한다() {
+        // given
+        final Long categoryId = 카테고리_추가_요청(간편식사);
+        final Product product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 5.0, 간편식사);
+        final Product product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 3.0, 간편식사);
+        final Product product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 1.0, 간편식사);
+        final Product product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", 4.0, 간편식사);
+        final Product product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", 4.5, 간편식사);
+        final Product product6 = new Product("삼각김밥6", 1700L, "image.png", "맛있는 삼각김밥6", 2.5, 간편식사);
+        final Product product7 = new Product("삼각김밥7", 1800L, "image.png", "맛있는 삼각김밥7", 2.0, 간편식사);
+        final Product product8 = new Product("삼각김밥8", 800L, "image.png", "맛있는 삼각김밥8", 1.5, 간편식사);
+        final Product product9 = new Product("삼각김밥9", 3100L, "image.png", "맛있는 삼각김밥9", 3.5, 간편식사);
+        final Product product10 = new Product("삼각김밥10", 2700L, "image.png", "맛있는 삼각김밥10", 1.0, 간편식사);
+        final Product product11 = new Product("삼각김밥11", 300L, "image.png", "맛있는 삼각김밥11", 0.5, 간편식사);
+        final List<Product> products = List.of(product1, product2, product3, product4, product5, product6, product7,
+                product8, product9, product10, product11);
+        복수_상품_추가_요청(products);
+
+        // when
+        final var response = 카테고리별_상품_목록_조회_요청(categoryId, "averageRating", "desc", 0);
+
+        // then
+        STATUS_CODE를_검증한다(response, 정상_처리);
+        페이지를_검증한다(response, (long) products.size(), 0L);
+        카테고리별_상품_목록_조회_결과를_검증한다(response,
+                List.of(product1, product5, product4, product9, product2, product6, product7, product8, product3,
+                        product10));
+    }
+
+    @Test
+    void 카테고리별_상품_목록을_평점낮은순으로_조회한다() {
+        // given
+        final Long categoryId = 카테고리_추가_요청(간편식사);
+        final Product product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 5.0, 간편식사);
+        final Product product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 3.0, 간편식사);
+        final Product product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 1.0, 간편식사);
+        final Product product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", 4.0, 간편식사);
+        final Product product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", 4.5, 간편식사);
+        final Product product6 = new Product("삼각김밥6", 1700L, "image.png", "맛있는 삼각김밥6", 2.5, 간편식사);
+        final Product product7 = new Product("삼각김밥7", 1800L, "image.png", "맛있는 삼각김밥7", 2.0, 간편식사);
+        final Product product8 = new Product("삼각김밥8", 800L, "image.png", "맛있는 삼각김밥8", 1.5, 간편식사);
+        final Product product9 = new Product("삼각김밥9", 3100L, "image.png", "맛있는 삼각김밥9", 3.5, 간편식사);
+        final Product product10 = new Product("삼각김밥10", 2700L, "image.png", "맛있는 삼각김밥10", 1.0, 간편식사);
+        final Product product11 = new Product("삼각김밥11", 300L, "image.png", "맛있는 삼각김밥11", 0.5, 간편식사);
+        final List<Product> products = List.of(product1, product2, product3, product4, product5, product6, product7,
+                product8, product9, product10, product11);
+        복수_상품_추가_요청(products);
+
+        // when
+        final var response = 카테고리별_상품_목록_조회_요청(categoryId, "averageRating", "asc", 0);
+
+        // then
+        STATUS_CODE를_검증한다(response, 정상_처리);
+        페이지를_검증한다(response, (long) products.size(), 0L);
+        카테고리별_상품_목록_조회_결과를_검증한다(response,
+                List.of(product11, product10, product3, product8, product7, product6, product2, product9, product4,
+                        product5));
+    }
+
+    @Test
     void 상품_상세_정보를_조회한다() {
         // given
         카테고리_추가_요청(간편식사);

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
@@ -21,6 +21,7 @@ import com.funeat.product.dto.CategoryResponse;
 import com.funeat.product.dto.ProductInCategoryDto;
 import com.funeat.product.dto.ProductResponse;
 import com.funeat.product.dto.ProductsInCategoryPageDto;
+import com.funeat.review.domain.Review;
 import com.funeat.review.presentation.dto.ReviewCreateRequest;
 import com.funeat.tag.domain.Tag;
 import io.restassured.common.mapper.TypeRef;
@@ -165,64 +166,196 @@ class ProductAcceptanceTest extends AcceptanceTest {
         }
     }
 
-    @Test
-    void 카테고리별_상품_목록을_평점높은순으로_조회한다() {
-        // given
-        final Long categoryId = 카테고리_추가_요청(간편식사);
-        final Product product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 5.0, 간편식사);
-        final Product product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 3.0, 간편식사);
-        final Product product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 1.0, 간편식사);
-        final Product product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", 4.0, 간편식사);
-        final Product product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", 4.5, 간편식사);
-        final Product product6 = new Product("삼각김밥6", 1700L, "image.png", "맛있는 삼각김밥6", 2.5, 간편식사);
-        final Product product7 = new Product("삼각김밥7", 1800L, "image.png", "맛있는 삼각김밥7", 2.0, 간편식사);
-        final Product product8 = new Product("삼각김밥8", 800L, "image.png", "맛있는 삼각김밥8", 1.5, 간편식사);
-        final Product product9 = new Product("삼각김밥9", 3100L, "image.png", "맛있는 삼각김밥9", 3.5, 간편식사);
-        final Product product10 = new Product("삼각김밥10", 2700L, "image.png", "맛있는 삼각김밥10", 1.0, 간편식사);
-        final Product product11 = new Product("삼각김밥11", 300L, "image.png", "맛있는 삼각김밥11", 0.5, 간편식사);
-        final List<Product> products = List.of(product1, product2, product3, product4, product5, product6, product7,
-                product8, product9, product10, product11);
-        복수_상품_추가_요청(products);
+    @Nested
+    class 평점_기준_내림차순으로_카테고리별_상품_목록_조회 {
+        @Test
+        void 상품_평점이_서로_다르면_평점_기준_내림차순으로_정렬할_수_있다() {
+            // given
+            final Long categoryId = 카테고리_추가_요청(간편식사);
+            final Product product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 5.0, 간편식사);
+            final Product product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 3.0, 간편식사);
+            final Product product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 1.0, 간편식사);
+            final Product product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", 4.0, 간편식사);
+            final Product product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", 4.5, 간편식사);
+            final Product product6 = new Product("삼각김밥6", 1700L, "image.png", "맛있는 삼각김밥6", 2.5, 간편식사);
+            final Product product7 = new Product("삼각김밥7", 1800L, "image.png", "맛있는 삼각김밥7", 2.0, 간편식사);
+            final Product product8 = new Product("삼각김밥8", 800L, "image.png", "맛있는 삼각김밥8", 1.5, 간편식사);
+            final Product product9 = new Product("삼각김밥9", 3100L, "image.png", "맛있는 삼각김밥9", 3.5, 간편식사);
+            final Product product10 = new Product("삼각김밥10", 2700L, "image.png", "맛있는 삼각김밥10", 0.0, 간편식사);
+            final Product product11 = new Product("삼각김밥11", 300L, "image.png", "맛있는 삼각김밥11", 0.5, 간편식사);
+            final List<Product> products = List.of(product1, product2, product3, product4, product5, product6, product7,
+                    product8, product9, product10, product11);
+            복수_상품_추가_요청(products);
 
-        // when
-        final var response = 카테고리별_상품_목록_조회_요청(categoryId, "averageRating", "desc", 0);
+            // when
+            final var response = 카테고리별_상품_목록_조회_요청(categoryId, "averageRating", "desc", 0);
 
-        // then
-        STATUS_CODE를_검증한다(response, 정상_처리);
-        페이지를_검증한다(response, (long) products.size(), 0L);
-        카테고리별_상품_목록_조회_결과를_검증한다(response,
-                List.of(product1, product5, product4, product9, product2, product6, product7, product8, product3,
-                        product10));
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            페이지를_검증한다(response, (long) products.size(), 0L);
+            카테고리별_상품_목록_조회_결과를_검증한다(response,
+                    List.of(product1, product5, product4, product9, product2, product6, product7, product8, product3,
+                            product11));
+        }
+
+        @Test
+        void 상품_평점이_서로_같으면_ID_기준_내림차순으로_정렬할_수_있다() {
+            // given
+            final Long categoryId = 카테고리_추가_요청(간편식사);
+            final Product product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 5.0, 간편식사);
+            final Product product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 3.0, 간편식사);
+            final Product product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 1.0, 간편식사);
+            final Product product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", 4.0, 간편식사);
+            final Product product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", 4.5, 간편식사);
+            final Product product6 = new Product("삼각김밥6", 1700L, "image.png", "맛있는 삼각김밥6", 2.5, 간편식사);
+            final Product product7 = new Product("삼각김밥7", 1800L, "image.png", "맛있는 삼각김밥7", 2.0, 간편식사);
+            final Product product8 = new Product("삼각김밥8", 800L, "image.png", "맛있는 삼각김밥8", 1.5, 간편식사);
+            final Product product9 = new Product("삼각김밥9", 3100L, "image.png", "맛있는 삼각김밥9", 3.5, 간편식사);
+            final Product product10 = new Product("삼각김밥10", 2700L, "image.png", "맛있는 삼각김밥10", 1.0, 간편식사);
+            final Product product11 = new Product("삼각김밥11", 300L, "image.png", "맛있는 삼각김밥11", 0.5, 간편식사);
+            final List<Product> products = List.of(product1, product2, product3, product4, product5, product6, product7,
+                    product8, product9, product10, product11);
+            복수_상품_추가_요청(products);
+
+            // when
+            final var response = 카테고리별_상품_목록_조회_요청(categoryId, "averageRating", "desc", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            페이지를_검증한다(response, (long) products.size(), 0L);
+            카테고리별_상품_목록_조회_결과를_검증한다(response,
+                    List.of(product1, product5, product4, product9, product2, product6, product7, product8, product10,
+                            product3));
+        }
     }
 
-    @Test
-    void 카테고리별_상품_목록을_평점낮은순으로_조회한다() {
-        // given
-        final Long categoryId = 카테고리_추가_요청(간편식사);
-        final Product product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 5.0, 간편식사);
-        final Product product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 3.0, 간편식사);
-        final Product product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 1.0, 간편식사);
-        final Product product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", 4.0, 간편식사);
-        final Product product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", 4.5, 간편식사);
-        final Product product6 = new Product("삼각김밥6", 1700L, "image.png", "맛있는 삼각김밥6", 2.5, 간편식사);
-        final Product product7 = new Product("삼각김밥7", 1800L, "image.png", "맛있는 삼각김밥7", 2.0, 간편식사);
-        final Product product8 = new Product("삼각김밥8", 800L, "image.png", "맛있는 삼각김밥8", 1.5, 간편식사);
-        final Product product9 = new Product("삼각김밥9", 3100L, "image.png", "맛있는 삼각김밥9", 3.5, 간편식사);
-        final Product product10 = new Product("삼각김밥10", 2700L, "image.png", "맛있는 삼각김밥10", 1.0, 간편식사);
-        final Product product11 = new Product("삼각김밥11", 300L, "image.png", "맛있는 삼각김밥11", 0.5, 간편식사);
-        final List<Product> products = List.of(product1, product2, product3, product4, product5, product6, product7,
-                product8, product9, product10, product11);
-        복수_상품_추가_요청(products);
+    @Nested
+    class 평점_기준_오름차순으로_카테고리별_상품_목록_조회 {
+        @Test
+        void 상품_평점이_서로_다르면_평점_기준_오름차순으로_정렬할_수_있다() {
+            // given
+            final Long categoryId = 카테고리_추가_요청(간편식사);
+            final Product product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 5.0, 간편식사);
+            final Product product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 3.0, 간편식사);
+            final Product product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 1.0, 간편식사);
+            final Product product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", 4.0, 간편식사);
+            final Product product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", 4.5, 간편식사);
+            final Product product6 = new Product("삼각김밥6", 1700L, "image.png", "맛있는 삼각김밥6", 2.5, 간편식사);
+            final Product product7 = new Product("삼각김밥7", 1800L, "image.png", "맛있는 삼각김밥7", 2.0, 간편식사);
+            final Product product8 = new Product("삼각김밥8", 800L, "image.png", "맛있는 삼각김밥8", 1.5, 간편식사);
+            final Product product9 = new Product("삼각김밥9", 3100L, "image.png", "맛있는 삼각김밥9", 3.5, 간편식사);
+            final Product product10 = new Product("삼각김밥10", 2700L, "image.png", "맛있는 삼각김밥10", 0.0, 간편식사);
+            final Product product11 = new Product("삼각김밥11", 300L, "image.png", "맛있는 삼각김밥11", 0.5, 간편식사);
+            final List<Product> products = List.of(product1, product2, product3, product4, product5, product6, product7,
+                    product8, product9, product10, product11);
+            복수_상품_추가_요청(products);
 
-        // when
-        final var response = 카테고리별_상품_목록_조회_요청(categoryId, "averageRating", "asc", 0);
+            // when
+            final var response = 카테고리별_상품_목록_조회_요청(categoryId, "averageRating", "asc", 0);
 
-        // then
-        STATUS_CODE를_검증한다(response, 정상_처리);
-        페이지를_검증한다(response, (long) products.size(), 0L);
-        카테고리별_상품_목록_조회_결과를_검증한다(response,
-                List.of(product11, product10, product3, product8, product7, product6, product2, product9, product4,
-                        product5));
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            페이지를_검증한다(response, (long) products.size(), 0L);
+            카테고리별_상품_목록_조회_결과를_검증한다(response,
+                    List.of(product10, product11, product3, product8, product7, product6, product2, product9, product4,
+                            product5));
+        }
+
+        @Test
+        void 상품_평점이_서로_같으면_ID_기준_내림차순으로_정렬할_수_있다() {
+            // given
+            final Long categoryId = 카테고리_추가_요청(간편식사);
+            final Product product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 5.0, 간편식사);
+            final Product product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 3.0, 간편식사);
+            final Product product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 1.0, 간편식사);
+            final Product product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", 4.0, 간편식사);
+            final Product product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", 4.5, 간편식사);
+            final Product product6 = new Product("삼각김밥6", 1700L, "image.png", "맛있는 삼각김밥6", 2.5, 간편식사);
+            final Product product7 = new Product("삼각김밥7", 1800L, "image.png", "맛있는 삼각김밥7", 2.0, 간편식사);
+            final Product product8 = new Product("삼각김밥8", 800L, "image.png", "맛있는 삼각김밥8", 1.5, 간편식사);
+            final Product product9 = new Product("삼각김밥9", 3100L, "image.png", "맛있는 삼각김밥9", 3.5, 간편식사);
+            final Product product10 = new Product("삼각김밥10", 2700L, "image.png", "맛있는 삼각김밥10", 1.0, 간편식사);
+            final Product product11 = new Product("삼각김밥11", 300L, "image.png", "맛있는 삼각김밥11", 0.5, 간편식사);
+            final List<Product> products = List.of(product1, product2, product3, product4, product5, product6, product7,
+                    product8, product9, product10, product11);
+            복수_상품_추가_요청(products);
+
+            // when
+            final var response = 카테고리별_상품_목록_조회_요청(categoryId, "averageRating", "asc", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            페이지를_검증한다(response, (long) products.size(), 0L);
+            카테고리별_상품_목록_조회_결과를_검증한다(response,
+                    List.of(product11, product10, product3, product8, product7, product6, product2, product9, product4,
+                            product5));
+        }
+    }
+
+    @Nested
+    class 리뷰수_기준_내림차순으로_카테고리별_상품_목록_조회 {
+        @Test
+        void 리뷰수가_서로_다르면_리뷰수_기준_내림차순으로_정렬할_수_있다() {
+            // given
+            final Long categoryId = 카테고리_추가_요청(간편식사);
+            final Product product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 5.0, 간편식사);
+            final Product product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 3.0, 간편식사);
+            final Product product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 1.0, 간편식사);
+            final List<Product> products = List.of(product1, product2, product3);
+            복수_상품_추가_요청(products);
+
+            Member member = 멤버_추가_요청(new Member("test", "image.png"));
+            상품_리뷰_추가_요청(new Review(member, product1, "review.png", 5L, "이 삼각김밥은 최고!!", true));
+            상품_리뷰_추가_요청(new Review(member, product1, "review.png", 4L, "이 삼각김밥은 좀 맛있다", true));
+            상품_리뷰_추가_요청(new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true));
+            상품_리뷰_추가_요청(new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true));
+            상품_리뷰_추가_요청(new Review(member, product3, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
+            상품_리뷰_추가_요청(new Review(member, product3, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
+            상품_리뷰_추가_요청(new Review(member, product3, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
+            상품_리뷰_추가_요청(new Review(member, product2, "review.png", 1L, "이 삼각김밥은 맛없다", false));
+            상품_리뷰_추가_요청(new Review(member, product2, "review.png", 1L, "이 삼각김밥은 맛없다", false));
+
+            // when
+            final var response = 카테고리별_상품_목록_조회_요청(categoryId, "reviewCount", "desc", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            페이지를_검증한다(response, (long) products.size(), 0L);
+            카테고리별_상품_목록_조회_결과를_검증한다(response,
+                    List.of(product1, product3, product2));
+        }
+
+        @Test
+        void 리뷰수가_서로_같으면_ID_기준_내림차순으로_정렬할_수_있다() {
+            // given
+            final Long categoryId = 카테고리_추가_요청(간편식사);
+            final Product product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 5.0, 간편식사);
+            final Product product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 3.0, 간편식사);
+            final Product product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 1.0, 간편식사);
+            final Product product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", 4.0, 간편식사);
+            final Product product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", 4.5, 간편식사);
+            final List<Product> products = List.of(product1, product2, product3, product4, product5);
+            복수_상품_추가_요청(products);
+
+            Member member = 멤버_추가_요청(new Member("test", "image.png"));
+            상품_리뷰_추가_요청(new Review(member, product1, "review.png", 5L, "이 삼각김밥은 최고!!", true));
+            상품_리뷰_추가_요청(new Review(member, product1, "review.png", 4L, "이 삼각김밥은 좀 맛있다", true));
+            상품_리뷰_추가_요청(new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true));
+            상품_리뷰_추가_요청(new Review(member, product2, "review.png", 3L, "이 삼각김밥은 맛있다", true));
+            상품_리뷰_추가_요청(new Review(member, product2, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
+            상품_리뷰_추가_요청(new Review(member, product3, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
+            상품_리뷰_추가_요청(new Review(member, product3, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
+            상품_리뷰_추가_요청(new Review(member, product4, "review.png", 1L, "이 삼각김밥은 맛없다", false));
+
+            // when
+            final var response = 카테고리별_상품_목록_조회_요청(categoryId, "reviewCount", "desc", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            페이지를_검증한다(response, (long) products.size(), 0L);
+            카테고리별_상품_목록_조회_결과를_검증한다(response,
+                    List.of(product1, product3, product2, product4, product5));
+        }
     }
 
     @Test
@@ -231,7 +364,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
         카테고리_추가_요청(간편식사);
         final Product product = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 간편식사);
         final Long productId = 상품_추가_요청(product);
-        final Long memberId = 멤버_추가_요청();
+        final Long memberId = 기본_멤버_추가_요청();
         final Tag tag1 = 태그_추가_요청(new Tag("1번"));
         final Tag tag2 = 태그_추가_요청(new Tag("2번"));
         final Tag tag3 = 태그_추가_요청(new Tag("3번"));
@@ -243,6 +376,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 "request2", true, memberId);
         final ReviewCreateRequest request3 = new ReviewCreateRequest(3L, List.of(tag2.getId()), "request3", true,
                 memberId);
+        리뷰_추가_요청(productId, image, request1);
         리뷰_추가_요청(productId, image, request1);
         리뷰_추가_요청(productId, image, request2);
         리뷰_추가_요청(productId, image, request3);
@@ -287,9 +421,17 @@ class ProductAcceptanceTest extends AcceptanceTest {
         return tagRepository.save(tag);
     }
 
-    private Long 멤버_추가_요청() {
+    private Long 기본_멤버_추가_요청() {
         final Member testMember = memberRepository.save(new Member("test", "image.png"));
         return testMember.getId();
+    }
+
+    private Member 멤버_추가_요청(Member member) {
+        return memberRepository.save(member);
+    }
+
+    private Review 상품_리뷰_추가_요청(final Review review) {
+        return reviewRepository.save(review);
     }
 
     private void 페이지를_검증한다(final ExtractableResponse<Response> response, Long dataSize, Long page) {

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
@@ -305,15 +305,19 @@ class ProductAcceptanceTest extends AcceptanceTest {
             복수_상품_추가_요청(products);
 
             Member member = 멤버_추가_요청(new Member("test", "image.png"));
-            상품_리뷰_추가_요청(new Review(member, product1, "review.png", 5L, "이 삼각김밥은 최고!!", true));
-            상품_리뷰_추가_요청(new Review(member, product1, "review.png", 4L, "이 삼각김밥은 좀 맛있다", true));
-            상품_리뷰_추가_요청(new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true));
-            상품_리뷰_추가_요청(new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true));
-            상품_리뷰_추가_요청(new Review(member, product3, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
-            상품_리뷰_추가_요청(new Review(member, product3, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
-            상품_리뷰_추가_요청(new Review(member, product3, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
-            상품_리뷰_추가_요청(new Review(member, product2, "review.png", 1L, "이 삼각김밥은 맛없다", false));
-            상품_리뷰_추가_요청(new Review(member, product2, "review.png", 1L, "이 삼각김밥은 맛없다", false));
+            final Review review1_1 = new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true);
+            final Review review1_2 = new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true);
+            final Review review1_3 = new Review(member, product1, "review.png", 4L, "이 삼각김밥은 좀 맛있다", true);
+            final Review review1_4 = new Review(member, product1, "review.png", 5L, "이 삼각김밥은 최고!!", true);
+            final Review review2_1 = new Review(member, product2, "review.png", 1L, "이 삼각김밥은 맛없다", false);
+            final Review review2_2 = new Review(member, product2, "review.png", 1L, "이 삼각김밥은 맛없다", false);
+            final Review review3_1 = new Review(member, product3, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false);
+            final Review review3_2 = new Review(member, product3, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false);
+            final Review review3_3 = new Review(member, product3, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false);
+            List<Review> reviews = List.of(review1_1, review1_2, review1_3, review1_4, review2_1, review2_2,
+                    review3_1, review3_2, review3_3);
+            복수_리뷰_추가_요청(reviews);
+
 
             // when
             final var response = 카테고리별_상품_목록_조회_요청(categoryId, "reviewCount", "desc", 0);
@@ -338,14 +342,18 @@ class ProductAcceptanceTest extends AcceptanceTest {
             복수_상품_추가_요청(products);
 
             final Member member = 멤버_추가_요청(new Member("test", "image.png"));
-            상품_리뷰_추가_요청(new Review(member, product1, "review.png", 5L, "이 삼각김밥은 최고!!", true));
-            상품_리뷰_추가_요청(new Review(member, product1, "review.png", 4L, "이 삼각김밥은 좀 맛있다", true));
-            상품_리뷰_추가_요청(new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true));
-            상품_리뷰_추가_요청(new Review(member, product2, "review.png", 3L, "이 삼각김밥은 맛있다", true));
-            상품_리뷰_추가_요청(new Review(member, product2, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
-            상품_리뷰_추가_요청(new Review(member, product3, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
-            상품_리뷰_추가_요청(new Review(member, product3, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
-            상품_리뷰_추가_요청(new Review(member, product4, "review.png", 1L, "이 삼각김밥은 맛없다", false));
+            final Review review1_1 = new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true);
+            final Review review1_2 = new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true);
+            final Review review1_3 = new Review(member, product1, "review.png", 4L, "이 삼각김밥은 좀 맛있다", true);
+            final Review review1_4 = new Review(member, product1, "review.png", 5L, "이 삼각김밥은 최고!!", true);
+            final Review review2_1 = new Review(member, product2, "review.png", 1L, "이 삼각김밥은 맛없다", false);
+            final Review review2_2 = new Review(member, product2, "review.png", 1L, "이 삼각김밥은 맛없다", false);
+            final Review review3_1 = new Review(member, product3, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false);
+            final Review review3_2 = new Review(member, product3, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false);
+            final Review review3_3 = new Review(member, product3, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false);
+            List<Review> reviews = List.of(review1_1, review1_2, review1_3, review1_4, review2_1, review2_2,
+                    review3_1, review3_2, review3_3);
+            복수_리뷰_추가_요청(reviews);
 
             // when
             final var response = 카테고리별_상품_목록_조회_요청(categoryId, "reviewCount", "desc", 0);
@@ -429,8 +437,8 @@ class ProductAcceptanceTest extends AcceptanceTest {
         return memberRepository.save(member);
     }
 
-    private Review 상품_리뷰_추가_요청(final Review review) {
-        return reviewRepository.save(review);
+    private void 복수_리뷰_추가_요청(final List<Review> reviews) {
+        reviewRepository.saveAll(reviews);
     }
 
     private void 페이지를_검증한다(final ExtractableResponse<Response> response, Long dataSize, Long page) {

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
@@ -362,7 +362,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
             STATUS_CODE를_검증한다(response, 정상_처리);
             페이지를_검증한다(response, (long) products.size(), 0L);
             카테고리별_상품_목록_조회_결과를_검증한다(response,
-                    List.of(product1, product3, product2, product4, product5));
+                    List.of(product1, product3, product2, product5, product4));
         }
     }
 

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
@@ -337,7 +337,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
             final List<Product> products = List.of(product1, product2, product3, product4, product5);
             복수_상품_추가_요청(products);
 
-            Member member = 멤버_추가_요청(new Member("test", "image.png"));
+            final Member member = 멤버_추가_요청(new Member("test", "image.png"));
             상품_리뷰_추가_요청(new Review(member, product1, "review.png", 5L, "이 삼각김밥은 최고!!", true));
             상품_리뷰_추가_요청(new Review(member, product1, "review.png", 4L, "이 삼각김밥은 좀 맛있다", true));
             상품_리뷰_추가_요청(new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true));
@@ -376,7 +376,6 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 "request2", true, memberId);
         final ReviewCreateRequest request3 = new ReviewCreateRequest(3L, List.of(tag2.getId()), "request3", true,
                 memberId);
-        리뷰_추가_요청(productId, image, request1);
         리뷰_추가_요청(productId, image, request1);
         리뷰_추가_요청(productId, image, request2);
         리뷰_추가_요청(productId, image, request3);
@@ -426,7 +425,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
         return testMember.getId();
     }
 
-    private Member 멤버_추가_요청(Member member) {
+    private Member 멤버_추가_요청(final Member member) {
         return memberRepository.save(member);
     }
 

--- a/backend/src/test/java/com/funeat/product/persistence/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/product/persistence/ProductRepositoryTest.java
@@ -132,4 +132,66 @@ class ProductRepositoryTest {
         // then
         assertThat(actual).containsExactly(product8, product1, product4);
     }
+
+    @Test
+    void 카테고리별_상품을_리뷰수가_많은_순으로_정렬한다() {
+        // given
+        final var category = categoryRepository.save(new Category("간편식사", CategoryType.FOOD));
+        final var product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", category);
+        final var product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", category);
+        final var product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", category);
+        final var product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", category);
+        final var product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", category);
+        productRepository.saveAll(
+                List.of(product1, product2, product3, product4, product5));
+
+        Member member = memberRepository.save(new Member("test", "image.png", 27, Gender.FEMALE, "01036551086"));
+
+        reviewRepository.save(new Review(member, product1, "review.png", 5L, "이 삼각김밥은 최고!!", true));
+        reviewRepository.save(new Review(member, product1, "review.png", 4L, "이 삼각김밥은 좀 맛있다", true));
+        reviewRepository.save(new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true));
+        reviewRepository.save(new Review(member, product4, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
+        reviewRepository.save(new Review(member, product4, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
+        reviewRepository.save(new Review(member, product2, "review.png", 1L, "이 삼각김밥은 맛없다", false));
+
+        // when
+        final var pageRequest = PageRequest.of(0, 3, Sort.by("reviewCount").descending());
+        final var actual = productRepository.findAllByCategory(category, pageRequest).getContent();
+
+        // then
+        assertThat(actual).containsExactly(product1, product4, product2);
+    }
+
+    @Test
+    void 카테고리별_상품을_리뷰수가_적은_순으로_정렬한다() {
+        // given
+        final var category = categoryRepository.save(new Category("간편식사", CategoryType.FOOD));
+        final var product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", category);
+        final var product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", category);
+        final var product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", category);
+        final var product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", category);
+        final var product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", category);
+        productRepository.saveAll(
+                List.of(product1, product2, product3, product4, product5));
+
+        Member member = memberRepository.save(new Member("test", "image.png", 27, Gender.FEMALE, "01036551086"));
+
+        reviewRepository.save(new Review(member, product1, "review.png", 5L, "이 삼각김밥은 최고!!", true));
+        reviewRepository.save(new Review(member, product1, "review.png", 4L, "이 삼각김밥은 좀 맛있다", true));
+        reviewRepository.save(new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true));
+        reviewRepository.save(new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true));
+        reviewRepository.save(new Review(member, product4, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
+        reviewRepository.save(new Review(member, product4, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
+        reviewRepository.save(new Review(member, product4, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
+        reviewRepository.save(new Review(member, product2, "review.png", 1L, "이 삼각김밥은 맛없다", false));
+        reviewRepository.save(new Review(member, product2, "review.png", 1L, "이 삼각김밥은 맛없다", false));
+        reviewRepository.save(new Review(member, product3, "review.png", 1L, "이 삼각김밥은 맛없다", false));
+
+        // when
+        final var pageRequest = PageRequest.of(0, 3, Sort.by("reviewCount").ascending());
+        final var actual = productRepository.findAllByCategory(category, pageRequest).getContent();
+
+        // then
+        assertThat(actual).containsExactly(product5, product3, product2);
+    }
 }

--- a/backend/src/test/java/com/funeat/product/persistence/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/product/persistence/ProductRepositoryTest.java
@@ -157,7 +157,7 @@ class ProductRepositoryTest {
         productRepository.saveAll(
                 List.of(product1, product2, product3, product4, product5));
 
-        Member member = memberRepository.save(new Member("test", "image.png"));
+        final var member = memberRepository.save(new Member("test", "image.png"));
 
         reviewRepository.save(new Review(member, product1, "review.png", 5L, "이 삼각김밥은 최고!!", true));
         reviewRepository.save(new Review(member, product1, "review.png", 4L, "이 삼각김밥은 좀 맛있다", true));

--- a/backend/src/test/java/com/funeat/product/persistence/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/product/persistence/ProductRepositoryTest.java
@@ -4,9 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.funeat.common.DataCleaner;
 import com.funeat.common.DataClearExtension;
+import com.funeat.member.domain.Gender;
+import com.funeat.member.domain.Member;
+import com.funeat.member.persistence.MemberRepository;
 import com.funeat.product.domain.Category;
 import com.funeat.product.domain.CategoryType;
 import com.funeat.product.domain.Product;
+import com.funeat.review.domain.Review;
+import com.funeat.review.persistence.ReviewRepository;
 import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -26,10 +31,56 @@ import org.springframework.data.domain.Sort;
 class ProductRepositoryTest {
 
     @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
     private CategoryRepository categoryRepository;
 
     @Autowired
     private ProductRepository productRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Test
+    void 카테고리별_상품을_평점이_높은_순으로_정렬한다() {
+        // given
+        final var category = categoryRepository.save(new Category("간편식사", CategoryType.FOOD));
+        final var product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 5.0, category);
+        final var product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 3.5, category);
+        final var product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 4.0, category);
+        final var product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", 3.0, category);
+        final var product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", 4.5, category);
+        productRepository.saveAll(
+                List.of(product1, product2, product3, product4, product5));
+
+        // when
+        final var pageRequest = PageRequest.of(0, 3, Sort.by("averageRating").descending());
+        final var actual = productRepository.findAllByCategory(category, pageRequest).getContent();
+
+        // then
+        assertThat(actual).containsExactly(product1, product5, product3);
+    }
+
+    @Test
+    void 카테고리별_상품을_평점이_낮은_순으로_정렬한다() {
+        // given
+        final var category = categoryRepository.save(new Category("간편식사", CategoryType.FOOD));
+        final var product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 5.0, category);
+        final var product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 3.5, category);
+        final var product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 4.0, category);
+        final var product4 = new Product("삼각김밥4", 1200L, "image.png", "맛있는 삼각김밥4", 3.0, category);
+        final var product5 = new Product("삼각김밥5", 2300L, "image.png", "맛있는 삼각김밥5", 4.5, category);
+        productRepository.saveAll(
+                List.of(product1, product2, product3, product4, product5));
+
+        // when
+        final var pageRequest = PageRequest.of(0, 3, Sort.by("averageRating").ascending());
+        final var actual = productRepository.findAllByCategory(category, pageRequest).getContent();
+
+        // then
+        assertThat(actual).containsExactly(product4, product2, product3);
+    }
 
     @Test
     void 카테고리별_상품을_가격이_높은_순으로_정렬한다() {

--- a/backend/src/test/java/com/funeat/product/persistence/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/product/persistence/ProductRepositoryTest.java
@@ -59,7 +59,8 @@ class ProductRepositoryTest {
         final var actual = productRepository.findAllByCategory(category, pageRequest).getContent();
 
         // then
-        final var expected = List.of(ProductInCategoryDto.toDto(product1, 0L), ProductInCategoryDto.toDto(product5, 0L), ProductInCategoryDto.toDto(product3, 0L));
+        final var expected = List.of(ProductInCategoryDto.toDto(product1, 0L), ProductInCategoryDto.toDto(product5, 0L),
+                ProductInCategoryDto.toDto(product3, 0L));
         assertThat(actual).usingRecursiveComparison()
                 .isEqualTo(expected);
     }
@@ -159,16 +160,20 @@ class ProductRepositoryTest {
 
         final var member = memberRepository.save(new Member("test", "image.png"));
 
-        reviewRepository.save(new Review(member, product1, "review.png", 5L, "이 삼각김밥은 최고!!", true));
-        reviewRepository.save(new Review(member, product1, "review.png", 4L, "이 삼각김밥은 좀 맛있다", true));
-        reviewRepository.save(new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true));
-        reviewRepository.save(new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true));
-        reviewRepository.save(new Review(member, product4, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
-        reviewRepository.save(new Review(member, product4, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
-        reviewRepository.save(new Review(member, product4, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false));
-        reviewRepository.save(new Review(member, product2, "review.png", 1L, "이 삼각김밥은 맛없다", false));
-        reviewRepository.save(new Review(member, product2, "review.png", 1L, "이 삼각김밥은 맛없다", false));
-        reviewRepository.save(new Review(member, product3, "review.png", 1L, "이 삼각김밥은 맛없다", false));
+        final var review1_1 = new Review(member, product1, "review.png", 5L, "이 삼각김밥은 최고!!", true);
+        final var review1_2 = new Review(member, product1, "review.png", 4L, "이 삼각김밥은 좀 맛있다", true);
+        final var review1_3 = new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true);
+        final var review1_4 = new Review(member, product1, "review.png", 3L, "이 삼각김밥은 맛있다", true);
+        final var review2_1 = new Review(member, product2, "review.png", 1L, "이 삼각김밥은 맛없다", false);
+        final var review2_2 = new Review(member, product2, "review.png", 1L, "이 삼각김밥은 맛없다", false);
+        final var review3_1 = new Review(member, product3, "review.png", 1L, "이 삼각김밥은 맛없다", false);
+        final var review4_1 = new Review(member, product4, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false);
+        final var review4_2 = new Review(member, product4, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false);
+        final var review4_3 = new Review(member, product4, "review.png", 2L, "이 삼각김밥은 좀 맛없다", false);
+        reviewRepository.saveAll(
+                List.of(review1_1, review1_2, review1_3, review1_4, review2_1, review2_2, review3_1, review4_1,
+                        review4_2, review4_3)
+        );
 
         // when
         final var pageRequest = PageRequest.of(0, 3);

--- a/backend/src/test/java/com/funeat/product/persistence/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/product/persistence/ProductRepositoryTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.funeat.common.DataCleaner;
 import com.funeat.common.DataClearExtension;
-import com.funeat.member.domain.Gender;
 import com.funeat.member.domain.Member;
 import com.funeat.member.persistence.MemberRepository;
 import com.funeat.product.domain.Category;
@@ -158,7 +157,7 @@ class ProductRepositoryTest {
         productRepository.saveAll(
                 List.of(product1, product2, product3, product4, product5));
 
-        Member member = memberRepository.save(new Member("test", "image.png", 27, Gender.FEMALE, "01036551086"));
+        Member member = memberRepository.save(new Member("test", "image.png"));
 
         reviewRepository.save(new Review(member, product1, "review.png", 5L, "이 삼각김밥은 최고!!", true));
         reviewRepository.save(new Review(member, product1, "review.png", 4L, "이 삼각김밥은 좀 맛있다", true));


### PR DESCRIPTION
## Issue

- close #134 

## ✨ 구현한 기능

카테고리별 상품 목록 조회 조건에 `평점순`과 `리뷰개수순` 추가

- 오전에 논의했던 대로 `@formula`사용 대신 조회에 사용되는 repository 메서드 분리 
  - findAllByCategory : 평점순/가격순
  - findAllByCategoryOrderByReviewCountDesc : 리뷰개수순
- findAll~의 반환값을 `Page<Product>`에서 `Page<ProductInCategoryDto>`로 수정
- 기타 개선사항
  - 기존 count 쿼리 10번 -> 현재 1번
  - 페이징의 totalCount를 위한 count 쿼리에서 join 제외

## 📢 논의하고 싶은 내용

- ProductAcceptanceTest에서 테스트의 중심이 아닌 Review 데이터 세팅할 때
  - reviewRepository.save(new Review~);
  - restAssured로 review 작성 api 요청
  

## 🎸 기타

-  X

## ⏰ 일정

- 추정 시간 : 2h
- 걸린 시간 : 6h 
