### PR TITLE
[BE] refactor: 트랜잭션을 팀 컨벤션에 맞게 리팩터링

### DIFF
--- a/backend/src/main/java/com/funeat/auth/application/AuthService.java
+++ b/backend/src/main/java/com/funeat/auth/application/AuthService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class AuthService {
 
     private final MemberService memberService;

--- a/backend/src/main/java/com/funeat/member/application/MemberService.java
+++ b/backend/src/main/java/com/funeat/member/application/MemberService.java
@@ -1,7 +1,5 @@
 package com.funeat.member.application;
 
-import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
-
 import com.funeat.auth.dto.SignUserDto;
 import com.funeat.auth.dto.UserInfoDto;
 import com.funeat.member.domain.Member;
@@ -12,7 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class MemberService {
 
     private final MemberRepository memberRepository;
@@ -21,6 +19,7 @@ public class MemberService {
         this.memberRepository = memberRepository;
     }
 
+    @Transactional
     public SignUserDto findOrCreateMember(final UserInfoDto userInfoDto) {
         final String platformId = userInfoDto.getId().toString();
 
@@ -29,8 +28,7 @@ public class MemberService {
                 .orElseGet(() -> save(userInfoDto));
     }
 
-    @Transactional(propagation = REQUIRES_NEW)
-    public SignUserDto save(final UserInfoDto userInfoDto) {
+    private SignUserDto save(final UserInfoDto userInfoDto) {
         final Member member = userInfoDto.toMember();
         memberRepository.save(member);
 


### PR DESCRIPTION
## Issue

- close #283

## ✨ 구현한 기능

- 클래스단에 readOnly = true 추가
- findOrCreateMember에 `@Transactional` 추가
- save에 `@Transactional(propagtion=REQUIRES_NEW)` 제거

같은 클래스에서 findOrCreateMember 호출하고, 내부에서 save를 호출하면 `@Transactional`이 적용되지 않습니다.
왜냐하면 [스프링 트랜잭션 공식 문서](https://docs.spring.io/spring-framework/reference/data-access/transaction/declarative/annotations.html)에서 아래와 같은 내용이 나와있습니다.
그래서 프록시로 호출하기 때문에 같은 클래스 내부에 부모 메서드 호출 -> 자식 메서드를 호출하면 자식 메서드에 적혀있는 트랜잭션이 무시됩니다.

>In proxy mode (which is the default), only external method calls coming in through the proxy are intercepted.
This means that self-invocation (in effect, a method within the target object calling another method of the target object) does not lead to an actual transaction at runtime even if the invoked method is marked with @Transactional.
Also, the proxy must be fully initialized to provide the expected behavior, so you should not rely on this feature in your initialization code — for example, in a @PostConstruct method.

만약 이게 적용이 안된다면 findOrCreateMember에 `@Transactional`이 아닌 `@Transactional(propagation=REQUIRES_NEW)`로 설정해야합니다.
- `REQUIRES_NEW` : 부모 트랜잭션이 존재하면, 부모 트랜잭션을 중지하고, 새로운 트랜잭션을 생성함


## 📢 논의하고 싶은 내용

- 논의하고 싶은 내용을 작성합니다.

## 🎸 기타

- 특이 사항이 있으면 작성합니다.

## ⏰ 일정

- 추정 시간 :
- 걸린 시간 :
