### PR TITLE
[BE] fix: 카카오 로그인 경로 수정

### DIFF
--- a/backend/src/main/java/com/funeat/auth/util/KakaoPlatformUserProvider.java
+++ b/backend/src/main/java/com/funeat/auth/util/KakaoPlatformUserProvider.java
@@ -25,6 +25,7 @@ public class KakaoPlatformUserProvider implements PlatformUserProvider {
 
     private static final String AUTHORIZATION_BASE_URL = "https://kauth.kakao.com";
     private static final String RESOURCE_BASE_URL = "https://kapi.kakao.com";
+    private static final String OAUTH_URI = "/oauth/authorize";
     private static final String ACCESS_TOKEN_URI = "/oauth/token";
     private static final String USER_INFO_URI = "/v2/user/me";
     private static final String AUTHORIZATION_CODE = "authorization_code";
@@ -117,6 +118,6 @@ public class KakaoPlatformUserProvider implements PlatformUserProvider {
         joiner.add("client_id=" + kakaoRestApiKey);
         joiner.add("redirect_uri=" + redirectUri);
 
-        return AUTHORIZATION_BASE_URL + "?" + joiner;
+        return AUTHORIZATION_BASE_URL + OAUTH_URI + "?" + joiner;
     }
 }


### PR DESCRIPTION
## Issue

- close #323

## ✨ 구현한 기능

- 카카오 로그인 경로를 수정했습니다. (KOE002 에러 해결)
- +) 젠킨스 환경 변수가 funeat.site가 아닌 ip주소로 되어 있어서 이것도 같이 수정헀습니다. (KOE303 에러 해결)

현재 경로

<img width="366" alt="스크린샷 2023-08-04 오후 12 44 01" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/79046106/7b5823a3-b1f0-4c38-aa04-dd37a71b7ab2">

</br>

수정해야할 경로

<img width="829" alt="스크린샷 2023-08-04 오후 12 47 07" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/79046106/504bc7bb-a621-417b-8fcf-270dd40d4268">


## 📢 논의하고 싶은 내용

x

## 🎸 기타

x

## ⏰ 일정

- 추정 시간 : 0.05
- 걸린 시간 : 0.05
