### PR TITLE
[FE] 충돌 해결

### DIFF
--- a/frontend/src/components/Common/CategoryMenu/CategoryMenu.tsx
+++ b/frontend/src/components/Common/CategoryMenu/CategoryMenu.tsx
@@ -1,4 +1,4 @@
-import { Button, Text, theme } from '@fun-eat/design-system';
+import { Button, theme } from '@fun-eat/design-system';
 import type { CSSProp } from 'styled-components';
 import styled from 'styled-components';
 
@@ -20,21 +20,19 @@ const CategoryMenu = ({ menuList, menuVariant }: CategoryMenuProps) => {
         const isSelected = menu.id === currentCategoryId;
         return (
           <li key={menu.id}>
-            <Button
+            <CategoryButton
               type="button"
               customHeight="30px"
               color={isSelected ? 'primary' : 'gray3'}
               size="xs"
               weight="bold"
               variant={isSelected ? 'filled' : 'outlined'}
-              css={`
-                padding: 6px 12px;
-                ${isSelected ? selectedCategoryMenuStyles[menuVariant] : ''}
-              `}
+              isSelected={isSelected}
+              menuVariant={menuVariant}
               onClick={() => selectCategory(menuVariant, menu.id)}
             >
               {menu.name}
-            </Button>
+            </CategoryButton>
           </li>
         );
       })}
@@ -49,6 +47,11 @@ type CategoryMenuStyleProps = Pick<CategoryMenuProps, 'menuVariant'>;
 const CategoryMenuContainer = styled.ul`
   display: flex;
   gap: 8px;
+`;
+
+const CategoryButton = styled(Button)<{ isSelected: boolean } & CategoryMenuStyleProps>`
+  padding: 6px 12px;
+  ${({ isSelected, menuVariant }) => (isSelected ? selectedCategoryMenuStyles[menuVariant] : '')}
 `;
 
 const selectedCategoryMenuStyles: Record<CategoryMenuStyleProps['menuVariant'], CSSProp> = {

--- a/frontend/src/components/Review/StarRate/StarRate.tsx
+++ b/frontend/src/components/Review/StarRate/StarRate.tsx
@@ -31,7 +31,7 @@ const StarRate = () => {
               variant="star"
               color={star <= (hovering || rating) ? theme.colors.secondary : theme.colors.gray2}
             />
-          </StarButton>
+          </Button>
         ))}
       </div>
     </StarRateContainer>
@@ -50,7 +50,6 @@ const StarRateContainer = styled.div`
 const RequiredMark = styled.sup`
   color: ${({ theme }) => theme.colors.error};
 `;
-
 
 const SvgIconWrapper = styled(SvgIcon)`
   transition: all 0.3s ease-out;

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -5,11 +5,7 @@ import styled from 'styled-components';
 import { SortButton, SortOptionList, TabMenu } from '@/components/Common';
 import { ProductDetailItem, ProductTitle } from '@/components/Product';
 import { ReviewItem } from '@/components/Review';
-
 import ReviewRegisterForm from '@/components/Review/ReviewRegisterForm/ReviewRegisterForm';
-import productDetails from '@/mocks/data/productDetails.json';
-import mockReviews from '@/mocks/data/reviews.json';
-
 import { REVIEW_SORT_OPTIONS } from '@/constants';
 import { useProductReview, useProductDetail } from '@/hooks/product';
 import useSortOption from '@/hooks/useSortOption';
@@ -51,12 +47,19 @@ const ProductDetailPage = () => {
       </section>
       <Spacing size={100} />
       <ReviewRegisterButtonWrapper>
-        <Button type="button" customWidth="100%" customHeight="60px" size="xl" onClick={handleOpenBottomSheet}>
+        <Button
+          type="button"
+          customWidth="100%"
+          customHeight="60px"
+          size="xl"
+          weight="bold"
+          onClick={handleOpenBottomSheet}
+        >
           리뷰 작성하기
         </Button>
       </ReviewRegisterButtonWrapper>
       <BottomSheet maxWidth="600px" ref={ref} isClosing={isClosing} close={handleCloseBottomSheet}>
-        <ReviewRegisterForm product={targetProductDetail} close={handleCloseBottomSheet} />
+        <ReviewRegisterForm product={productDetail} close={handleCloseBottomSheet} />
       </BottomSheet>
       <BottomSheet ref={ref} isClosing={isClosing} maxWidth="600px" close={handleCloseBottomSheet}>
         <SortOptionList


### PR DESCRIPTION
## Issue

- close #166

## ✨ 구현한 기능

닫는 태그의 불일치
mock 데이터 미사용

두가지의 충돌을 해결하였습니다.

또, category button이 안먹는 에러가 있었는데요.
이거는 css가 적용이 안돼서 그런거였습니다!
styled로 옮기니까 정상 작동!

## 📢 논의하고 싶은 내용

bottom sheet가 2개여서 역시나 에러가 납니다...
리뷰 작성하기 버튼을 누르면 정렬 바텀시트가 열리네여...
일단 모달 하나만 다른 곳으로 옮기거나 ref랑 상태를 각 모달마다 따로 주는 (이건 똑똑이 말이어서 좀 찾아봐야 할 듯) 방법이 있습니다.

<똑똑이의 추천 방법>
이렇게 하면 bottom sheet 하나로 가능. 하지만 코드가 좀 더러워짐. 대충 해서 그런지 닫는 애니메이션이 또 안 먹는 느낌임.
```js
  const [activeSheet, setActiveSheet] = useState<'registerReview' | 'sortOption' | null>(null);

  const handleOpenRegisterReviewSheet = () => {
    setActiveSheet('registerReview');
    handleOpenBottomSheet();
  };

  const handleOpenSortOptionSheet = () => {
    setActiveSheet('sortOption');
    handleOpenBottomSheet();
  };

  const handleCloseSpecificBottomSheet = () => {
    setActiveSheet(null);
    handleCloseBottomSheet();
  };
```

좋은 방안이 있으면 얘기해주세요.
이거는 따로 이슈 파서 진행하겠습니다!

## 🎸 기타

- 특이 사항이 있으면 작성합니다.

## ⏰ 일정

- 추정 시간 : 30분
- 걸린 시간 : 30분
