### PR TITLE
[BE] fix: 트랜잭션 전파 옵션을 설정

### DIFF
--- a/backend/src/main/java/com/funeat/member/application/MemberService.java
+++ b/backend/src/main/java/com/funeat/member/application/MemberService.java
@@ -1,5 +1,7 @@
 package com.funeat.member.application;
 
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
+
 import com.funeat.auth.dto.SignUserDto;
 import com.funeat.auth.dto.UserInfoDto;
 import com.funeat.member.domain.Member;
@@ -19,7 +21,7 @@ public class MemberService {
         this.memberRepository = memberRepository;
     }
 
-    @Transactional
+    @Transactional(propagation = REQUIRES_NEW)
     public SignUserDto findOrCreateMember(final UserInfoDto userInfoDto) {
         final String platformId = userInfoDto.getId().toString();
 

--- a/backend/src/test/java/com/funeat/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/funeat/member/application/MemberServiceTest.java
@@ -28,7 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 class MemberServiceTest {
 
     @Autowired
-    private MemberService memberService;
+    private TestMemberService memberService;
 
     @Autowired
     private MemberRepository memberRepository;

--- a/backend/src/test/java/com/funeat/member/application/TestMemberService.java
+++ b/backend/src/test/java/com/funeat/member/application/TestMemberService.java
@@ -1,0 +1,21 @@
+package com.funeat.member.application;
+
+import com.funeat.auth.dto.SignUserDto;
+import com.funeat.auth.dto.UserInfoDto;
+import com.funeat.member.persistence.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TestMemberService extends MemberService {
+
+    public TestMemberService(final MemberRepository memberRepository) {
+        super(memberRepository);
+    }
+
+    @Override
+    @Transactional
+    public SignUserDto findOrCreateMember(final UserInfoDto userInfoDto) {
+        return super.findOrCreateMember(userInfoDto);
+    }
+}


### PR DESCRIPTION
## Issue

- close #298 

## ✨ 구현한 기능

- 1. 트랜잭션 전파 옵션을 REQUIRES_NEW로 설정합니다.
- 2. 테스트에서는 REQUIRES_NEW를 하면 서비스 테스트만 새로운 트랜잭션이 생성되어서 테스트가 불가능합니다.
그래서 기존 서비스를 상속하는 테스트용 서비스를 제작하여 REQUIRES_NEW인 테스트만 `@Transactional`로 변경했습니다.

## 📢 논의하고 싶은 내용

- x

## 🎸 기타

- x

## ⏰ 일정

- 추정 시간 : 0.5
- 걸린 시간 : 0.5
