### PR TITLE
[FE] feat: 이미지 압축 구현

### DIFF
--- a/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
+++ b/frontend/src/components/Review/ReviewImageUploader/ReviewImageUploader.tsx
@@ -25,7 +25,7 @@ const ReviewImageUploader = ({
       </Heading>
       <Spacing size={2} />
       <Text color={theme.textColors.disabled} tabIndex={0}>
-        (사진은 1MB 이하, 1장까지 업로드 할 수 있어요.)
+        (사진은 5MB 이하, 1장까지 업로드 할 수 있어요.)
       </Text>
       <Spacing size={20} />
       {reviewPreviewImage ? (

--- a/frontend/src/hooks/review/useReviewImageUploader.ts
+++ b/frontend/src/hooks/review/useReviewImageUploader.ts
@@ -8,6 +8,12 @@ const useReviewImageUploader = () => {
   const [reviewPreviewImage, setReviewPreviewImage] = useState('');
   const [reviewImageFile, setReviewImageFile] = useState<File | null>(null);
 
+  const options = {
+    maxSizeMB: 1,
+    maxWidthOrHeight: 1920,
+    useWebWorker: true,
+  };
+
   const uploadReviewImage: ChangeEventHandler<HTMLInputElement> = async (event) => {
     if (!event.target.files) {
       return;
@@ -20,12 +26,6 @@ const useReviewImageUploader = () => {
       event.target.value = '';
       return;
     }
-
-    const options = {
-      maxSizeMB: 1,
-      maxWidthOrHeight: 1920,
-      useWebWorker: true,
-    };
 
     try {
       const compressedFile = await imageCompression(imageFile, options);

--- a/frontend/src/hooks/review/useReviewImageUploader.ts
+++ b/frontend/src/hooks/review/useReviewImageUploader.ts
@@ -2,7 +2,7 @@ import imageCompression from 'browser-image-compression';
 import type { ChangeEventHandler } from 'react';
 import { useState } from 'react';
 
-const MAX_SIZE = 5120 * 5120;
+const MAX_SIZE = 5 * 1024 * 1024;
 
 const useReviewImageUploader = () => {
   const [reviewPreviewImage, setReviewPreviewImage] = useState('');

--- a/frontend/src/hooks/review/useReviewImageUploader.ts
+++ b/frontend/src/hooks/review/useReviewImageUploader.ts
@@ -1,13 +1,14 @@
+import imageCompression from 'browser-image-compression';
 import type { ChangeEventHandler } from 'react';
 import { useState } from 'react';
 
-const MAX_SIZE = 1024 * 1024;
+const MAX_SIZE = 5120 * 5120;
 
 const useReviewImageUploader = () => {
   const [reviewPreviewImage, setReviewPreviewImage] = useState('');
   const [reviewImageFile, setReviewImageFile] = useState<File | null>(null);
 
-  const uploadReviewImage: ChangeEventHandler<HTMLInputElement> = (event) => {
+  const uploadReviewImage: ChangeEventHandler<HTMLInputElement> = async (event) => {
     if (!event.target.files) {
       return;
     }
@@ -15,13 +16,31 @@ const useReviewImageUploader = () => {
     const imageFile = event.target.files[0];
 
     if (imageFile.size > MAX_SIZE) {
-      alert('이미지 크기가 너무 커요. 1MB 이하의 이미지를 골라주세요.');
+      alert('이미지 크기가 너무 커요. 5MB 이하의 이미지를 골라주세요.');
       event.target.value = '';
       return;
     }
 
+    const options = {
+      maxSizeMB: 1,
+      maxWidthOrHeight: 1920,
+      useWebWorker: true,
+    };
+
+    try {
+      const compressedFile = await imageCompression(imageFile, options);
+      const compressedImageFilePromise = imageCompression.getFilefromDataUrl(
+        await imageCompression.getDataUrlFromFile(compressedFile),
+        compressedFile.name
+      );
+      compressedImageFilePromise.then((result) => {
+        setReviewImageFile(result);
+      });
+    } catch (error) {
+      console.log(error);
+    }
+
     setReviewPreviewImage(URL.createObjectURL(imageFile));
-    setReviewImageFile(imageFile);
   };
 
   const deleteReviewImage = () => {
@@ -29,7 +48,13 @@ const useReviewImageUploader = () => {
     setReviewPreviewImage('');
   };
 
-  return { reviewPreviewImage, setReviewPreviewImage, reviewImageFile, uploadReviewImage, deleteReviewImage };
+  return {
+    reviewPreviewImage,
+    setReviewPreviewImage,
+    reviewImageFile,
+    uploadReviewImage,
+    deleteReviewImage,
+  };
 };
 
 export default useReviewImageUploader;


### PR DESCRIPTION
## Issue

- close #350 

## ✨ 구현한 기능

이미지 압축을 구현하였습니다.

## 📢 논의하고 싶은 내용

현재 최대 사이즈를 1MB로 해놓았습니다.
직접 7MB의 이미지를 압축해보았는데요.

<img width="413" alt="스크린샷 2023-08-09 오전 10 55 58" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/80464961/f98be7af-ebef-420d-8c4c-d40705a3efa7">

1MB가 안 되게 압축이 됩니다.
저희가 1MB 이상으로 못 올리잖아요?
그래서 강제로 막는건 있어야할 거 같아서 5MB로 막아놓았습니다.

5MB const MAX_SIZE = 5120 * 5120; 이거 맞나요?
그냥 1024에 5 곱했음...

## 🎸 기타

x

## ⏰ 일정

- 추정 시간 : 4시간
- 걸린 시간 : 0.5시간
