### PR TITLE
[BE] feat: 회원 정보를 수정하는 기능 추가

### DIFF
--- a/backend/src/main/java/com/funeat/member/application/MemberService.java
+++ b/backend/src/main/java/com/funeat/member/application/MemberService.java
@@ -3,6 +3,7 @@ package com.funeat.member.application;
 import com.funeat.auth.dto.SignUserDto;
 import com.funeat.auth.dto.UserInfoDto;
 import com.funeat.member.domain.Member;
+import com.funeat.member.dto.MemberRequest;
 import com.funeat.member.persistence.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,5 +32,14 @@ public class MemberService {
         memberRepository.save(member);
 
         return SignUserDto.of(true, member);
+    }
+
+    @Transactional
+    public void modify(final Long memberId, final MemberRequest request) {
+        final Member findMember = memberRepository.findById(memberId)
+                .orElseThrow(IllegalArgumentException::new);
+
+        findMember.modifyNickname(request.getNickname());
+        findMember.modifyProfileImage(request.getProfileImage());
     }
 }

--- a/backend/src/main/java/com/funeat/member/application/MemberService.java
+++ b/backend/src/main/java/com/funeat/member/application/MemberService.java
@@ -39,7 +39,9 @@ public class MemberService {
         final Member findMember = memberRepository.findById(memberId)
                 .orElseThrow(IllegalArgumentException::new);
 
-        findMember.modifyNickname(request.getNickname());
-        findMember.modifyProfileImage(request.getProfileImage());
+        final String nickname = request.getNickname();
+        final String profileImage = request.getProfileImage();
+
+        findMember.modifyProfile(nickname, profileImage);
     }
 }

--- a/backend/src/main/java/com/funeat/member/domain/Member.java
+++ b/backend/src/main/java/com/funeat/member/domain/Member.java
@@ -78,11 +78,8 @@ public class Member {
         return recipeBookmarks;
     }
 
-    public void modifyNickname(final String nickname) {
+    public void modifyProfile(final String nickname, final String profileImage) {
         this.nickname = nickname;
-    }
-
-    public void modifyProfileImage(final String profileImage) {
         this.profileImage = profileImage;
     }
 }

--- a/backend/src/main/java/com/funeat/member/domain/Member.java
+++ b/backend/src/main/java/com/funeat/member/domain/Member.java
@@ -77,4 +77,12 @@ public class Member {
     public List<RecipeBookmark> getRecipeBookmarks() {
         return recipeBookmarks;
     }
+
+    public void modifyNickname(final String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void modifyProfileImage(final String profileImage) {
+        this.profileImage = profileImage;
+    }
 }

--- a/backend/src/main/java/com/funeat/member/dto/MemberRequest.java
+++ b/backend/src/main/java/com/funeat/member/dto/MemberRequest.java
@@ -1,0 +1,20 @@
+package com.funeat.member.dto;
+
+public class MemberRequest {
+
+    private final String nickname;
+    private final String profileImage;
+
+    public MemberRequest(final String nickname, final String profileImage) {
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getProfileImage() {
+        return profileImage;
+    }
+}

--- a/backend/src/main/java/com/funeat/member/presentation/MemberApiController.java
+++ b/backend/src/main/java/com/funeat/member/presentation/MemberApiController.java
@@ -1,0 +1,27 @@
+package com.funeat.member.presentation;
+
+import com.funeat.member.application.MemberService;
+import com.funeat.member.dto.MemberRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MemberApiController {
+
+    private final MemberService memberService;
+
+    public MemberApiController(final MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @PutMapping("/api/members/{memberId}")
+    public ResponseEntity<Void> putMemberProfile(@PathVariable final Long memberId,
+                                                 @RequestBody final MemberRequest request) {
+        memberService.modify(memberId, request);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/funeat/member/presentation/MemberApiController.java
+++ b/backend/src/main/java/com/funeat/member/presentation/MemberApiController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class MemberApiController {
+public class MemberApiController implements MemberController {
 
     private final MemberService memberService;
 

--- a/backend/src/main/java/com/funeat/member/presentation/MemberController.java
+++ b/backend/src/main/java/com/funeat/member/presentation/MemberController.java
@@ -1,0 +1,22 @@
+package com.funeat.member.presentation;
+
+import com.funeat.member.dto.MemberRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "05.Member", description = "사용자 기능")
+public interface MemberController {
+
+    @Operation(summary = "사용자 정보 수정", description = "사용자 닉네임과 프로필 사진을 수정한다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "사용자 정보 수정 성공."
+    )
+    @PutMapping
+    ResponseEntity<Void> putMemberProfile(@PathVariable Long memberId, @RequestBody MemberRequest request);
+}

--- a/backend/src/test/java/com/funeat/acceptance/member/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/member/MemberAcceptanceTest.java
@@ -1,0 +1,45 @@
+package com.funeat.acceptance.member;
+
+import static com.funeat.acceptance.common.CommonSteps.STATUS_CODE를_검증한다;
+import static com.funeat.acceptance.common.CommonSteps.정상_처리;
+import static io.restassured.RestAssured.given;
+
+import com.funeat.acceptance.common.AcceptanceTest;
+import com.funeat.member.domain.Member;
+import com.funeat.member.dto.MemberRequest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class MemberAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 사용자_정보를_수정하다() {
+        // given
+        final var member = new Member("before", "http://www.before.com", "1");
+        final var memberId = 멤버_추가_요청(member);
+
+        final var request = new MemberRequest("after", "http://www.after.com");
+
+        // when
+        final var response = 사용자_정보_수정_요청(memberId, request);
+
+        // then
+        STATUS_CODE를_검증한다(response, 정상_처리);
+    }
+
+    private Long 멤버_추가_요청(final Member member) {
+        return memberRepository.save(member).getId();
+    }
+
+    private ExtractableResponse<Response> 사용자_정보_수정_요청(final Long memberId, final MemberRequest request) {
+        return given()
+                .contentType("application/json")
+                .body(request)
+                .when()
+                .put("/api/members/{memberId}", memberId)
+                .then()
+                .extract();
+    }
+}

--- a/backend/src/test/java/com/funeat/acceptance/member/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/member/MemberAcceptanceTest.java
@@ -2,13 +2,11 @@ package com.funeat.acceptance.member;
 
 import static com.funeat.acceptance.common.CommonSteps.STATUS_CODE를_검증한다;
 import static com.funeat.acceptance.common.CommonSteps.정상_처리;
-import static io.restassured.RestAssured.given;
+import static com.funeat.acceptance.member.MemberSteps.사용자_정보_수정_요청;
 
 import com.funeat.acceptance.common.AcceptanceTest;
 import com.funeat.member.domain.Member;
 import com.funeat.member.dto.MemberRequest;
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -31,15 +29,5 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
     private Long 멤버_추가_요청(final Member member) {
         return memberRepository.save(member).getId();
-    }
-
-    private ExtractableResponse<Response> 사용자_정보_수정_요청(final Long memberId, final MemberRequest request) {
-        return given()
-                .contentType("application/json")
-                .body(request)
-                .when()
-                .put("/api/members/{memberId}", memberId)
-                .then()
-                .extract();
     }
 }

--- a/backend/src/test/java/com/funeat/acceptance/member/MemberSteps.java
+++ b/backend/src/test/java/com/funeat/acceptance/member/MemberSteps.java
@@ -1,0 +1,20 @@
+package com.funeat.acceptance.member;
+
+import static io.restassured.RestAssured.given;
+
+import com.funeat.member.dto.MemberRequest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+public class MemberSteps {
+
+    public static ExtractableResponse<Response> 사용자_정보_수정_요청(final Long memberId, final MemberRequest request) {
+        return given()
+                .contentType("application/json")
+                .body(request)
+                .when()
+                .put("/api/members/{memberId}", memberId)
+                .then()
+                .extract();
+    }
+}

--- a/backend/src/test/java/com/funeat/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/funeat/member/application/MemberServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.funeat.auth.dto.UserInfoDto;
 import com.funeat.common.DataClearExtension;
 import com.funeat.member.domain.Member;
+import com.funeat.member.dto.MemberRequest;
 import com.funeat.member.persistence.MemberRepository;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Assertions;
@@ -68,6 +69,124 @@ class MemberServiceTest {
             SoftAssertions.assertSoftly(softAssertions -> {
                 Assertions.assertTrue(actual.isSignIn());
                 assertThat(expected).doesNotContain(actual.getMember());
+            });
+        }
+    }
+
+    @Nested
+    class modify_테스트 {
+
+        @Test
+        void 닉네임과_프로필_사진이_그대로면_사용자_정보는_바뀌지_않는다() {
+            // given
+            final var nickname = "test";
+            final var profileImage = "http://www.test.com";
+            final MemberRequest request = new MemberRequest(nickname, profileImage);
+
+            final var member = new Member(nickname, profileImage, "1");
+            final var memberId = memberRepository.save(member).getId();
+
+            final var expected = memberRepository.findById(memberId).get();
+            final var expectedNickname = expected.getNickname();
+            final var expectedProfileImage = expected.getProfileImage();
+
+            // when
+            memberService.modify(memberId, request);
+            final var actual = memberRepository.findById(memberId).get();
+            final var actualNickname = actual.getNickname();
+            final var actualProfileImage = actual.getProfileImage();
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(actualNickname).isEqualTo(expectedNickname);
+                softAssertions.assertThat(actualProfileImage).isEqualTo(expectedProfileImage);
+            });
+        }
+
+        @Test
+        void 닉네임만_바뀌고_프로필_사진은_그대로면_닉네임만_바뀐다() {
+            // given
+            final var beforeNickname = "before";
+            final var profileImage = "http://www.test.com";
+            final var afterNickname = "after";
+            final MemberRequest request = new MemberRequest(afterNickname, profileImage);
+
+            final var member = new Member(beforeNickname, profileImage, "1");
+            final var memberId = memberRepository.save(member).getId();
+
+            final var expected = memberRepository.findById(memberId).get();
+            final var expectedNickname = expected.getNickname();
+            final var expectedProfileImage = expected.getProfileImage();
+
+            // when
+            memberService.modify(memberId, request);
+            final var actual = memberRepository.findById(memberId).get();
+            final var actualNickname = actual.getNickname();
+            final var actualProfileImage = actual.getProfileImage();
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(actualNickname).isNotEqualTo(expectedNickname);
+                softAssertions.assertThat(actualProfileImage).isEqualTo(expectedProfileImage);
+            });
+        }
+
+        @Test
+        void 닉네임은_그대로이고_프로필_사진이_바뀌면_프로필_사진만_바뀐다() {
+            // given
+            final var nickname = "test";
+            final var beforeProfileImage = "http://www.before.com";
+            final var afterProfileImage = "http://www.after.com";
+
+            final MemberRequest request = new MemberRequest(nickname, afterProfileImage);
+
+            final var member = new Member(nickname, beforeProfileImage, "1");
+            final var memberId = memberRepository.save(member).getId();
+
+            final var expected = memberRepository.findById(memberId).get();
+            final var expectedNickname = expected.getNickname();
+            final var expectedProfileImage = expected.getProfileImage();
+
+            // when
+            memberService.modify(memberId, request);
+            final var actual = memberRepository.findById(memberId).get();
+            final var actualNickname = actual.getNickname();
+            final var actualProfileImage = actual.getProfileImage();
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(actualNickname).isEqualTo(expectedNickname);
+                softAssertions.assertThat(actualProfileImage).isNotEqualTo(expectedProfileImage);
+            });
+        }
+
+        @Test
+        void 닉네임과_프로필_사진_모두_바뀌면_모두_바뀐다() {
+            // given
+            final var beforeNickname = "before";
+            final var afterNickname = "after";
+            final var beforeProfileImage = "http://www.before.com";
+            final var afterProfileImage = "http://www.after.com";
+
+            final MemberRequest request = new MemberRequest(afterNickname, afterProfileImage);
+
+            final var member = new Member(beforeNickname, beforeProfileImage, "1");
+            final var memberId = memberRepository.save(member).getId();
+
+            final var expected = memberRepository.findById(memberId).get();
+            final var expectedNickname = expected.getNickname();
+            final var expectedProfileImage = expected.getProfileImage();
+
+            // when
+            memberService.modify(memberId, request);
+            final var actual = memberRepository.findById(memberId).get();
+            final var actualNickname = actual.getNickname();
+            final var actualProfileImage = actual.getProfileImage();
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(actualNickname).isNotEqualTo(expectedNickname);
+                softAssertions.assertThat(actualProfileImage).isNotEqualTo(expectedProfileImage);
             });
         }
     }

--- a/backend/src/test/java/com/funeat/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/funeat/member/application/MemberServiceTest.java
@@ -1,13 +1,13 @@
 package com.funeat.member.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.funeat.auth.dto.UserInfoDto;
 import com.funeat.common.DataClearExtension;
 import com.funeat.member.domain.Member;
 import com.funeat.member.dto.MemberRequest;
 import com.funeat.member.persistence.MemberRepository;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -47,7 +47,7 @@ class MemberServiceTest {
             final var actual = memberService.findOrCreateMember(userInfoDto);
 
             // then
-            SoftAssertions.assertSoftly(softAssertions -> {
+            assertSoftly(softAssertions -> {
                 Assertions.assertFalse(actual.isSignIn());
                 assertThat(expected).containsExactly(actual.getMember());
             });
@@ -66,7 +66,7 @@ class MemberServiceTest {
             final var actual = memberService.findOrCreateMember(userInfoDto);
 
             // then
-            SoftAssertions.assertSoftly(softAssertions -> {
+            assertSoftly(softAssertions -> {
                 Assertions.assertTrue(actual.isSignIn());
                 assertThat(expected).doesNotContain(actual.getMember());
             });
@@ -97,7 +97,7 @@ class MemberServiceTest {
             final var actualProfileImage = actual.getProfileImage();
 
             // then
-            SoftAssertions.assertSoftly(softAssertions -> {
+            assertSoftly(softAssertions -> {
                 softAssertions.assertThat(actualNickname).isEqualTo(expectedNickname);
                 softAssertions.assertThat(actualProfileImage).isEqualTo(expectedProfileImage);
             });
@@ -125,7 +125,7 @@ class MemberServiceTest {
             final var actualProfileImage = actual.getProfileImage();
 
             // then
-            SoftAssertions.assertSoftly(softAssertions -> {
+            assertSoftly(softAssertions -> {
                 softAssertions.assertThat(actualNickname).isNotEqualTo(expectedNickname);
                 softAssertions.assertThat(actualProfileImage).isEqualTo(expectedProfileImage);
             });
@@ -154,7 +154,7 @@ class MemberServiceTest {
             final var actualProfileImage = actual.getProfileImage();
 
             // then
-            SoftAssertions.assertSoftly(softAssertions -> {
+            assertSoftly(softAssertions -> {
                 softAssertions.assertThat(actualNickname).isEqualTo(expectedNickname);
                 softAssertions.assertThat(actualProfileImage).isNotEqualTo(expectedProfileImage);
             });
@@ -184,7 +184,7 @@ class MemberServiceTest {
             final var actualProfileImage = actual.getProfileImage();
 
             // then
-            SoftAssertions.assertSoftly(softAssertions -> {
+            assertSoftly(softAssertions -> {
                 softAssertions.assertThat(actualNickname).isNotEqualTo(expectedNickname);
                 softAssertions.assertThat(actualProfileImage).isNotEqualTo(expectedProfileImage);
             });

--- a/backend/src/test/java/com/funeat/member/domain/MemberTest.java
+++ b/backend/src/test/java/com/funeat/member/domain/MemberTest.java
@@ -1,0 +1,40 @@
+package com.funeat.member.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+public class MemberTest {
+
+    @Test
+    void 사용자의_닉네임을_변경할_수_있다() {
+        // given
+        final var member = new Member("test", "http://www.test.com", "1");
+        final var expected = "hello";
+
+        // when
+        member.modifyNickname(expected);
+        final var actual = member.getNickname();
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void 사용자의_프로필_이미지_주소를_변경할_수_있다() {
+        // given
+        final var member = new Member("test", "http://www.test.com", "1");
+        final var expected = "http://www.hello.com";
+
+        // when
+        member.modifyProfileImage(expected);
+        final var actual = member.getProfileImage();
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/com/funeat/member/domain/MemberTest.java
+++ b/backend/src/test/java/com/funeat/member/domain/MemberTest.java
@@ -1,6 +1,6 @@
 package com.funeat.member.domain;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -11,30 +11,21 @@ import org.junit.jupiter.api.Test;
 public class MemberTest {
 
     @Test
-    void 사용자의_닉네임을_변경할_수_있다() {
+    void 사용자의_닉네임과_이미지_주소를_변경할_수_있다() {
         // given
-        final var member = new Member("test", "http://www.test.com", "1");
-        final var expected = "hello";
+        final var member = new Member("before", "http://www.before.com", "1");
+        final var expectedNickname = "after";
+        final var expectedProfileImage = "http://www.after.com";
 
         // when
-        member.modifyNickname(expected);
-        final var actual = member.getNickname();
+        member.modifyProfile(expectedNickname, expectedProfileImage);
+        final var actualNickname = member.getNickname();
+        final var actualProfileImage = member.getProfileImage();
 
         // then
-        assertThat(actual).isEqualTo(expected);
-    }
-
-    @Test
-    void 사용자의_프로필_이미지_주소를_변경할_수_있다() {
-        // given
-        final var member = new Member("test", "http://www.test.com", "1");
-        final var expected = "http://www.hello.com";
-
-        // when
-        member.modifyProfileImage(expected);
-        final var actual = member.getProfileImage();
-
-        // then
-        assertThat(actual).isEqualTo(expected);
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actualNickname).isEqualTo(expectedNickname);
+            softAssertions.assertThat(actualProfileImage).isEqualTo(expectedProfileImage);
+        });
     }
 }


### PR DESCRIPTION
## Issue

- close #184 

## ✨ 구현한 기능

- 닉네임, 프로필사진을 가지고 오면 내용을 수정하는 로직을 추가했습니다.

## 📢 논의하고 싶은 내용

- x

## 🎸 기타

- x

## ⏰ 일정

- 추정 시간 : 1
- 걸린 시간 : 0.8
