### PR TITLE
[FE] feat: 웹 접근성 추가

### DIFF
--- a/frontend/src/components/Common/CategoryMenu/CategoryMenu.tsx
+++ b/frontend/src/components/Common/CategoryMenu/CategoryMenu.tsx
@@ -30,6 +30,7 @@ const CategoryMenu = ({ menuList, menuVariant }: CategoryMenuProps) => {
               isSelected={isSelected}
               menuVariant={menuVariant}
               onClick={() => selectCategory(menuVariant, menu.id)}
+              aria-pressed={isSelected}
             >
               {menu.name}
             </CategoryButton>

--- a/frontend/src/components/Common/TabMenu/TabMenu.tsx
+++ b/frontend/src/components/Common/TabMenu/TabMenu.tsx
@@ -1,4 +1,4 @@
-import { Button, useTheme } from '@fun-eat/design-system';
+import { Button } from '@fun-eat/design-system';
 import { useState } from 'react';
 import styled from 'styled-components';
 
@@ -8,7 +8,6 @@ interface TabMenuProps {
 
 const TabMenu = ({ tabMenus }: TabMenuProps) => {
   const [selectedTab, setSelectedTab] = useState(0);
-  const theme = useTheme();
 
   const selectTabMenu = (selectedIndex: number) => {
     setSelectedTab(selectedIndex);
@@ -19,12 +18,7 @@ const TabMenu = ({ tabMenus }: TabMenuProps) => {
       {tabMenus.map((menu, index) => {
         const isSelected = selectedTab === index;
         return (
-          <TabMenuItem
-            key={menu}
-            css={`
-              border-bottom: 2px solid ${isSelected ? theme.borderColors.strong : theme.borderColors.disabled};
-            `}
-          >
+          <TabMenuItem key={menu} isSelected={isSelected}>
             <TabMenuButton
               type="button"
               customWidth="100%"
@@ -49,10 +43,12 @@ const TabMenuContainer = styled.ul`
   display: flex;
 `;
 
-const TabMenuItem = styled.li`
+const TabMenuItem = styled.li<{ isSelected: boolean }>`
   flex-grow: 1;
   width: 50%;
   height: 45px;
+  border-bottom: 2px solid
+    ${({ isSelected, theme }) => (isSelected ? theme.borderColors.strong : theme.borderColors.disabled)};
 `;
 
 const TabMenuButton = styled(Button)`

--- a/frontend/src/components/Common/Title/Title.tsx
+++ b/frontend/src/components/Common/Title/Title.tsx
@@ -14,7 +14,7 @@ const Title = ({ headingTitle }: TitleProps) => {
 
   return (
     <TitleContainer>
-      <Button type="button" variant="transparent" onClick={routeBack}>
+      <Button type="button" variant="transparent" onClick={routeBack} aria-label="뒤로 가기">
         <SvgIconWrapper>
           <SvgIcon variant="arrow" color={theme.colors.gray5} width={20} height={20} />
         </SvgIconWrapper>

--- a/frontend/src/components/Product/PBProductItem/PBProductItem.tsx
+++ b/frontend/src/components/Product/PBProductItem/PBProductItem.tsx
@@ -13,13 +13,13 @@ const PBProductItem = ({ pbProduct }: PBProductItemProps) => {
 
   return (
     <PBProductItemContainer>
-      <PBProductImage src={image} alt={name} width={110} height={110} />
+      <PBProductImage src={image} alt={`${name}사진`} width={110} height={110} />
       <PBProductInfoWrapper>
         <PBProductName weight="bold">{name}</PBProductName>
         <PBProductReviewWrapper>
           <RatingWrapper>
             <SvgIcon variant="star" color={theme.colors.secondary} width={18} height={18} />
-            <Text as="span" size="sm" weight="bold" color={theme.textColors.info}>
+            <Text as="span" size="sm" weight="bold" color={theme.textColors.info} aria-label={`${averageRating}점`}>
               {averageRating}
             </Text>
           </RatingWrapper>

--- a/frontend/src/components/Product/ProductDetailItem/ProductDetailItem.tsx
+++ b/frontend/src/components/Product/ProductDetailItem/ProductDetailItem.tsx
@@ -25,7 +25,7 @@ const ProductDetailItem = ({ product }: ProductDetailProps) => {
           <Text weight="bold">상품 설명</Text>
           <Text>{content}</Text>
         </DescriptionWrapper>
-        <DescriptionWrapper>
+        <DescriptionWrapper aria-label={`평균 평점 ${averageRating}점`}>
           <Text weight="bold">평균 평점</Text>
           <RatingIconWrapper>
             <SvgIcon variant="star" width={20} height={20} color={theme.colors.secondary} />

--- a/frontend/src/components/Product/ProductItem/ProductItem.tsx
+++ b/frontend/src/components/Product/ProductItem/ProductItem.tsx
@@ -14,7 +14,7 @@ const ProductItem = ({ product }: ProductItemProps) => {
 
   return (
     <ProductItemContainer>
-      <img src={image} width={90} height={90} alt={name} />
+      <img src={image} width={90} height={90} alt={`${name}사진`} />
       <ProductInfoWrapper>
         <Text size="lg" weight="bold">
           {name}
@@ -25,13 +25,13 @@ const ProductItem = ({ product }: ProductItemProps) => {
         <ProductReviewWrapper>
           <RatingIconWrapper>
             <SvgIcon variant="star" width={20} height={20} color={theme.colors.secondary} />
-            <Text as="span" size="sm" css="line-height: 24px;">
+            <Text as="span" size="sm" css="line-height: 24px;" aria-label={`${averageRating}점`}>
               {averageRating}
             </Text>
           </RatingIconWrapper>
           <ReviewIconWrapper>
             <SvgIcon variant="review" width={20} height={20} color={theme.colors.gray5} />
-            <Text as="span" size="sm" css="line-height: 24px">
+            <Text as="span" size="sm" css="line-height: 24px" aria-label={`리뷰 ${reviewCount}개`}>
               {reviewCount}
             </Text>
           </ReviewIconWrapper>

--- a/frontend/src/components/Product/ProductOverviewItem/ProductOverviewItem.tsx
+++ b/frontend/src/components/Product/ProductOverviewItem/ProductOverviewItem.tsx
@@ -13,7 +13,7 @@ const ProductOverviewItem = ({ rank, name, image }: ProductOverviewItemProps) =>
       <Text size="lg" weight="bold" align="center">
         {rank ?? ''}
       </Text>
-      <ProductOverviewImage src={image} alt={rank ? `${rank}위 상품` : name} />
+      <ProductOverviewImage src={image} alt={rank ? `${rank}위 상품` : `${name}사진`} />
       <Text size="lg" weight="bold" align="center">
         {name}
       </Text>

--- a/frontend/src/components/Product/ProductTitle/ProductTitle.tsx
+++ b/frontend/src/components/Product/ProductTitle/ProductTitle.tsx
@@ -15,14 +15,14 @@ const ProductTitle = ({ name, bookmark }: ProductTitleProps) => {
   return (
     <ProductTitleContainer>
       <ProductTitleWrapper>
-        <Button type="button" variant="transparent" onClick={routeBack}>
+        <Button type="button" variant="transparent" onClick={routeBack} aria-label="뒤로 가기">
           <SvgIcon variant="arrow" color={theme.colors.gray5} width={15} height={15} />
         </Button>
         <Heading size="xl" css="margin-left: 20px">
           {name}
         </Heading>
       </ProductTitleWrapper>
-      <Button type="button" customWidth="32px" variant="transparent">
+      <Button type="button" customWidth="32px" variant="transparent" aria-label="북마크">
         <SvgIcon
           variant={bookmark ? 'bookmarkFilled' : 'bookmark'}
           color={bookmark ? theme.colors.primary : theme.colors.gray5}

--- a/frontend/src/components/Rank/ReviewRankingItem/ReviewRankingItem.tsx
+++ b/frontend/src/components/Rank/ReviewRankingItem/ReviewRankingItem.tsx
@@ -21,13 +21,13 @@ const ReviewRankingItem = ({ reviewRanking }: ReviewRankingItemProps) => {
       </ReviewText>
       <Spacing size={4} />
       <FavoriteStarWrapper>
-        <FavoriteIconWrapper>
+        <FavoriteIconWrapper aria-label={`좋아요 ${favoriteCount}개`}>
           <SvgIcon variant="favoriteFilled" color="red" width={11} height={13} />
           <Text size="xs" weight="bold">
             {favoriteCount}
           </Text>
         </FavoriteIconWrapper>
-        <RatingIconWrapper>
+        <RatingIconWrapper aria-label={`${rating.toFixed(1)}점`}>
           <SvgIcon variant="star" color={theme.colors.secondary} width={16} height={16} />
           <Text size="xs" weight="bold">
             {rating.toFixed(1)}

--- a/frontend/src/components/Review/ReviewItem/ReviewItem.tsx
+++ b/frontend/src/components/Review/ReviewItem/ReviewItem.tsx
@@ -44,21 +44,20 @@ const ReviewItem = ({ productId, review }: ReviewItemProps) => {
           </div>
         </ReviewerInfoWrapper>
         {rebuy && (
-          <Badge
-            color={theme.colors.primary}
-            textColor={theme.textColors.default}
-            css={`
-              font-weight: ${theme.fontWeights.bold};
-            `}
-          >
+          <RebuyBadge color={theme.colors.primary} textColor={theme.textColors.default}>
             😝 또 살래요
-          </Badge>
+          </RebuyBadge>
         )}
       </ReviewerWrapper>
       {image !== null && <ReviewImage src={image} height={150} alt={`${userName}의 리뷰`} />}
       <TagList tags={tags} />
       <Text css="white-space: pre-wrap">{content}</Text>
-      <FavoriteButton type="button" variant="transparent" onClick={handleToggleFavorite}>
+      <FavoriteButton
+        type="button"
+        variant="transparent"
+        onClick={handleToggleFavorite}
+        aria-label={`좋아요 ${favoriteCount}개`}
+      >
         <SvgIcon variant={favorite ? 'favoriteFilled' : 'favorite'} color={favorite ? 'red' : theme.colors.gray4} />
         <Text as="span" weight="bold">
           {favoriteCount}
@@ -86,6 +85,10 @@ const ReviewerInfoWrapper = styled.div`
   display: flex;
   align-items: center;
   column-gap: 10px;
+`;
+
+const RebuyBadge = styled(Badge)`
+  font-weight: ${({ theme }) => theme.fontWeights.bold};
 `;
 
 const ReviewerImage = styled.img`

--- a/frontend/src/components/Review/ReviewRegisterForm/ReviewRegisterForm.tsx
+++ b/frontend/src/components/Review/ReviewRegisterForm/ReviewRegisterForm.tsx
@@ -19,7 +19,7 @@ const ReviewRegisterForm = ({ product, close }: ReviewRegisterFormProps) => {
   return (
     <ReviewRegisterFormContainer>
       <ReviewHeading>리뷰 작성</ReviewHeading>
-      <CloseButton variant="transparent" onClick={close}>
+      <CloseButton variant="transparent" onClick={close} aria-label="닫기">
         <SvgIcon variant="close" color={theme.colors.black} width={20} height={20} />
       </CloseButton>
       <Divider />

--- a/frontend/src/components/Review/ReviewTagList/ReviewTagList.tsx
+++ b/frontend/src/components/Review/ReviewTagList/ReviewTagList.tsx
@@ -67,7 +67,13 @@ const ReviewTagList = () => {
       </TagListWrapper>
       <Spacing size={26} />
       {canShowMore && (
-        <Button type="button" customHeight="fit-content" variant="transparent" onClick={showMoreTags}>
+        <Button
+          type="button"
+          customHeight="fit-content"
+          variant="transparent"
+          onClick={showMoreTags}
+          aria-label="태그 더보기"
+        >
           <SvgWrapper>
             <SvgIcon variant="arrow" width={15} />
           </SvgWrapper>

--- a/frontend/src/components/Review/StarRate/StarRate.tsx
+++ b/frontend/src/components/Review/StarRate/StarRate.tsx
@@ -26,6 +26,7 @@ const StarRate = () => {
             onClick={() => handleRating(star)}
             onMouseEnter={() => handleMouseEnter(star)}
             onMouseLeave={handleMouseLeave}
+            aria-label={`별점 ${star}점`}
           >
             <SvgIconWrapper
               variant="star"


### PR DESCRIPTION
## Issue

- close #163 

## ✨ 구현한 기능

svg 컴포넌트에 aria lable을 붙였습니다.
그 외에도 눈에 보이는 웹 접근성 부분을 추가하였습니다.

스크린 리더에는 브라우저 모드와 포커스 모드가 있습니다.
브라우저 모드는 html을 다 읽는 거 같고, 포커스 모드는 버튼이나 링크처럼 포커스 되는 부분을 읽는 거 같아요.
맥북 내장인 보이스 오버는 둘 다 지원한다고 하는데 여기서는 지금 포커스 모드만 읽네요.
그래서 현재 되는 부분만 먼저 웹 접근성을 고려하여 작성하였습니다.

이번 데모데이에 시연을 해야하는데 핵심 기능이라고 되어있기에 리뷰 작성 부분에 웹 접근성을 고려해보려고 합니다.
아직 리뷰 작성 기능이 완성되지 않아 완성 후 작성해보겠습니다.

## 📢 논의하고 싶은 내용

x

## 🎸 기타

x

## ⏰ 일정

- 추정 시간 : 2시간
- 걸린 시간 : 1시간 반
