### PR TITLE
[FE] feat: 상세 레이아웃 추가

### DIFF
--- a/frontend/src/components/Layout/DetailLayout.tsx
+++ b/frontend/src/components/Layout/DetailLayout.tsx
@@ -1,0 +1,27 @@
+import type { PropsWithChildren } from 'react';
+import styled from 'styled-components';
+
+import Header from '../Common/Header/Header';
+
+const DetailLayout = ({ children }: PropsWithChildren) => {
+  return (
+    <DetailLayoutContainer>
+      <Header />
+      <MainWrapper>{children}</MainWrapper>
+    </DetailLayoutContainer>
+  );
+};
+
+export default DetailLayout;
+
+const DetailLayoutContainer = styled.div`
+  max-width: 600px;
+  height: 100%;
+  margin: 0 auto;
+`;
+
+const MainWrapper = styled.main`
+  height: calc(100% - 60px);
+  padding: 20px;
+  overflow-y: auto;
+`;

--- a/frontend/src/components/Layout/index.ts
+++ b/frontend/src/components/Layout/index.ts
@@ -1,2 +1,3 @@
 export { default as DefaultLayout } from './DefaultLayout';
 export { default as AuthLayout } from './AuthLayout';
+export { default as DetailLayout } from './DetailLayout';

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -103,7 +103,7 @@ const ReviewItemWrapper = styled.ul`
 
 const ReviewRegisterButtonWrapper = styled.div`
   position: fixed;
-  bottom: 60px;
+  bottom: 0;
   left: 50%;
   width: calc(100% - 40px);
   max-width: 560px;

--- a/frontend/src/router/App.tsx
+++ b/frontend/src/router/App.tsx
@@ -1,7 +1,6 @@
 import { Outlet } from 'react-router-dom';
 
-import { AuthLayout, DefaultLayout } from '@/components/Layout';
-import DetailLayout from '@/components/Layout/DetailLayout';
+import { AuthLayout, DefaultLayout, DetailLayout } from '@/components/Layout';
 
 interface AppProps {
   layout?: 'auth' | 'detail' | 'default';

--- a/frontend/src/router/App.tsx
+++ b/frontend/src/router/App.tsx
@@ -1,9 +1,10 @@
 import { Outlet } from 'react-router-dom';
 
 import { AuthLayout, DefaultLayout } from '@/components/Layout';
+import DetailLayout from '@/components/Layout/DetailLayout';
 
 interface AppProps {
-  layout?: 'auth' | 'default';
+  layout?: 'auth' | 'detail' | 'default';
 }
 
 const App = ({ layout = 'default' }: AppProps) => {
@@ -12,6 +13,14 @@ const App = ({ layout = 'default' }: AppProps) => {
       <AuthLayout>
         <Outlet />
       </AuthLayout>
+    );
+  }
+
+  if (layout === 'detail') {
+    return (
+      <DetailLayout>
+        <Outlet />
+      </DetailLayout>
     );
   }
 

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -34,10 +34,6 @@ const router = createBrowserRouter([
         ),
       },
       {
-        path: `${PATH.PRODUCT_LIST}/:category/:productId`,
-        element: <ProductDetailPage />,
-      },
-      {
         path: PATH.RECIPE,
         element: <RecipePage />,
       },
@@ -58,6 +54,16 @@ const router = createBrowserRouter([
       {
         path: PATH.LOGIN,
         element: <LoginPage />,
+      },
+    ],
+  },
+  {
+    path: '/',
+    element: <App layout="detail" />,
+    children: [
+      {
+        path: `${PATH.PRODUCT_LIST}/:category/:productId`,
+        element: <ProductDetailPage />,
       },
     ],
   },


### PR DESCRIPTION
## Issue

- close #181 

## ✨ 구현한 기능

- 상세 페이지 레이아웃 추가(헤더만 있는 레이아웃)

## 📢 논의하고 싶은 내용

x

## 🎸 기타

<img width="1440" alt="스크린샷 2023-07-31 오후 3 00 30" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/78616893/065b1d7d-091c-4eb3-8194-15a6985a7fcf">


## ⏰ 일정

- 추정 시간 : 0.5시간
- 걸린 시간 : 10분
