### PR TITLE
[BE] fix: 정렬된 리뷰 목록 페이징 요청시 API가 정상적으로 응답하도록 수정

### DIFF
--- a/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewDto.java
+++ b/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewDto.java
@@ -3,7 +3,7 @@ package com.funeat.review.presentation.dto;
 import com.funeat.member.domain.favorite.ReviewFavorite;
 import com.funeat.review.domain.Review;
 import com.funeat.review.domain.ReviewTag;
-import com.funeat.tag.domain.Tag;
+import com.funeat.tag.dto.TagDto;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -14,22 +14,15 @@ public class SortingReviewDto {
     private final String profileImage;
     private final String image;
     private final Long rating;
-    private final List<Tag> tags;
+    private final List<TagDto> tags;
     private final String content;
     private final boolean rebuy;
     private final Long favoriteCount;
     private final boolean favorite;
 
-    public SortingReviewDto(final Long id,
-                            final String userName,
-                            final String profileImage,
-                            final String image,
-                            final Long rating,
-                            final List<Tag> tags,
-                            final String content,
-                            final boolean rebuy,
-                            final Long favoriteCount,
-                            final boolean favorite) {
+    public SortingReviewDto(final Long id, final String userName, final String profileImage, final String image,
+                            final Long rating, final List<TagDto> tags, final String content, final boolean rebuy,
+                            final Long favoriteCount, final boolean favorite) {
         this.id = id;
         this.userName = userName;
         this.profileImage = profileImage;
@@ -49,7 +42,7 @@ public class SortingReviewDto {
                 review.getMember().getProfileImage(),
                 review.getImage(),
                 review.getRating(),
-                findTags(review),
+                findTagDtos(review),
                 review.getContent(),
                 review.getReBuy(),
                 review.getFavoriteCount(),
@@ -57,10 +50,10 @@ public class SortingReviewDto {
         );
     }
 
-    private static List<Tag> findTags(final Review review) {
-        return review.getReviewTags()
-                .stream()
+    private static List<TagDto> findTagDtos(final Review review) {
+        return review.getReviewTags().stream()
                 .map(ReviewTag::getTag)
+                .map(TagDto::toDto)
                 .collect(Collectors.toList());
     }
 
@@ -94,7 +87,7 @@ public class SortingReviewDto {
         return rating;
     }
 
-    public List<Tag> getTags() {
+    public List<TagDto> getTags() {
         return tags;
     }
 

--- a/backend/src/main/java/com/funeat/tag/dto/TagDto.java
+++ b/backend/src/main/java/com/funeat/tag/dto/TagDto.java
@@ -1,19 +1,22 @@
 package com.funeat.tag.dto;
 
 import com.funeat.tag.domain.Tag;
+import com.funeat.tag.domain.TagType;
 
 public class TagDto {
 
     private final Long id;
     private final String name;
+    private final TagType tagType;
 
-    public TagDto(final Long id, final String name) {
+    public TagDto(final Long id, final String name, final TagType tagType) {
         this.id = id;
         this.name = name;
+        this.tagType = tagType;
     }
 
     public static TagDto toDto(final Tag tag) {
-        return new TagDto(tag.getId(), tag.getName());
+        return new TagDto(tag.getId(), tag.getName(), tag.getTagType());
     }
 
     public Long getId() {
@@ -22,5 +25,9 @@ public class TagDto {
 
     public String getName() {
         return name;
+    }
+
+    public TagType getTagType() {
+        return tagType;
     }
 }


### PR DESCRIPTION
## Issue

- close #173 

## ✨ 구현한 기능

- 리뷰 목록 페이징 요청시 500 에러가 나와서 해결했습니다. Tag를 반환해서 TagDto를 반환하도록 수정했어요

## 📢 논의하고 싶은 내용

- x

## 🎸 기타

- x

## ⏰ 일정

- 추정 시간 : 0.5
- 걸린 시간 : 0.5
