### PR TITLE
[BE] fix: 로그인된 회원 기준으로 좋아요 조회되게 수정

### DIFF
--- a/backend/src/main/java/com/funeat/member/domain/favorite/ReviewFavorite.java
+++ b/backend/src/main/java/com/funeat/member/domain/favorite/ReviewFavorite.java
@@ -40,17 +40,20 @@ public class ReviewFavorite {
         reviewFavorite.review.getReviewFavorites().add(reviewFavorite);
         reviewFavorite.member.getReviewFavorites().add(reviewFavorite);
         reviewFavorite.favorite = favorite;
+        reviewFavorite.review.addFavoriteCount();
         return reviewFavorite;
     }
 
     public void updateChecked(final Boolean favorite) {
-        this.favorite = favorite;
-        if (favorite) {
+        if (!this.favorite && favorite) {
             this.review.addFavoriteCount();
+            this.favorite = favorite;
             return;
         }
-        this.review.minusFavoriteCount();
-
+        if (this.favorite && !favorite) {
+            this.review.minusFavoriteCount();
+            this.favorite = favorite;
+        }
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/funeat/review/application/ReviewService.java
+++ b/backend/src/main/java/com/funeat/review/application/ReviewService.java
@@ -106,8 +106,10 @@ public class ReviewService {
         return reviewFavoriteRepository.save(reviewFavorite);
     }
 
-    public SortingReviewsResponse sortingReviews(final Long productId,
-                                                 final Pageable pageable) {
+    public SortingReviewsResponse sortingReviews(final Long productId, final Pageable pageable, final Long memberId) {
+        final Member member = memberRepository.findById(memberId)
+                .orElseThrow(IllegalArgumentException::new);
+
         final Product product = productRepository.findById(productId)
                 .orElseThrow(IllegalArgumentException::new);
 
@@ -115,7 +117,7 @@ public class ReviewService {
 
         final SortingReviewsPageDto pageDto = SortingReviewsPageDto.toDto(reviewPage);
         final List<SortingReviewDto> reviewDtos = reviewPage.stream()
-                .map(SortingReviewDto::toDto)
+                .map(review -> SortingReviewDto.toDto(review, member))
                 .collect(Collectors.toList());
 
         return SortingReviewsResponse.toResponse(pageDto, reviewDtos);

--- a/backend/src/main/java/com/funeat/review/presentation/ReviewApiController.java
+++ b/backend/src/main/java/com/funeat/review/presentation/ReviewApiController.java
@@ -55,7 +55,7 @@ public class ReviewApiController implements ReviewController {
     public ResponseEntity<SortingReviewsResponse> getSortingReviews(@AuthenticationPrincipal LoginInfo loginInfo,
                                                                     @PathVariable Long productId,
                                                                     @PageableDefault Pageable pageable) {
-        final SortingReviewsResponse response = reviewService.sortingReviews(productId, pageable);
+        final SortingReviewsResponse response = reviewService.sortingReviews(productId, pageable, loginInfo.getId());
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewDto.java
+++ b/backend/src/main/java/com/funeat/review/presentation/dto/SortingReviewDto.java
@@ -1,5 +1,6 @@
 package com.funeat.review.presentation.dto;
 
+import com.funeat.member.domain.Member;
 import com.funeat.member.domain.favorite.ReviewFavorite;
 import com.funeat.review.domain.Review;
 import com.funeat.review.domain.ReviewTag;
@@ -39,7 +40,7 @@ public class SortingReviewDto {
         this.createdAt = createdAt;
     }
 
-    public static SortingReviewDto toDto(final Review review) {
+    public static SortingReviewDto toDto(final Review review, final Member member) {
         return new SortingReviewDto(
                 review.getId(),
                 review.getMember().getNickname(),
@@ -50,7 +51,7 @@ public class SortingReviewDto {
                 review.getContent(),
                 review.getReBuy(),
                 review.getFavoriteCount(),
-                findReviewFavoriteChecked(review),
+                findReviewFavoriteChecked(review, member),
                 review.getCreatedAt()
         );
     }
@@ -62,11 +63,11 @@ public class SortingReviewDto {
                 .collect(Collectors.toList());
     }
 
-    private static boolean findReviewFavoriteChecked(final Review review) {
+    private static boolean findReviewFavoriteChecked(final Review review, final Member member) {
         return review.getReviewFavorites()
                 .stream()
                 .filter(reviewFavorite -> reviewFavorite.getReview().equals(review))
-                .filter(reviewFavorite -> reviewFavorite.getMember().equals(review.getMember()))
+                .filter(reviewFavorite -> reviewFavorite.getMember().equals(member))
                 .findFirst()
                 .map(ReviewFavorite::getFavorite)
                 .orElse(false);

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -161,7 +161,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
 
             // then
             STATUS_CODE를_검증한다(response, 정상_처리);
-            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, pageDto);
+            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, pageDto, member1);
         }
 
         @Test
@@ -196,7 +196,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
 
             // then
             STATUS_CODE를_검증한다(response, 정상_처리);
-            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, pageDto);
+            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, pageDto, member1);
         }
     }
 
@@ -233,7 +233,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
 
             // then
             STATUS_CODE를_검증한다(response, 정상_처리);
-            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
+            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page, member1);
         }
 
         @Test
@@ -268,7 +268,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
 
             // then
             STATUS_CODE를_검증한다(response, 정상_처리);
-            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
+            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page, member1);
         }
     }
 
@@ -305,7 +305,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
 
             // then
             STATUS_CODE를_검증한다(response, 정상_처리);
-            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
+            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page, member1);
         }
     }
 
@@ -342,7 +342,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
 
             // then
             STATUS_CODE를_검증한다(response, 정상_처리);
-            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
+            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page, member1);
         }
 
         @Test
@@ -377,7 +377,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
 
             // then
             STATUS_CODE를_검증한다(response, 정상_처리);
-            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page);
+            정렬된_리뷰_목록_조회_결과를_검증한다(response, sortingReviews, page, member1);
         }
     }
 
@@ -458,23 +458,21 @@ class ReviewAcceptanceTest extends AcceptanceTest {
                 .extract();
     }
 
-    private void 정렬된_리뷰_목록_조회_결과를_검증한다(final ExtractableResponse<Response> response,
-                                       final List<Review> reviews,
-                                       final SortingReviewsPageDto pageDto) {
+    private void 정렬된_리뷰_목록_조회_결과를_검증한다(final ExtractableResponse<Response> response, final List<Review> reviews,
+                                       final SortingReviewsPageDto pageDto, final Member member) {
         페이지를_검증한다(response, pageDto);
-        리뷰_목록을_검증한다(response, reviews);
+        리뷰_목록을_검증한다(response, reviews, member);
     }
 
-    private void 페이지를_검증한다(final ExtractableResponse<Response> response,
-                           final SortingReviewsPageDto expected) {
+    private void 페이지를_검증한다(final ExtractableResponse<Response> response, final SortingReviewsPageDto expected) {
         final var actual = response.jsonPath().getObject("page", SortingReviewsPageDto.class);
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
     }
 
-    private void 리뷰_목록을_검증한다(final ExtractableResponse<Response> response,
-                             final List<Review> reviews) {
+    private void 리뷰_목록을_검증한다(final ExtractableResponse<Response> response, final List<Review> reviews,
+                             final Member member) {
         final List<SortingReviewDto> expected = reviews.stream()
-                .map(SortingReviewDto::toDto)
+                .map(review -> SortingReviewDto.toDto(review, member))
                 .collect(Collectors.toList());
         final List<SortingReviewDto> actual = response.jsonPath().getList("reviews", SortingReviewDto.class);
         assertThat(actual).usingRecursiveComparison()
@@ -482,8 +480,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
                 .isEqualTo(expected);
     }
 
-    private void 리뷰_랭킹_조회_결과를_검증한다(final ExtractableResponse<Response> response,
-                                   final List<Review> reviews) {
+    private void 리뷰_랭킹_조회_결과를_검증한다(final ExtractableResponse<Response> response, final List<Review> reviews) {
         final var expected = reviews.stream()
                 .map(RankingReviewDto::toDto)
                 .collect(Collectors.toList());

--- a/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 
 import com.funeat.common.DataClearExtension;
 import com.funeat.member.domain.Member;
-import com.funeat.member.domain.favorite.ReviewFavorite;
 import com.funeat.member.persistence.MemberRepository;
 import com.funeat.member.persistence.ReviewFavoriteRepository;
 import com.funeat.product.domain.Product;
@@ -120,12 +119,8 @@ class ReviewServiceTest {
         final var reviewResult = reviewRepository.findAll().get(0);
 
         // then
-        final var expected = ReviewFavorite.createReviewFavoriteByMemberAndReview(member, savedReview, true);
         assertThat(reviewResult.getFavoriteCount()).isEqualTo(1L);
-        assertThat(reviewFavoriteResult).usingRecursiveComparison()
-                .ignoringExpectedNullFields()
-                .comparingOnlyFields("member", "review", "checked")
-                .isEqualTo(expected);
+        assertThat(reviewFavoriteResult.getFavorite()).isTrue();
     }
 
     @Test
@@ -154,12 +149,8 @@ class ReviewServiceTest {
         final var reviewResult = reviewRepository.findAll().get(0);
 
         // then
-        final var expected = ReviewFavorite.createReviewFavoriteByMemberAndReview(member, savedReview, false);
         assertThat(reviewResult.getFavoriteCount()).isEqualTo(0L);
-        assertThat(reviewFavoriteResult).usingRecursiveComparison()
-                .ignoringExpectedNullFields()
-                .comparingOnlyFields("member", "review", "checked")
-                .isEqualTo(expected);
+        assertThat(reviewFavoriteResult.getFavorite()).isFalse();
     }
 
     private MockMultipartFile 리뷰_페이크_사진_요청() {

--- a/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -195,11 +195,11 @@ class ReviewServiceTest {
 
             final var pageable = PageRequest.of(0, 2, Sort.by("favoriteCount").descending());
             final var expected = Stream.of(review1, review3)
-                    .map(SortingReviewDto::toDto)
+                    .map(review -> SortingReviewDto.toDto(review, member1))
                     .collect(Collectors.toList());
 
             // when
-            final var actual = reviewService.sortingReviews(product.getId(), pageable)
+            final var actual = reviewService.sortingReviews(product.getId(), pageable, member1.getId())
                     .getReviews();
 
             // then
@@ -226,11 +226,11 @@ class ReviewServiceTest {
 
             final var pageable = PageRequest.of(0, 2, Sort.by("rating").ascending());
             final var expected = Stream.of(review1, review3)
-                    .map(SortingReviewDto::toDto)
+                    .map(review -> SortingReviewDto.toDto(review, member1))
                     .collect(Collectors.toList());
 
             // when
-            final var actual = reviewService.sortingReviews(product.getId(), pageable)
+            final var actual = reviewService.sortingReviews(product.getId(), pageable, member1.getId())
                     .getReviews();
 
             // then
@@ -257,11 +257,11 @@ class ReviewServiceTest {
 
             final var pageable = PageRequest.of(0, 2, Sort.by("rating").descending());
             final var expected = Stream.of(review2, review3)
-                    .map(SortingReviewDto::toDto)
+                    .map(review -> SortingReviewDto.toDto(review, member1))
                     .collect(Collectors.toList());
 
             // when
-            final var actual = reviewService.sortingReviews(product.getId(), pageable)
+            final var actual = reviewService.sortingReviews(product.getId(), pageable, member1.getId())
                     .getReviews();
 
             // then
@@ -288,11 +288,11 @@ class ReviewServiceTest {
 
             final var pageable = PageRequest.of(0, 2, Sort.by("createdAt").descending());
             final var expected = Stream.of(review3, review2)
-                    .map(SortingReviewDto::toDto)
+                    .map(review -> SortingReviewDto.toDto(review, member1))
                     .collect(Collectors.toList());
 
             // when
-            final var actual = reviewService.sortingReviews(product.getId(), pageable)
+            final var actual = reviewService.sortingReviews(product.getId(), pageable, member1.getId())
                     .getReviews();
 
             // then


### PR DESCRIPTION
## Issue

- close #290 

## ✨ 구현한 기능

- 로그인된 회원 기준으로 좋아요 조회되게 수정

## 📢 논의하고 싶은 내용

- x

## 🎸 기타

- x

## ⏰ 일정

- 추정 시간 : 0.2
- 걸린 시간 : 0.2
