### PR TITLE
[BE] fix: Service Test에 Data Cleaner 적용

### DIFF
--- a/backend/src/test/java/com/funeat/member/persistence/ReviewFavoriteRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/member/persistence/ReviewFavoriteRepositoryTest.java
@@ -2,6 +2,8 @@ package com.funeat.member.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.funeat.common.DataCleaner;
+import com.funeat.common.DataClearExtension;
 import com.funeat.member.domain.Member;
 import com.funeat.member.domain.favorite.ReviewFavorite;
 import com.funeat.product.domain.Product;
@@ -13,10 +15,14 @@ import io.restassured.specification.MultiPartSpecification;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@Import(DataCleaner.class)
+@ExtendWith(DataClearExtension.class)
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class ReviewFavoriteRepositoryTest {

--- a/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -3,6 +3,7 @@ package com.funeat.review.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 
+import com.funeat.common.DataClearExtension;
 import com.funeat.member.domain.Member;
 import com.funeat.member.domain.favorite.ReviewFavorite;
 import com.funeat.member.persistence.MemberRepository;
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
@@ -33,6 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 @SpringBootTest
+@ExtendWith(DataClearExtension.class)
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class ReviewServiceTest {


### PR DESCRIPTION
## Issue

- close #154 

## ✨ 구현한 기능

- 기존: Service Test는 `@Transactional`만 사용하여 테스트 격리를 함
- 수정: Service Test는 `DataCleaner`를 추가하여 통일된 테스트 격리를 함

## 📢 논의하고 싶은 내용

- x

## 🎸 기타

- x

## ⏰ 일정

- 추정 시간 : 0.5
- 걸린 시간 : 
