### PR TITLE
[FE] feat: 상품 목록 정렬 기능 API 연결

### DIFF
--- a/frontend/src/hooks/product/useCategoryProducts.ts
+++ b/frontend/src/hooks/product/useCategoryProducts.ts
@@ -1,9 +1,10 @@
 import { useGet } from '../useGet';
 
 import { categoryApi } from '@/apis';
+import { PRODUCT_SORT_OPTIONS } from '@/constants';
 import type { CategoryProductResponse } from '@/types/response';
 
-const useCategoryProducts = (categoryId: number, sort = 'price,desc') => {
+const useCategoryProducts = (categoryId: number, sort: string = PRODUCT_SORT_OPTIONS[0].value) => {
   return useGet<CategoryProductResponse>(
     () => categoryApi.get({ params: `/${categoryId}/products`, queries: `?page=1&sort=${sort}` }),
     [categoryId, sort]

--- a/frontend/src/hooks/product/useCategoryProducts.ts
+++ b/frontend/src/hooks/product/useCategoryProducts.ts
@@ -3,10 +3,10 @@ import { useGet } from '../useGet';
 import { categoryApi } from '@/apis';
 import type { CategoryProductResponse } from '@/types/response';
 
-const useCategoryProducts = (categoryId: number) => {
+const useCategoryProducts = (categoryId: number, sort = 'price,desc') => {
   return useGet<CategoryProductResponse>(
-    () => categoryApi.get({ params: `/${categoryId}/products`, queries: `?page=1&sort=price,desc ` }),
-    categoryId
+    () => categoryApi.get({ params: `/${categoryId}/products`, queries: `?page=1&sort=${sort}` }),
+    [categoryId, sort]
   );
 };
 

--- a/frontend/src/hooks/product/useProductReview.ts
+++ b/frontend/src/hooks/product/useProductReview.ts
@@ -6,7 +6,7 @@ import type { ProductReviewResponse } from '@/types/response';
 const useProductReview = (productId: string, sort: string) => {
   return useGet<ProductReviewResponse>(
     () => productApi.get({ params: `/${productId}/reviews`, queries: `?sort=${sort}` }),
-    sort
+    [sort]
   );
 };
 

--- a/frontend/src/hooks/useGet.ts
+++ b/frontend/src/hooks/useGet.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-export const useGet = <T>(callback: () => Promise<T>, dependency?: unknown) => {
+export const useGet = <T>(callback: () => Promise<T>, dependencies: unknown[] = []) => {
   const [data, setData] = useState<T>();
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
@@ -10,7 +10,7 @@ export const useGet = <T>(callback: () => Promise<T>, dependency?: unknown) => {
     if (error) {
       throw new Error(error);
     }
-  }, [dependency, error]);
+  }, [...dependencies, error]);
 
   const request = async () => {
     try {

--- a/frontend/src/pages/ProductListPage.tsx
+++ b/frontend/src/pages/ProductListPage.tsx
@@ -26,7 +26,7 @@ const ProductListPage = () => {
   const { categoryIds } = useCategoryContext();
 
   const { data: menuList } = useCategory(categoryVariant);
-  const { data: productListResponse } = useCategoryProducts(categoryIds[categoryVariant]);
+  const { data: productListResponse } = useCategoryProducts(categoryIds[categoryVariant], selectedOption.value);
 
   return (
     <>


### PR DESCRIPTION
## Issue

- close #130

## ✨ 구현한 기능

-  상품 목록 정렬 기능 추가
- `useGet`에서 dependency를 여러개 가질 수 있어서 배열로 수정했습니다. (없는 경우는 그냥 똑같이 안 써주면 됩니다. 근데 하나만 있는 경우에는 `[dependency]` 이렇게 써줘야돼요.)

## 📢 논의하고 싶은 내용

x

## 🎸 기타

x

## ⏰ 일정

- 추정 시간 : 2시간
- 걸린 시간 : 30분
