### PR TITLE
[FE] feat: 리뷰 작성 페이지 웹 접근성 고려

### DIFF
--- a/frontend/src/components/Product/ProductOverviewItem/ProductOverviewItem.tsx
+++ b/frontend/src/components/Product/ProductOverviewItem/ProductOverviewItem.tsx
@@ -9,12 +9,12 @@ interface ProductOverviewItemProps {
 
 const ProductOverviewItem = ({ rank, name, image }: ProductOverviewItemProps) => {
   return (
-    <ProductOverviewContainer rank={rank}>
+    <ProductOverviewContainer rank={rank} tabIndex={0}>
       <Text size="lg" weight="bold" align="center">
         {rank ?? ''}
       </Text>
       <ProductOverviewImage src={image} alt={rank ? `${rank}위 상품` : `${name}사진`} />
-      <Text size="lg" weight="bold" align="center">
+      <Text size="lg" weight="bold" align="center" aria-label={name}>
         {name}
       </Text>
     </ProductOverviewContainer>

--- a/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
+++ b/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
@@ -1,6 +1,8 @@
 import { Button, Heading, Spacing, Text, useTheme } from '@fun-eat/design-system';
-import type { ChangeEventHandler } from 'react';
+import { type ChangeEventHandler } from 'react';
 import styled from 'styled-components';
+
+import useEnterKeyDown from '@/hooks/useEnterKeyDown';
 
 interface ReviewImageUploaderProps {
   reviewImage: string;
@@ -15,6 +17,7 @@ const ReviewImageUploader = ({
   deleteReviewImage,
   uploadImageFile,
 }: ReviewImageUploaderProps) => {
+  const { inputRef, handleKeydown } = useEnterKeyDown();
   const theme = useTheme();
 
   const handle: ChangeEventHandler<HTMLInputElement> = (event) => {
@@ -47,9 +50,9 @@ const ReviewImageUploader = ({
           </Button>
         </ReviewImageButtonWrapper>
       ) : (
-        <ImageUploadLabel tabIndex={0} aria-label="사진 업로드 버튼">
+        <ImageUploadLabel tabIndex={0} onKeyDown={handleKeydown} aria-label="사진 업로드 버튼">
           +
-          <input type="file" accept="image/*" onChange={handle} />
+          <input ref={inputRef} type="file" accept="image/*" onChange={handle} />
         </ImageUploadLabel>
       )}
     </ReviewImageUploaderContainer>

--- a/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
+++ b/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
@@ -21,11 +21,13 @@ const ReviewImageUploader = () => {
 
   return (
     <ReviewImageUploaderContainer>
-      <Heading as="h2" size="xl">
+      <Heading as="h2" size="xl" tabIndex={0}>
         구매한 상품 사진이 있다면 올려주세요.
       </Heading>
       <Spacing size={2} />
-      <Text color={theme.textColors.disabled}>(사진은 1장까지 업로드 할 수 있어요)</Text>
+      <Text color={theme.textColors.disabled} tabIndex={0}>
+        (사진은 1장까지 업로드 할 수 있어요)
+      </Text>
       <Spacing size={20} />
       {reviewImage ? (
         <ReviewImageButtonWrapper>
@@ -42,7 +44,7 @@ const ReviewImageUploader = () => {
           </Button>
         </ReviewImageButtonWrapper>
       ) : (
-        <ImageUploadLabel>
+        <ImageUploadLabel tabIndex={0} aria-label="사진 업로드 버튼">
           +
           <input type="file" accept="image/*" onChange={uploadReviewImage} />
         </ImageUploadLabel>

--- a/frontend/src/components/Review/ReviewRegisterForm/ReviewRegisterForm.tsx
+++ b/frontend/src/components/Review/ReviewRegisterForm/ReviewRegisterForm.tsx
@@ -13,6 +13,7 @@ import { MIN_DISPLAYED_TAGS_LENGTH } from '@/constants';
 import { useReviewTextarea, useSelectedTags } from '@/hooks/review';
 import useReviewImageUploader from '@/hooks/review/useReviewImageUploader';
 import useReviewRegisterForm from '@/hooks/review/useReviewRegisterForm';
+import useEnterKeyDown from '@/hooks/useEnterKeyDown';
 import useStarRating from '@/hooks/useStarRate';
 import type { ProductDetail } from '@/types/product';
 
@@ -32,6 +33,8 @@ const ReviewRegisterForm = ({ product, close }: ReviewRegisterFormProps) => {
   const { selectedTags, toggleTagSelection } = useSelectedTags(MIN_DISPLAYED_TAGS_LENGTH);
   const { content, handleReviewInput } = useReviewTextarea();
   const [reBuy, setReBuy] = useState(false);
+
+  const { inputRef, handleKeydown } = useEnterKeyDown();
   const [submitEnabled, setSubmitEnabled] = useState(false);
 
   const { request } = useReviewRegisterForm(product.id);
@@ -198,11 +201,10 @@ const ReviewRegisterForm = ({ product, close }: ReviewRegisterFormProps) => {
         <Spacing size={60} />
         <ReviewTextarea content={content} onReviewInput={handleReviewInput} />
         <Spacing size={80} />
-        <p tabIndex={0}>
-          <Checkbox weight="bold" onChange={handleRebuy}>
-            재구매할 생각이 있으신가요?
-          </Checkbox>
-        </p>
+        {/* TODO: ref랑 tabindex 추가해주세요 */}
+        <Checkbox weight="bold" onChange={handleRebuy}>
+          재구매할 생각이 있으신가요?
+        </Checkbox>
         <Spacing size={16} />
         <FormButton
           type="submit"

--- a/frontend/src/components/Review/ReviewRegisterForm/ReviewRegisterForm.tsx
+++ b/frontend/src/components/Review/ReviewRegisterForm/ReviewRegisterForm.tsx
@@ -18,7 +18,7 @@ interface ReviewRegisterFormProps {
 const ReviewRegisterForm = ({ product, close }: ReviewRegisterFormProps) => {
   return (
     <ReviewRegisterFormContainer>
-      <ReviewHeading>리뷰 작성</ReviewHeading>
+      <ReviewHeading tabIndex={0}>리뷰 작성</ReviewHeading>
       <CloseButton variant="transparent" onClick={close} aria-label="닫기">
         <SvgIcon variant="close" color={theme.colors.black} width={20} height={20} />
       </CloseButton>
@@ -36,7 +36,9 @@ const ReviewRegisterForm = ({ product, close }: ReviewRegisterFormProps) => {
         <Spacing size={60} />
         <ReviewTextarea />
         <Spacing size={80} />
-        <Checkbox weight="bold">재구매할 생각이 있으신가요?</Checkbox>
+        <p tabIndex={0}>
+          <Checkbox weight="bold">재구매할 생각이 있으신가요?</Checkbox>
+        </p>
         <Spacing size={16} />
         <Button customWidth="100%" customHeight="60px" size="xl" weight="bold">
           등록하기

--- a/frontend/src/components/Review/ReviewTagList/ReviewTagList.tsx
+++ b/frontend/src/components/Review/ReviewTagList/ReviewTagList.tsx
@@ -35,16 +35,16 @@ const ReviewTagList = () => {
 
   return (
     <ReviewTagListContainer>
-      <Heading as="h2" size="xl">
+      <Heading as="h2" size="xl" tabIndex={0}>
         태그를 골라주세요. (3개)
-        <RequiredMark>*</RequiredMark>
+        <RequiredMark aria-label="필수 작성">*</RequiredMark>
       </Heading>
       <Spacing size={25} />
       <TagListWrapper>
         {tagsData.map(({ tagType, tags }) => {
           return (
             <TagItemWrapper key={tagType}>
-              <TagTitle as="h3" size="md">
+              <TagTitle as="h3" size="md" tabIndex={0}>
                 {TAG_TITLE[tagType]}
               </TagTitle>
               <Spacing size={20} />
@@ -129,5 +129,6 @@ const TagTitle = styled(Heading)`
 `;
 
 const SvgWrapper = styled.span`
+  display: inline-block;
   transform: rotate(270deg);
 `;

--- a/frontend/src/components/Review/ReviewTextarea/ReviewTextarea.tsx
+++ b/frontend/src/components/Review/ReviewTextarea/ReviewTextarea.tsx
@@ -15,9 +15,9 @@ const ReviewTextarea = () => {
 
   return (
     <ReviewTextareaContainer>
-      <Heading as="h2" size="xl">
+      <Heading as="h2" size="xl" tabIndex={0}>
         리뷰를 남겨주세요.
-        <RequiredMark>*</RequiredMark>
+        <RequiredMark aria-label="필수 작성">*</RequiredMark>
       </Heading>
       <Spacing size={20} />
       <Textarea
@@ -29,8 +29,8 @@ const ReviewTextarea = () => {
         onChange={handleReviewInput}
       />
       <Spacing size={16} />
-      <ReviewWritingStatusText color={theme.textColors.info}>
-        작성한 글자 수: {reviewValue.length} / {MAX_LENGTH}
+      <ReviewWritingStatusText color={theme.textColors.info} tabIndex={0}>
+        작성한 글자 수: {reviewValue.length}자 / {MAX_LENGTH}자
       </ReviewWritingStatusText>
     </ReviewTextareaContainer>
   );

--- a/frontend/src/components/Review/StarRate/StarRate.tsx
+++ b/frontend/src/components/Review/StarRate/StarRate.tsx
@@ -11,9 +11,9 @@ const StarRate = () => {
 
   return (
     <StarRateContainer>
-      <Heading as="h2" size="xl">
+      <Heading as="h2" size="xl" tabIndex={0}>
         별점을 남겨주세요.
-        <RequiredMark>*</RequiredMark>
+        <RequiredMark aria-label="필수 작성">*</RequiredMark>
       </Heading>
       <Spacing size={20} />
       <div>

--- a/frontend/src/hooks/useEnterKeyDown.ts
+++ b/frontend/src/hooks/useEnterKeyDown.ts
@@ -1,0 +1,17 @@
+import type { KeyboardEventHandler } from 'react';
+import { useRef } from 'react';
+
+const useEnterKeyDown = () => {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleKeydown: KeyboardEventHandler<HTMLLabelElement> = (e) => {
+    if (e.keyCode === 13) {
+      e.preventDefault();
+      inputRef.current?.click();
+    }
+  };
+
+  return { inputRef, handleKeydown };
+};
+
+export default useEnterKeyDown;


### PR DESCRIPTION
## Issue

- close #226 

## ✨ 구현한 기능

리뷰 작성 페이지의 웹 접근성을 고려하였습니다.
스크린 리더 외에도 키보드만으로 작성이 가능하도록 구현하였습니다.

현재 별점을 클릭했을 때 바로 알려주는 기능과 (아마 대한항공처럼 polite나 assertive 쓰면 될 거 같음. 근데 제대로 작동할 지 모름)
태그 더보기 버튼을 클릭했을 때 추가된 태그로 포커스가 가는 기능은 황펭이 이어서 작업해줄 예정입니다.

## 📢 논의하고 싶은 내용

태그 읽을 때 이모지는 안 읽게 하는 건 실패했습니다.
막 '도넛 단짠단짠' 이렇게 읽는데 이게 백에서 태그 이름이 내려오는거다보니 우리가 처리할 수 있는 방법이 안 떠오르더라구요.
근데 또 아이폰에서는 이모지도 읽어준다는 이야기를 듣고 굳이 안 읽게 만들어야하나 생각도 드네요?

## 🎸 기타

x

## ⏰ 일정

- 추정 시간 : 2시간
- 걸린 시간 : 2시간
