### PR TITLE
[BE] feat: 전체 태그 목록 조회 기능 추가

### DIFF
--- a/backend/src/main/java/com/funeat/product/dto/ProductResponse.java
+++ b/backend/src/main/java/com/funeat/product/dto/ProductResponse.java
@@ -2,7 +2,7 @@ package com.funeat.product.dto;
 
 import com.funeat.product.domain.Product;
 import com.funeat.tag.domain.Tag;
-import com.funeat.tag.domain.TagDto;
+import com.funeat.tag.dto.TagDto;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/backend/src/main/java/com/funeat/tag/application/TagService.java
+++ b/backend/src/main/java/com/funeat/tag/application/TagService.java
@@ -1,0 +1,38 @@
+package com.funeat.tag.application;
+
+import com.funeat.tag.domain.TagType;
+import com.funeat.tag.dto.TagDto;
+import com.funeat.tag.dto.TagsResponse;
+import com.funeat.tag.persistence.TagRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class TagService {
+
+    private final TagRepository tagRepository;
+
+    public TagService(final TagRepository tagRepository) {
+        this.tagRepository = tagRepository;
+    }
+
+    public List<TagsResponse> getAllTags() {
+        final List<TagsResponse> responses = new ArrayList<>();
+        for (final TagType tagType : TagType.values()) {
+            getTagsByTagType(responses, tagType);
+        }
+        return responses;
+    }
+
+    private void getTagsByTagType(final List<TagsResponse> responses, final TagType tagType) {
+        final List<TagDto> tags = tagRepository.findTagsByTagType(tagType).stream()
+                .map(TagDto::toDto)
+                .collect(Collectors.toList());
+        final TagsResponse tagsResponse = new TagsResponse(tagType.name(), tags);
+        responses.add(tagsResponse);
+    }
+}

--- a/backend/src/main/java/com/funeat/tag/application/TagService.java
+++ b/backend/src/main/java/com/funeat/tag/application/TagService.java
@@ -32,7 +32,7 @@ public class TagService {
         final List<TagDto> tags = tagRepository.findTagsByTagType(tagType).stream()
                 .map(TagDto::toDto)
                 .collect(Collectors.toList());
-        final TagsResponse tagsResponse = new TagsResponse(tagType.name(), tags);
+        final TagsResponse tagsResponse = TagsResponse.toResponse(tagType.name(), tags);
         responses.add(tagsResponse);
     }
 }

--- a/backend/src/main/java/com/funeat/tag/application/TagService.java
+++ b/backend/src/main/java/com/funeat/tag/application/TagService.java
@@ -23,16 +23,15 @@ public class TagService {
     public List<TagsResponse> getAllTags() {
         final List<TagsResponse> responses = new ArrayList<>();
         for (final TagType tagType : TagType.values()) {
-            getTagsByTagType(responses, tagType);
+            responses.add(getTagsByTagType(tagType));
         }
         return responses;
     }
 
-    private void getTagsByTagType(final List<TagsResponse> responses, final TagType tagType) {
+    private TagsResponse getTagsByTagType(final TagType tagType) {
         final List<TagDto> tags = tagRepository.findTagsByTagType(tagType).stream()
                 .map(TagDto::toDto)
                 .collect(Collectors.toList());
-        final TagsResponse tagsResponse = TagsResponse.toResponse(tagType.name(), tags);
-        responses.add(tagsResponse);
+        return TagsResponse.toResponse(tagType.name(), tags);
     }
 }

--- a/backend/src/main/java/com/funeat/tag/domain/Tag.java
+++ b/backend/src/main/java/com/funeat/tag/domain/Tag.java
@@ -1,6 +1,8 @@
 package com.funeat.tag.domain;
 
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -14,11 +16,19 @@ public class Tag {
 
     private String name;
 
+    @Enumerated(EnumType.STRING)
+    private TagType tagType;
+
     protected Tag() {
     }
 
     public Tag(final String name) {
         this.name = name;
+    }
+
+    public Tag(final String name, final TagType tagType) {
+        this.name = name;
+        this.tagType = tagType;
     }
 
     public Long getId() {
@@ -27,5 +37,9 @@ public class Tag {
 
     public String getName() {
         return name;
+    }
+
+    public TagType getTagType() {
+        return tagType;
     }
 }

--- a/backend/src/main/java/com/funeat/tag/domain/Tag.java
+++ b/backend/src/main/java/com/funeat/tag/domain/Tag.java
@@ -22,10 +22,6 @@ public class Tag {
     protected Tag() {
     }
 
-    public Tag(final String name) {
-        this.name = name;
-    }
-
     public Tag(final String name, final TagType tagType) {
         this.name = name;
         this.tagType = tagType;

--- a/backend/src/main/java/com/funeat/tag/domain/TagType.java
+++ b/backend/src/main/java/com/funeat/tag/domain/TagType.java
@@ -1,0 +1,6 @@
+package com.funeat.tag.domain;
+
+public enum TagType {
+
+    TASTE, PRICE, ETC
+}

--- a/backend/src/main/java/com/funeat/tag/dto/TagDto.java
+++ b/backend/src/main/java/com/funeat/tag/dto/TagDto.java
@@ -1,4 +1,6 @@
-package com.funeat.tag.domain;
+package com.funeat.tag.dto;
+
+import com.funeat.tag.domain.Tag;
 
 public class TagDto {
 

--- a/backend/src/main/java/com/funeat/tag/dto/TagsResponse.java
+++ b/backend/src/main/java/com/funeat/tag/dto/TagsResponse.java
@@ -12,6 +12,10 @@ public class TagsResponse {
         this.tags = tags;
     }
 
+    public static TagsResponse toResponse(final String tagType, final List<TagDto> tags) {
+        return new TagsResponse(tagType, tags);
+    }
+
     public String getTagType() {
         return tagType;
     }

--- a/backend/src/main/java/com/funeat/tag/dto/TagsResponse.java
+++ b/backend/src/main/java/com/funeat/tag/dto/TagsResponse.java
@@ -1,0 +1,22 @@
+package com.funeat.tag.dto;
+
+import java.util.List;
+
+public class TagsResponse {
+
+    private final String tagType;
+    private final List<TagDto> tags;
+
+    public TagsResponse(final String tagType, final List<TagDto> tags) {
+        this.tagType = tagType;
+        this.tags = tags;
+    }
+
+    public String getTagType() {
+        return tagType;
+    }
+
+    public List<TagDto> getTags() {
+        return tags;
+    }
+}

--- a/backend/src/main/java/com/funeat/tag/persistence/TagRepository.java
+++ b/backend/src/main/java/com/funeat/tag/persistence/TagRepository.java
@@ -1,10 +1,13 @@
 package com.funeat.tag.persistence;
 
 import com.funeat.tag.domain.Tag;
+import com.funeat.tag.domain.TagType;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
     List<Tag> findTagsByIdIn(final List<Long> tagIds);
+
+    List<Tag> findTagsByTagType(final TagType tagType);
 }

--- a/backend/src/main/java/com/funeat/tag/presentation/TagApiController.java
+++ b/backend/src/main/java/com/funeat/tag/presentation/TagApiController.java
@@ -1,0 +1,24 @@
+package com.funeat.tag.presentation;
+
+import com.funeat.tag.application.TagService;
+import com.funeat.tag.dto.TagsResponse;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TagApiController implements TagController {
+
+    private final TagService tagService;
+
+    public TagApiController(final TagService tagService) {
+        this.tagService = tagService;
+    }
+
+    @GetMapping("/api/tags")
+    public ResponseEntity<List<TagsResponse>> getAllTags() {
+        final List<TagsResponse> responses = tagService.getAllTags();
+        return ResponseEntity.ok(responses);
+    }
+}

--- a/backend/src/main/java/com/funeat/tag/presentation/TagController.java
+++ b/backend/src/main/java/com/funeat/tag/presentation/TagController.java
@@ -1,0 +1,21 @@
+package com.funeat.tag.presentation;
+
+import com.funeat.tag.dto.TagsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Tag(name = "04.Tag", description = "태그 기능")
+public interface TagController {
+
+    @Operation(summary = "전체 태그 목록 조회", description = "전체 태그 목록을 태그 타입 별로 조회한다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "전체 태그 목록 조회 성공."
+    )
+    @GetMapping
+    ResponseEntity<List<TagsResponse>> getAllTags();
+}

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
@@ -24,6 +24,7 @@ import com.funeat.product.dto.ProductsInCategoryPageDto;
 import com.funeat.review.domain.Review;
 import com.funeat.review.presentation.dto.ReviewCreateRequest;
 import com.funeat.tag.domain.Tag;
+import com.funeat.tag.domain.TagType;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -318,7 +319,6 @@ class ProductAcceptanceTest extends AcceptanceTest {
                     review3_1, review3_2, review3_3);
             복수_리뷰_추가_요청(reviews);
 
-
             // when
             final var response = 카테고리별_상품_목록_조회_요청(categoryId, "reviewCount", "desc", 0);
 
@@ -373,9 +373,9 @@ class ProductAcceptanceTest extends AcceptanceTest {
         final Product product = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 간편식사);
         final Long productId = 상품_추가_요청(product);
         final Long memberId = 기본_멤버_추가_요청();
-        final Tag tag1 = 태그_추가_요청(new Tag("1번"));
-        final Tag tag2 = 태그_추가_요청(new Tag("2번"));
-        final Tag tag3 = 태그_추가_요청(new Tag("3번"));
+        final Tag tag1 = 태그_추가_요청(new Tag("1번", TagType.ETC));
+        final Tag tag2 = 태그_추가_요청(new Tag("2번", TagType.ETC));
+        final Tag tag3 = 태그_추가_요청(new Tag("3번", TagType.ETC));
         final MultiPartSpecification image = 리뷰_사진_명세_요청();
 
         final ReviewCreateRequest request1 = new ReviewCreateRequest(4L,

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -23,6 +23,7 @@ import com.funeat.review.presentation.dto.ReviewFavoriteRequest;
 import com.funeat.review.presentation.dto.SortingReviewDto;
 import com.funeat.review.presentation.dto.SortingReviewsPageDto;
 import com.funeat.tag.domain.Tag;
+import com.funeat.tag.domain.TagType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.MultiPartSpecification;
@@ -106,8 +107,8 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     }
 
     private List<Long> 태그_추가_요청() {
-        final Tag testTag1 = tagRepository.save(new Tag("testTag1"));
-        final Tag testTag2 = tagRepository.save(new Tag("testTag2"));
+        final Tag testTag1 = tagRepository.save(new Tag("testTag1", TagType.ETC));
+        final Tag testTag2 = tagRepository.save(new Tag("testTag2", TagType.ETC));
         return List.of(testTag1.getId(), testTag2.getId());
     }
 

--- a/backend/src/test/java/com/funeat/acceptance/tag/TagAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/tag/TagAcceptanceTest.java
@@ -42,8 +42,10 @@ public class TagAcceptanceTest extends AcceptanceTest {
     }
 
     private void 전체_태그_목록_조회_결과를_검증한다(final ExtractableResponse<Response> response, final List<Tag> tags) {
-        final var expectedByType = tags.stream().collect(Collectors.groupingBy(Tag::getTagType));
-        final var actual = response.jsonPath().getList("", TagsResponse.class);
+        final var expectedByType = tags.stream()
+                .collect(Collectors.groupingBy(Tag::getTagType));
+        final var actual = response.jsonPath()
+                .getList("", TagsResponse.class);
 
         for (final TagsResponse tagsResponse : actual) {
             final TagType tagType = TagType.valueOf(tagsResponse.getTagType());

--- a/backend/src/test/java/com/funeat/acceptance/tag/TagAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/tag/TagAcceptanceTest.java
@@ -1,0 +1,55 @@
+package com.funeat.acceptance.tag;
+
+import static com.funeat.acceptance.common.CommonSteps.STATUS_CODE를_검증한다;
+import static com.funeat.acceptance.common.CommonSteps.정상_처리;
+import static com.funeat.acceptance.tag.TagSteps.전체_태그_목록_조회_요청;
+import static com.funeat.tag.domain.TagType.ETC;
+import static com.funeat.tag.domain.TagType.PRICE;
+import static com.funeat.tag.domain.TagType.TASTE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.funeat.acceptance.common.AcceptanceTest;
+import com.funeat.tag.domain.Tag;
+import com.funeat.tag.domain.TagType;
+import com.funeat.tag.dto.TagsResponse;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class TagAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 전체_태그_목록을_조회할_수_있다() {
+        // given
+        final var tag1 = 태그_추가_요청(new Tag("단짠단짠", TASTE));
+        final var tag2 = 태그_추가_요청(new Tag("매콤해요", TASTE));
+        final var tag3 = 태그_추가_요청(new Tag("갓성비", PRICE));
+        final var tag4 = 태그_추가_요청(new Tag("바삭바삭", ETC));
+
+        // when
+        final var response = 전체_태그_목록_조회_요청();
+
+        // then
+        STATUS_CODE를_검증한다(response, 정상_처리);
+        전체_태그_목록_조회_결과를_검증한다(response, List.of(tag1, tag2, tag3, tag4));
+    }
+
+    private Tag 태그_추가_요청(final Tag tag) {
+        return tagRepository.save(tag);
+    }
+
+    private void 전체_태그_목록_조회_결과를_검증한다(final ExtractableResponse<Response> response, final List<Tag> tags) {
+        final var expectedByType = tags.stream().collect(Collectors.groupingBy(Tag::getTagType));
+        final var actual = response.jsonPath().getList("", TagsResponse.class);
+
+        for (final TagsResponse tagsResponse : actual) {
+            final TagType tagType = TagType.valueOf(tagsResponse.getTagType());
+            assertThat(tagType).isIn(expectedByType.keySet());
+            assertThat(tagsResponse.getTags()).usingRecursiveComparison()
+                    .isEqualTo(expectedByType.get(tagType));
+        }
+    }
+}

--- a/backend/src/test/java/com/funeat/acceptance/tag/TagSteps.java
+++ b/backend/src/test/java/com/funeat/acceptance/tag/TagSteps.java
@@ -1,0 +1,18 @@
+package com.funeat.acceptance.tag;
+
+import static io.restassured.RestAssured.given;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class TagSteps {
+
+    public static ExtractableResponse<Response> 전체_태그_목록_조회_요청() {
+        return given()
+                .when()
+                .get("/api/tags")
+                .then()
+                .extract();
+    }
+}

--- a/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -17,6 +17,7 @@ import com.funeat.review.presentation.dto.ReviewCreateRequest;
 import com.funeat.review.presentation.dto.ReviewFavoriteRequest;
 import com.funeat.review.presentation.dto.SortingReviewDto;
 import com.funeat.tag.domain.Tag;
+import com.funeat.tag.domain.TagType;
 import com.funeat.tag.persistence.TagRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -166,8 +167,8 @@ class ReviewServiceTest {
     }
 
     private List<Tag> 태그_추가_요청() {
-        final Tag testTag1 = tagRepository.save(new Tag("testTag1"));
-        final Tag testTag2 = tagRepository.save(new Tag("testTag2"));
+        final Tag testTag1 = tagRepository.save(new Tag("testTag1", TagType.ETC));
+        final Tag testTag2 = tagRepository.save(new Tag("testTag2", TagType.ETC));
 
         return List.of(testTag1, testTag2);
     }

--- a/backend/src/test/java/com/funeat/review/persistence/ReviewTagRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/review/persistence/ReviewTagRepositoryTest.java
@@ -11,6 +11,7 @@ import com.funeat.product.persistence.ProductRepository;
 import com.funeat.review.domain.Review;
 import com.funeat.review.domain.ReviewTag;
 import com.funeat.tag.domain.Tag;
+import com.funeat.tag.domain.TagType;
 import com.funeat.tag.persistence.TagRepository;
 import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -53,10 +54,10 @@ class ReviewTagRepositoryTest {
         final var product = new Product("망고", 1_000L, "mango.png", "망고망고", null);
         productRepository.save(product);
 
-        final var tag1 = new Tag("1번");
-        final var tag2 = new Tag("2번");
-        final var tag3 = new Tag("3번");
-        final var tag4 = new Tag("4번");
+        final var tag1 = new Tag("1번", TagType.ETC);
+        final var tag2 = new Tag("2번", TagType.ETC);
+        final var tag3 = new Tag("3번", TagType.ETC);
+        final var tag4 = new Tag("4번", TagType.ETC);
         tagRepository.saveAll(List.of(tag1, tag2, tag3, tag4));
 
         final var review1 = new Review(member, product, "review1.png", 5L, "최고의 망고", true, 25L);

--- a/backend/src/test/java/com/funeat/tag/persistence/TagRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/tag/persistence/TagRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.funeat.tag.persistence;
 
+import static com.funeat.tag.domain.TagType.ETC;
 import static com.funeat.tag.domain.TagType.PRICE;
 import static com.funeat.tag.domain.TagType.TASTE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,8 +31,8 @@ class TagRepositoryTest {
     @Test
     void 여러_태그_아이디로_태그들을_조회_할_수_있다() {
         // given
-        final var tag1 = 태그_추가_요청(new Tag("testTag1"));
-        final var tag2 = 태그_추가_요청(new Tag("testTag2"));
+        final var tag1 = 태그_추가_요청(new Tag("testTag1", ETC));
+        final var tag2 = 태그_추가_요청(new Tag("testTag2", ETC));
         final var tags = List.of(tag1, tag2);
         final var tagIds = tags.stream()
                 .map(Tag::getId)

--- a/backend/src/test/java/com/funeat/tag/persistence/TagRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/tag/persistence/TagRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.funeat.tag.persistence;
 
+import static com.funeat.tag.domain.TagType.PRICE;
+import static com.funeat.tag.domain.TagType.TASTE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.funeat.common.DataCleaner;
@@ -28,7 +30,9 @@ class TagRepositoryTest {
     @Test
     void 여러_태그_아이디로_태그들을_조회_할_수_있다() {
         // given
-        final var tags = 태그_추가_요청();
+        final var tag1 = 태그_추가_요청(new Tag("testTag1"));
+        final var tag2 = 태그_추가_요청(new Tag("testTag2"));
+        final var tags = List.of(tag1, tag2);
         final var tagIds = tags.stream()
                 .map(Tag::getId)
                 .collect(Collectors.toList());
@@ -41,10 +45,23 @@ class TagRepositoryTest {
                 .isEqualTo(tags);
     }
 
-    private List<Tag> 태그_추가_요청() {
-        final var testTag1 = tagRepository.save(new Tag("testTag1"));
-        final var testTag2 = tagRepository.save(new Tag("testTag2"));
+    @Test
+    void 태그_타입으로_태그들을_조회할_수_있다() {
+        // given
+        final var tag1 = 태그_추가_요청(new Tag("단짠단짠", TASTE));
+        final var tag2 = 태그_추가_요청(new Tag("매콤해요", TASTE));
+        final var tag3 = 태그_추가_요청(new Tag("갓성비", PRICE));
+        final var expected = List.of(tag1, tag2);
 
-        return List.of(testTag1, testTag2);
+        // when
+        final var actual = tagRepository.findTagsByTagType(TASTE);
+
+        // then
+        assertThat(actual).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    private Tag 태그_추가_요청(final Tag tag) {
+        return tagRepository.save(tag);
     }
 }


### PR DESCRIPTION
## Issue

- close #156 

## ✨ 구현한 기능

### 전체 태그 목록을 조회하는 기능 구현
- 태그 타입에 맞게 태그 목록을 리스트로 반환하도록 구현
  - 태그 타입 : `TASTE`, `PRICE`, `ETC`
  - 태그 타입에 맞게 태그 목록을 그룹화 하고 모든 태그 목록을 반환하도록 구현
- 관련 repository 테스트 추가
- 관련 인수 테스트 추가

## 📢 논의하고 싶은 내용

- **DTO 패키지 위치**
  - 기존 TagDto 클래스의 위치를 domain 패키지 -> dto 패키지로 이동
  - _현재 product 관련 dto 패키지는 `product.dto`에 위치하는데, review 관련 dto 패키지는 `review.presentation.dto`에 위치함_

- **service 테스트 관련**
  - 다른 조회 기능들처럼 이번에 구현한 전체 태그 목록 조회 service 메서드도 특별한 비즈니스 로직 없이 단순 조회만 반복하고 있다고 생각해서 repository 테스트만 작성하고 service 테스트는 추가하지 않았습니다.
  - 이 부분에 대해서 어떻게 생각하시나요??

- **성능 관련**
  - 일단 태그 타입 수만큼 조회를 하도록 간단하게 구현했는데, 여기서 성능을 더 개선할 방법이 있을까요??

## ⏰ 일정

- 추정 시간 : 1h
- 걸린 시간 : 2h
