### PR TITLE
[FE] feat: 리뷰 상대 날짜 추가

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@fun-eat/design-system": "^0.3.8",
+    "dayjs": "^1.11.9",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.2",

--- a/frontend/src/components/Review/ReviewItem/ReviewItem.tsx
+++ b/frontend/src/components/Review/ReviewItem/ReviewItem.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { SvgIcon, TagList } from '@/components/Common';
 import { useReviewFavorite } from '@/hooks/review';
 import type { Review, ReviewFavoriteRequestBody } from '@/types/review';
+import { getRelativeDate } from '@/utils/relativeDate';
 
 interface ReviewItemProps {
   productId: number;
@@ -12,7 +13,8 @@ interface ReviewItemProps {
 }
 
 const ReviewItem = ({ productId, review }: ReviewItemProps) => {
-  const { id, userName, profileImage, image, rating, tags, content, rebuy, favoriteCount, favorite } = review;
+  const { id, userName, profileImage, image, rating, tags, content, createdAt, rebuy, favoriteCount, favorite } =
+    review;
   const [isFavorite, setIsFavorite] = useState(favorite);
 
   const { request } = useReviewFavorite<ReviewFavoriteRequestBody>(productId, id);
@@ -40,6 +42,9 @@ const ReviewItem = ({ productId, review }: ReviewItemProps) => {
                   height={16}
                 />
               ))}
+              <Text as="span" size="sm" color={theme.textColors.info}>
+                {getRelativeDate(createdAt)}
+              </Text>
             </RatingIconWrapper>
           </div>
         </ReviewerInfoWrapper>
@@ -100,6 +105,10 @@ const RatingIconWrapper = styled.div`
   display: flex;
   align-items: center;
   margin-left: -2px;
+
+  & > span {
+    margin-left: 12px;
+  }
 `;
 
 const ReviewImage = styled.img`

--- a/frontend/src/mocks/data/reviews.json
+++ b/frontend/src/mocks/data/reviews.json
@@ -16,6 +16,7 @@
       "rating": 5,
       "tags": [],
       "content": "우가우가~!~!",
+      "createdAt": "2023-08-03T13:10:06.379389",
       "rebuy": false,
       "favoriteCount": 150,
       "favorite": false
@@ -37,6 +38,7 @@
         }
       ],
       "content": "할머니가 먹을 거 같은 맛입니다.\n\n1960년 전쟁 때 맛 보고 싶었는데 그때는 너무 가난해서 먹을 수 없었는데, 맛있어요.",
+      "createdAt": "2023-08-02T13:43:06.379389",
       "rebuy": true,
       "favoriteCount": 1320,
       "favorite": true
@@ -58,6 +60,7 @@
         }
       ],
       "content": "할머니가 먹을 거 같은 맛입니다. 1960년 전쟁 때 맛 보고 싶었는데 그때는 너무 가난해서 먹을 수 없었는데, 맛있어요. 하얀 짜파게티라니 말이 안된다고 생각했었죠. 실제로 맛을 보니까 까만 짜파게티랑 맛이 뭔가 다를게 없네요.",
+      "createdAt": "2023-07-03T13:43:06.379389",
       "rebuy": true,
       "favoriteCount": 1321,
       "favorite": true

--- a/frontend/src/types/review.ts
+++ b/frontend/src/types/review.ts
@@ -8,6 +8,7 @@ export interface Review {
   rating: number;
   tags: Tag[];
   content: string;
+  createdAt: string;
   rebuy: boolean;
   favoriteCount: number;
   favorite: boolean;

--- a/frontend/src/utils/relativeDate.ts
+++ b/frontend/src/utils/relativeDate.ts
@@ -1,0 +1,8 @@
+import 'dayjs/locale/ko';
+
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+
+dayjs.extend(relativeTime);
+
+export const getRelativeDate = (date: string) => dayjs().locale('ko').to(dayjs(date));

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4335,6 +4335,11 @@ csstype@^3.0.2, csstype@^3.1.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
+dayjs@^1.11.9:
+  version "1.11.9"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.9.tgz#9ca491933fadd0a60a2c19f6c237c03517d71d1a"
+  integrity sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==
+
 debug@2.6.9, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -8625,6 +8630,7 @@ strict-event-emitter@^0.4.3:
   integrity sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8698,6 +8704,7 @@ string_decoder@~1.1.1:
     safe-buffer "~5.1.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9579,6 +9586,7 @@ wordwrap@^1.0.0:
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Issue

- close #266

## ✨ 구현한 기능

- 리뷰 상대 날짜 추가 및 렌더

## 📢 논의하고 싶은 내용

- 상대날짜 포맷팅을 위해 dayjs 라이브러리를 설치했습니다. https://day.js.org/
- 번들 크기가 2kb여서 날짜 유틸 라이브러리 중 용량이 작습니다.
- Intl.RelativeTimeFormat을 사용하려 했지만, 분단위는 불가. 일, 월, 년 기준을 개발자측에서 정해줘야 해서 알아서 포맷팅 해주는 라이브러리를 선택했습니다. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat

## 🎸 기타

<img width="621" alt="스크린샷 2023-08-03 오후 1 54 31" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/78616893/882bcedb-c71c-46a5-ade6-24131cc77e76">

## ⏰ 일정

- 추정 시간 : 1시간
- 걸린 시간 : 1시간
