### PR TITLE
[BE] feat: 꿀조합 상세 정보 조회 기능

### DIFF
--- a/backend/src/main/java/com/funeat/member/domain/Member.java
+++ b/backend/src/main/java/com/funeat/member/domain/Member.java
@@ -1,7 +1,5 @@
 package com.funeat.member.domain;
 
-import com.funeat.member.domain.bookmark.ProductBookmark;
-import com.funeat.member.domain.bookmark.RecipeBookmark;
 import com.funeat.member.domain.favorite.RecipeFavorite;
 import com.funeat.member.domain.favorite.ReviewFavorite;
 import java.util.ArrayList;
@@ -30,12 +28,6 @@ public class Member {
 
     @OneToMany(mappedBy = "member")
     private List<RecipeFavorite> recipeFavorites;
-
-    @OneToMany(mappedBy = "member")
-    private List<ProductBookmark> productBookmarks;
-
-    @OneToMany(mappedBy = "member")
-    private List<RecipeBookmark> recipeBookmarks;
 
     protected Member() {
     }
@@ -68,14 +60,6 @@ public class Member {
 
     public List<RecipeFavorite> getRecipeFavorites() {
         return recipeFavorites;
-    }
-
-    public List<ProductBookmark> getProductBookmarks() {
-        return productBookmarks;
-    }
-
-    public List<RecipeBookmark> getRecipeBookmarks() {
-        return recipeBookmarks;
     }
 
     public void modifyProfile(final String nickname, final String profileImage) {

--- a/backend/src/main/java/com/funeat/member/domain/favorite/RecipeFavorite.java
+++ b/backend/src/main/java/com/funeat/member/domain/favorite/RecipeFavorite.java
@@ -24,15 +24,15 @@ public class RecipeFavorite {
     @JoinColumn(name = "recipe_id")
     private Recipe recipe;
 
-    private Boolean checked;
+    private Boolean favorite;
 
     protected RecipeFavorite() {
     }
 
-    public RecipeFavorite(final Member member, final Recipe recipe, final Boolean checked) {
+    public RecipeFavorite(final Member member, final Recipe recipe, final Boolean favorite) {
         this.member = member;
         this.recipe = recipe;
-        this.checked = checked;
+        this.favorite = favorite;
     }
 
     public Long getId() {
@@ -47,7 +47,7 @@ public class RecipeFavorite {
         return recipe;
     }
 
-    public Boolean getChecked() {
-        return checked;
+    public Boolean getFavorite() {
+        return favorite;
     }
 }

--- a/backend/src/main/java/com/funeat/member/domain/favorite/RecipeFavorite.java
+++ b/backend/src/main/java/com/funeat/member/domain/favorite/RecipeFavorite.java
@@ -25,4 +25,29 @@ public class RecipeFavorite {
     private Recipe recipe;
 
     private Boolean checked;
+
+    protected RecipeFavorite() {
+    }
+
+    public RecipeFavorite(final Member member, final Recipe recipe, final Boolean checked) {
+        this.member = member;
+        this.recipe = recipe;
+        this.checked = checked;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public Recipe getRecipe() {
+        return recipe;
+    }
+
+    public Boolean getChecked() {
+        return checked;
+    }
 }

--- a/backend/src/main/java/com/funeat/member/persistence/RecipeFavoriteRepository.java
+++ b/backend/src/main/java/com/funeat/member/persistence/RecipeFavoriteRepository.java
@@ -3,10 +3,9 @@ package com.funeat.member.persistence;
 import com.funeat.member.domain.Member;
 import com.funeat.member.domain.favorite.RecipeFavorite;
 import com.funeat.recipe.domain.Recipe;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecipeFavoriteRepository extends JpaRepository<RecipeFavorite, Long> {
 
-    Optional<RecipeFavorite> findByMemberAndRecipe(final Member member, final Recipe recipe);
+    boolean existsByMemberAndRecipeAndFavoriteTrue(final Member member, final Recipe recipe);
 }

--- a/backend/src/main/java/com/funeat/member/persistence/RecipeFavoriteRepository.java
+++ b/backend/src/main/java/com/funeat/member/persistence/RecipeFavoriteRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecipeFavoriteRepository extends JpaRepository<RecipeFavorite, Long> {
 
-    Optional<RecipeFavorite> findByMemberAndRecipe(Member member, Recipe recipe);
+    Optional<RecipeFavorite> findByMemberAndRecipe(final Member member, final Recipe recipe);
 }

--- a/backend/src/main/java/com/funeat/member/persistence/RecipeFavoriteRepository.java
+++ b/backend/src/main/java/com/funeat/member/persistence/RecipeFavoriteRepository.java
@@ -1,7 +1,12 @@
 package com.funeat.member.persistence;
 
+import com.funeat.member.domain.Member;
 import com.funeat.member.domain.favorite.RecipeFavorite;
+import com.funeat.recipe.domain.Recipe;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecipeFavoriteRepository extends JpaRepository<RecipeFavorite, Long> {
+
+    Optional<RecipeFavorite> findByMemberAndRecipe(Member member, Recipe recipe);
 }

--- a/backend/src/main/java/com/funeat/product/persistence/ProductRecipeRepository.java
+++ b/backend/src/main/java/com/funeat/product/persistence/ProductRecipeRepository.java
@@ -10,5 +10,5 @@ import org.springframework.data.jpa.repository.Query;
 public interface ProductRecipeRepository extends JpaRepository<ProductRecipe, Long> {
 
     @Query("SELECT pr.product FROM ProductRecipe pr WHERE pr.recipe = :recipe")
-    List<Product> findProductByRecipe(Recipe recipe);
+    List<Product> findProductByRecipe(final Recipe recipe);
 }

--- a/backend/src/main/java/com/funeat/product/persistence/ProductRecipeRepository.java
+++ b/backend/src/main/java/com/funeat/product/persistence/ProductRecipeRepository.java
@@ -1,7 +1,14 @@
 package com.funeat.product.persistence;
 
+import com.funeat.product.domain.Product;
 import com.funeat.product.domain.ProductRecipe;
+import com.funeat.recipe.domain.Recipe;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ProductRecipeRepository extends JpaRepository<ProductRecipe, Long> {
+
+    @Query("SELECT pr.product FROM ProductRecipe pr WHERE pr.recipe = :recipe")
+    List<Product> findProductByRecipe(Recipe recipe);
 }

--- a/backend/src/main/java/com/funeat/product/presentation/ProductApiController.java
+++ b/backend/src/main/java/com/funeat/product/presentation/ProductApiController.java
@@ -22,9 +22,9 @@ public class ProductApiController implements ProductController {
         this.productService = productService;
     }
 
-    @GetMapping("/categories/{category_id}/products")
+    @GetMapping("/categories/{categoryId}/products")
     public ResponseEntity<ProductsInCategoryResponse> getAllProductsInCategory(
-            @PathVariable(name = "category_id") final Long categoryId,
+            @PathVariable final Long categoryId,
             @PageableDefault Pageable pageable
     ) {
         final ProductsInCategoryResponse response = productService.getAllProductsInCategory(categoryId, pageable);

--- a/backend/src/main/java/com/funeat/recipe/application/RecipeService.java
+++ b/backend/src/main/java/com/funeat/recipe/application/RecipeService.java
@@ -2,7 +2,6 @@ package com.funeat.recipe.application;
 
 import com.funeat.common.ImageService;
 import com.funeat.member.domain.Member;
-import com.funeat.member.domain.favorite.RecipeFavorite;
 import com.funeat.member.persistence.MemberRepository;
 import com.funeat.member.persistence.RecipeFavoriteRepository;
 import com.funeat.product.domain.Product;
@@ -85,8 +84,6 @@ public class RecipeService {
     private Boolean calculateFavoriteChecked(final Long memberId, final Recipe recipe) {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(IllegalArgumentException::new);
-        return recipeFavoriteRepository.findByMemberAndRecipe(member, recipe)
-                .map(RecipeFavorite::getFavorite)
-                .orElse(false);
+        return recipeFavoriteRepository.existsByMemberAndRecipeAndFavoriteTrue(member, recipe);
     }
 }

--- a/backend/src/main/java/com/funeat/recipe/application/RecipeService.java
+++ b/backend/src/main/java/com/funeat/recipe/application/RecipeService.java
@@ -46,7 +46,7 @@ public class RecipeService {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(IllegalArgumentException::new);
 
-        final Recipe savedRecipe = recipeRepository.save(new Recipe(request.getName(), request.getContent(), member));
+        final Recipe savedRecipe = recipeRepository.save(new Recipe(request.getTitle(), request.getContent(), member));
         request.getProductIds()
                 .stream()
                 .map(it -> productRepository.findById(it)

--- a/backend/src/main/java/com/funeat/recipe/application/RecipeService.java
+++ b/backend/src/main/java/com/funeat/recipe/application/RecipeService.java
@@ -69,8 +69,6 @@ public class RecipeService {
     }
 
     public RecipeDetailResponse getRecipeDetail(final Long memberId, final Long recipeId) {
-        final Member member = memberRepository.findById(memberId)
-                .orElseThrow(IllegalArgumentException::new);
         final Recipe recipe = recipeRepository.findById(recipeId)
                 .orElseThrow(IllegalArgumentException::new);
         final List<RecipeImage> images = recipeImageRepository.findByRecipe(recipe);
@@ -78,10 +76,17 @@ public class RecipeService {
         final Long totalPrice = products.stream()
                 .mapToLong(Product::getPrice)
                 .sum();
-        final Boolean favorite = recipeFavoriteRepository.findByMemberAndRecipe(member, recipe)
-                .map(RecipeFavorite::getChecked)
-                .orElse(false);
+
+        final Boolean favorite = calculateFavoriteChecked(memberId, recipe);
 
         return RecipeDetailResponse.toResponse(recipe, images, products, totalPrice, favorite);
+    }
+
+    private Boolean calculateFavoriteChecked(final Long memberId, final Recipe recipe) {
+        final Member member = memberRepository.findById(memberId)
+                .orElseThrow(IllegalArgumentException::new);
+        return recipeFavoriteRepository.findByMemberAndRecipe(member, recipe)
+                .map(RecipeFavorite::getChecked)
+                .orElse(false);
     }
 }

--- a/backend/src/main/java/com/funeat/recipe/application/RecipeService.java
+++ b/backend/src/main/java/com/funeat/recipe/application/RecipeService.java
@@ -8,6 +8,7 @@ import com.funeat.product.persistence.ProductRepository;
 import com.funeat.recipe.domain.Recipe;
 import com.funeat.recipe.domain.RecipeImage;
 import com.funeat.recipe.dto.RecipeCreateRequest;
+import com.funeat.recipe.dto.RecipeDetailResponse;
 import com.funeat.recipe.persistence.RecipeImageRepository;
 import com.funeat.recipe.persistence.RecipeRepository;
 import com.funeat.common.ImageService;
@@ -60,5 +61,9 @@ public class RecipeService {
         }
 
         return savedRecipe.getId();
+    }
+
+    public RecipeDetailResponse getRecipeDetail(final Long recipeId) {
+        return null;
     }
 }

--- a/backend/src/main/java/com/funeat/recipe/application/RecipeService.java
+++ b/backend/src/main/java/com/funeat/recipe/application/RecipeService.java
@@ -86,7 +86,7 @@ public class RecipeService {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(IllegalArgumentException::new);
         return recipeFavoriteRepository.findByMemberAndRecipe(member, recipe)
-                .map(RecipeFavorite::getChecked)
+                .map(RecipeFavorite::getFavorite)
                 .orElse(false);
     }
 }

--- a/backend/src/main/java/com/funeat/recipe/domain/Recipe.java
+++ b/backend/src/main/java/com/funeat/recipe/domain/Recipe.java
@@ -23,6 +23,8 @@ public class Recipe {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    private Long favoriteCount = 0L;
+
     protected Recipe() {
     }
 
@@ -46,5 +48,9 @@ public class Recipe {
 
     public Member getMember() {
         return member;
+    }
+
+    public Long getFavoriteCount() {
+        return favoriteCount;
     }
 }

--- a/backend/src/main/java/com/funeat/recipe/domain/Recipe.java
+++ b/backend/src/main/java/com/funeat/recipe/domain/Recipe.java
@@ -15,7 +15,7 @@ public class Recipe {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String name;
+    private String title;
 
     private String content;
 
@@ -28,8 +28,8 @@ public class Recipe {
     protected Recipe() {
     }
 
-    public Recipe(final String name, final String content, final Member member) {
-        this.name = name;
+    public Recipe(final String title, final String content, final Member member) {
+        this.title = title;
         this.content = content;
         this.member = member;
     }
@@ -38,8 +38,8 @@ public class Recipe {
         return id;
     }
 
-    public String getName() {
-        return name;
+    public String getTitle() {
+        return title;
     }
 
     public String getContent() {

--- a/backend/src/main/java/com/funeat/recipe/domain/RecipeImage.java
+++ b/backend/src/main/java/com/funeat/recipe/domain/RecipeImage.java
@@ -27,4 +27,16 @@ public class RecipeImage {
         this.image = image;
         this.recipe = recipe;
     }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public Recipe getRecipe() {
+        return recipe;
+    }
 }

--- a/backend/src/main/java/com/funeat/recipe/dto/ProductRecipeDto.java
+++ b/backend/src/main/java/com/funeat/recipe/dto/ProductRecipeDto.java
@@ -1,15 +1,21 @@
 package com.funeat.recipe.dto;
 
+import com.funeat.product.domain.Product;
+
 public class ProductRecipeDto {
 
     private final Long id;
     private final String name;
     private final Long price;
 
-    public ProductRecipeDto(final Long id, final String name, final Long price) {
+    private ProductRecipeDto(final Long id, final String name, final Long price) {
         this.id = id;
         this.name = name;
         this.price = price;
+    }
+
+    public static ProductRecipeDto toDto(final Product product) {
+        return new ProductRecipeDto(product.getId(), product.getName(), product.getPrice());
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/funeat/recipe/dto/ProductRecipeDto.java
+++ b/backend/src/main/java/com/funeat/recipe/dto/ProductRecipeDto.java
@@ -1,0 +1,26 @@
+package com.funeat.recipe.dto;
+
+public class ProductRecipeDto {
+
+    private final Long id;
+    private final String name;
+    private final Long price;
+
+    public ProductRecipeDto(final Long id, final String name, final Long price) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Long getPrice() {
+        return price;
+    }
+}

--- a/backend/src/main/java/com/funeat/recipe/dto/RecipeAuthorDto.java
+++ b/backend/src/main/java/com/funeat/recipe/dto/RecipeAuthorDto.java
@@ -1,0 +1,20 @@
+package com.funeat.recipe.dto;
+
+public class RecipeAuthorDto {
+
+    private final String profileImage;
+    private final String nickName;
+
+    public RecipeAuthorDto(final String profileImage, final String nickName) {
+        this.profileImage = profileImage;
+        this.nickName = nickName;
+    }
+
+    public String getProfileImage() {
+        return profileImage;
+    }
+
+    public String getNickName() {
+        return nickName;
+    }
+}

--- a/backend/src/main/java/com/funeat/recipe/dto/RecipeAuthorDto.java
+++ b/backend/src/main/java/com/funeat/recipe/dto/RecipeAuthorDto.java
@@ -1,13 +1,19 @@
 package com.funeat.recipe.dto;
 
+import com.funeat.member.domain.Member;
+
 public class RecipeAuthorDto {
 
     private final String profileImage;
     private final String nickName;
 
-    public RecipeAuthorDto(final String profileImage, final String nickName) {
+    private RecipeAuthorDto(final String profileImage, final String nickName) {
         this.profileImage = profileImage;
         this.nickName = nickName;
+    }
+
+    public static RecipeAuthorDto toDto(final Member member) {
+        return new RecipeAuthorDto(member.getProfileImage(), member.getNickname());
     }
 
     public String getProfileImage() {

--- a/backend/src/main/java/com/funeat/recipe/dto/RecipeCreateRequest.java
+++ b/backend/src/main/java/com/funeat/recipe/dto/RecipeCreateRequest.java
@@ -4,18 +4,18 @@ import java.util.List;
 
 public class RecipeCreateRequest {
 
-    private final String name;
+    private final String title;
     private final List<Long> productIds;
     private final String content;
 
-    public RecipeCreateRequest(final String name, final List<Long> productIds, final String content) {
-        this.name = name;
+    public RecipeCreateRequest(final String title, final List<Long> productIds, final String content) {
+        this.title = title;
         this.productIds = productIds;
         this.content = content;
     }
 
-    public String getName() {
-        return name;
+    public String getTitle() {
+        return title;
     }
 
     public List<Long> getProductIds() {

--- a/backend/src/main/java/com/funeat/recipe/dto/RecipeDetailResponse.java
+++ b/backend/src/main/java/com/funeat/recipe/dto/RecipeDetailResponse.java
@@ -1,0 +1,67 @@
+package com.funeat.recipe.dto;
+
+import java.util.List;
+
+public class RecipeDetailResponse {
+
+    private final Long id;
+    private final List<String> images;
+    private final String title;
+    private final String content;
+    private final RecipeAuthorDto author;
+    private final List<ProductRecipeDto> products;
+    private final Long totalPrice;
+    private final Long favoriteCount;
+    private final Boolean favorite;
+
+    public RecipeDetailResponse(final Long id, final List<String> images, final String title, final String content,
+                                final RecipeAuthorDto author,
+                                final List<ProductRecipeDto> products, final Long totalPrice, final Long favoriteCount,
+                                final Boolean favorite) {
+        this.id = id;
+        this.images = images;
+        this.title = title;
+        this.content = content;
+        this.author = author;
+        this.products = products;
+        this.totalPrice = totalPrice;
+        this.favoriteCount = favoriteCount;
+        this.favorite = favorite;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public List<String> getImages() {
+        return images;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public RecipeAuthorDto getAuthor() {
+        return author;
+    }
+
+    public List<ProductRecipeDto> getProducts() {
+        return products;
+    }
+
+    public Long getTotalPrice() {
+        return totalPrice;
+    }
+
+    public Long getFavoriteCount() {
+        return favoriteCount;
+    }
+
+    public Boolean getFavorite() {
+        return favorite;
+    }
+}

--- a/backend/src/main/java/com/funeat/recipe/dto/RecipeDetailResponse.java
+++ b/backend/src/main/java/com/funeat/recipe/dto/RecipeDetailResponse.java
@@ -1,6 +1,10 @@
 package com.funeat.recipe.dto;
 
+import com.funeat.product.domain.Product;
+import com.funeat.recipe.domain.Recipe;
+import com.funeat.recipe.domain.RecipeImage;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class RecipeDetailResponse {
 
@@ -14,7 +18,7 @@ public class RecipeDetailResponse {
     private final Long favoriteCount;
     private final Boolean favorite;
 
-    public RecipeDetailResponse(final Long id, final List<String> images, final String title, final String content,
+    private RecipeDetailResponse(final Long id, final List<String> images, final String title, final String content,
                                 final RecipeAuthorDto author,
                                 final List<ProductRecipeDto> products, final Long totalPrice, final Long favoriteCount,
                                 final Boolean favorite) {
@@ -27,6 +31,19 @@ public class RecipeDetailResponse {
         this.totalPrice = totalPrice;
         this.favoriteCount = favoriteCount;
         this.favorite = favorite;
+    }
+
+    public static RecipeDetailResponse toResponse(final Recipe recipe, final List<RecipeImage> recipeImages,
+                                           final List<Product> products, final Long totalPrice, final Boolean favorite) {
+        final RecipeAuthorDto authorDto = RecipeAuthorDto.toDto(recipe.getMember());
+        final List<ProductRecipeDto> productDtos  = products.stream()
+                .map(ProductRecipeDto::toDto)
+                .collect(Collectors.toList());
+        final List<String> images = recipeImages.stream()
+                .map(it -> it.getImage())
+                .collect(Collectors.toList());
+        return new RecipeDetailResponse(recipe.getId(), images, recipe.getTitle(), recipe.getContent(),
+                authorDto, productDtos, totalPrice, recipe.getFavoriteCount(), favorite);
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/funeat/recipe/dto/RecipeDetailResponse.java
+++ b/backend/src/main/java/com/funeat/recipe/dto/RecipeDetailResponse.java
@@ -40,7 +40,7 @@ public class RecipeDetailResponse {
                 .map(ProductRecipeDto::toDto)
                 .collect(Collectors.toList());
         final List<String> images = recipeImages.stream()
-                .map(it -> it.getImage())
+                .map(RecipeImage::getImage)
                 .collect(Collectors.toList());
         return new RecipeDetailResponse(recipe.getId(), images, recipe.getTitle(), recipe.getContent(),
                 authorDto, productDtos, totalPrice, recipe.getFavoriteCount(), favorite);

--- a/backend/src/main/java/com/funeat/recipe/persistence/RecipeImageRepository.java
+++ b/backend/src/main/java/com/funeat/recipe/persistence/RecipeImageRepository.java
@@ -1,7 +1,11 @@
 package com.funeat.recipe.persistence;
 
+import com.funeat.recipe.domain.Recipe;
 import com.funeat.recipe.domain.RecipeImage;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecipeImageRepository extends JpaRepository<RecipeImage, Long> {
+
+    List<RecipeImage> findByRecipe(final Recipe recipe);
 }

--- a/backend/src/main/java/com/funeat/recipe/presentation/RecipeApiController.java
+++ b/backend/src/main/java/com/funeat/recipe/presentation/RecipeApiController.java
@@ -37,7 +37,7 @@ public class RecipeApiController implements RecipeController{
     @GetMapping(value = "/api/recipes/{recipeId}")
     public ResponseEntity<RecipeDetailResponse> getRecipeDetail(@AuthenticationPrincipal final LoginInfo loginInfo,
                                                                 @PathVariable final Long recipeId) {
-        final RecipeDetailResponse response = recipeService.getRecipeDetail(recipeId);
+        final RecipeDetailResponse response = recipeService.getRecipeDetail(loginInfo.getId(), recipeId);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/funeat/recipe/presentation/RecipeApiController.java
+++ b/backend/src/main/java/com/funeat/recipe/presentation/RecipeApiController.java
@@ -4,10 +4,13 @@ import com.funeat.auth.dto.LoginInfo;
 import com.funeat.auth.util.AuthenticationPrincipal;
 import com.funeat.recipe.application.RecipeService;
 import com.funeat.recipe.dto.RecipeCreateRequest;
+import com.funeat.recipe.dto.RecipeDetailResponse;
 import java.net.URI;
 import java.util.List;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,5 +32,12 @@ public class RecipeApiController implements RecipeController{
         final Long recipeId = recipeService.create(loginInfo.getId(), images, recipeRequest);
 
         return ResponseEntity.created(URI.create("/api/recipes/" + recipeId)).build();
+    }
+
+    @GetMapping(value = "/api/recipes/{recipeId}")
+    public ResponseEntity<RecipeDetailResponse> getRecipeDetail(@AuthenticationPrincipal final LoginInfo loginInfo,
+                                                                @PathVariable final Long recipeId) {
+        final RecipeDetailResponse response = recipeService.getRecipeDetail(recipeId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/funeat/recipe/presentation/RecipeApiController.java
+++ b/backend/src/main/java/com/funeat/recipe/presentation/RecipeApiController.java
@@ -38,6 +38,7 @@ public class RecipeApiController implements RecipeController{
     public ResponseEntity<RecipeDetailResponse> getRecipeDetail(@AuthenticationPrincipal final LoginInfo loginInfo,
                                                                 @PathVariable final Long recipeId) {
         final RecipeDetailResponse response = recipeService.getRecipeDetail(loginInfo.getId(), recipeId);
+        
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/funeat/recipe/presentation/RecipeController.java
+++ b/backend/src/main/java/com/funeat/recipe/presentation/RecipeController.java
@@ -3,11 +3,14 @@ package com.funeat.recipe.presentation;
 import com.funeat.auth.dto.LoginInfo;
 import com.funeat.auth.util.AuthenticationPrincipal;
 import com.funeat.recipe.dto.RecipeCreateRequest;
+import com.funeat.recipe.dto.RecipeDetailResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
@@ -24,4 +27,13 @@ public interface RecipeController {
     ResponseEntity<Void> writeRecipe(@AuthenticationPrincipal LoginInfo loginInfo,
                                      @RequestPart List<MultipartFile> images,
                                      @RequestPart RecipeCreateRequest recipeRequest);
+
+    @Operation(summary = "꿀조합 상세 조회", description = "꿀조합의 상세 정보를 조회한다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "꿀조합 상세 조회 성공."
+    )
+    @GetMapping
+    ResponseEntity<RecipeDetailResponse> getRecipeDetail(@AuthenticationPrincipal final LoginInfo loginInfo,
+                                                                @PathVariable final Long recipeId);
 }

--- a/backend/src/test/java/com/funeat/acceptance/common/AcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/common/AcceptanceTest.java
@@ -5,6 +5,8 @@ import com.funeat.member.persistence.MemberRepository;
 import com.funeat.member.persistence.ReviewFavoriteRepository;
 import com.funeat.product.persistence.CategoryRepository;
 import com.funeat.product.persistence.ProductRepository;
+import com.funeat.recipe.persistence.RecipeImageRepository;
+import com.funeat.recipe.persistence.RecipeRepository;
 import com.funeat.review.persistence.ReviewRepository;
 import com.funeat.review.persistence.ReviewTagRepository;
 import com.funeat.tag.persistence.TagRepository;
@@ -47,6 +49,12 @@ public abstract class AcceptanceTest {
 
     @Autowired
     public ReviewFavoriteRepository reviewFavoriteRepository;
+
+    @Autowired
+    public RecipeRepository recipeRepository;
+
+    @Autowired
+    public RecipeImageRepository recipeImageRepository;
 
     @BeforeEach
     void setUp() {

--- a/backend/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
@@ -2,15 +2,20 @@ package com.funeat.acceptance.recipe;
 
 import static com.funeat.acceptance.common.CommonSteps.STATUS_CODE를_검증한다;
 import static com.funeat.acceptance.common.CommonSteps.정상_생성;
+import static com.funeat.acceptance.common.CommonSteps.정상_처리;
 import static com.funeat.acceptance.product.ProductSteps.간편식사;
+import static com.funeat.acceptance.recipe.RecipeSteps.레시피_상세_정보_요청;
 import static com.funeat.acceptance.recipe.RecipeSteps.레시피_추가_요청;
+import static com.funeat.acceptance.recipe.RecipeSteps.레시피_추가_요청하고_id_반환;
 import static com.funeat.acceptance.recipe.RecipeSteps.여러_사진_요청;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.funeat.acceptance.common.AcceptanceTest;
 import com.funeat.acceptance.common.LoginSteps;
 import com.funeat.product.domain.Category;
 import com.funeat.product.domain.Product;
 import com.funeat.recipe.dto.RecipeCreateRequest;
+import com.funeat.recipe.dto.RecipeDetailResponse;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -39,11 +44,46 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
         STATUS_CODE를_검증한다(response, 정상_생성);
     }
 
+    @Test
+    void 레시피의_상세_정보를_조회한다() {
+        // given
+        카테고리_추가_요청(간편식사);
+        final var product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 간편식사);
+        final var product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 간편식사);
+        final var product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 간편식사);
+        final var products = List.of(product1, product2, product3);
+        복수_상품_추가_요청(products);
+        final var loginCookie = LoginSteps.로그인_쿠키를_얻는다();
+
+        final var createRequest = new RecipeCreateRequest("제일로 맛있는 레시피",
+                List.of(product1.getId(), product2.getId(), product3.getId()),
+                "우선 밥을 넣어요. 그리고 밥을 또 넣어요. 그리고 밥을 또 넣으면.. 끝!!");
+        final var images = 여러_사진_요청(3);
+        final var recipeId = 레시피_추가_요청하고_id_반환(createRequest, images, loginCookie);
+
+        // when
+        final var response = 레시피_상세_정보_요청(loginCookie, recipeId);
+
+        // then
+        final var recipe = recipeRepository.findById(recipeId).get();
+        final var actual = response.as(RecipeDetailResponse.class);
+        final var expected = RecipeDetailResponse.toResponse(
+                recipe, recipeImageRepository.findByRecipe(recipe),
+                products, 4500L, false);
+        STATUS_CODE를_검증한다(response, 정상_처리);
+        레시피_상세_정보_조회_결과를_검증한다(actual, expected);
+    }
+
     private Long 카테고리_추가_요청(final Category category) {
         return categoryRepository.save(category).getId();
     }
 
     private void 복수_상품_추가_요청(final List<Product> products) {
         productRepository.saveAll(products);
+    }
+
+    private static void 레시피_상세_정보_조회_결과를_검증한다(final RecipeDetailResponse actual, final RecipeDetailResponse expected) {
+        assertThat(actual).usingRecursiveComparison()
+                .isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
@@ -3,6 +3,7 @@ package com.funeat.acceptance.recipe;
 import static com.funeat.acceptance.common.CommonSteps.STATUS_CODE를_검증한다;
 import static com.funeat.acceptance.common.CommonSteps.정상_생성;
 import static com.funeat.acceptance.common.CommonSteps.정상_처리;
+import static com.funeat.acceptance.common.LoginSteps.로그인_쿠키를_얻는다;
 import static com.funeat.acceptance.product.ProductSteps.간편식사;
 import static com.funeat.acceptance.recipe.RecipeSteps.레시피_상세_정보_요청;
 import static com.funeat.acceptance.recipe.RecipeSteps.레시피_추가_요청;
@@ -11,8 +12,8 @@ import static com.funeat.acceptance.recipe.RecipeSteps.여러_사진_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.funeat.acceptance.common.AcceptanceTest;
-import com.funeat.acceptance.common.LoginSteps;
 import com.funeat.product.domain.Category;
+import com.funeat.product.domain.CategoryType;
 import com.funeat.product.domain.Product;
 import com.funeat.recipe.dto.RecipeCreateRequest;
 import com.funeat.recipe.dto.RecipeDetailResponse;
@@ -31,7 +32,7 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
         final var product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 간편식사);
         final var products = List.of(product1, product2, product3);
         복수_상품_추가_요청(products);
-        final var loginCookie = LoginSteps.로그인_쿠키를_얻는다();
+        final var loginCookie = 로그인_쿠키를_얻는다();
 
         // when
         final var request = new RecipeCreateRequest("제일로 맛있는 레시피",
@@ -47,29 +48,31 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
     @Test
     void 레시피의_상세_정보를_조회한다() {
         // given
-        카테고리_추가_요청(간편식사);
+        final var category = new Category("간편식사", CategoryType.FOOD);
+        카테고리_추가_요청(category);
         final var product1 = new Product("삼각김밥1", 1000L, "image.png", "맛있는 삼각김밥1", 간편식사);
         final var product2 = new Product("삼각김밥2", 2000L, "image.png", "맛있는 삼각김밥2", 간편식사);
         final var product3 = new Product("삼각김밥3", 1500L, "image.png", "맛있는 삼각김밥3", 간편식사);
         final var products = List.of(product1, product2, product3);
         복수_상품_추가_요청(products);
-        final var loginCookie = LoginSteps.로그인_쿠키를_얻는다();
+        final var loginCookie = 로그인_쿠키를_얻는다();
 
         final var createRequest = new RecipeCreateRequest("제일로 맛있는 레시피",
                 List.of(product1.getId(), product2.getId(), product3.getId()),
                 "우선 밥을 넣어요. 그리고 밥을 또 넣어요. 그리고 밥을 또 넣으면.. 끝!!");
         final var images = 여러_사진_요청(3);
         final var recipeId = 레시피_추가_요청하고_id_반환(createRequest, images, loginCookie);
+        final var recipe = recipeRepository.findById(recipeId).get();
+        final var findImages = recipeImageRepository.findByRecipe(recipe);
+        final var expected = RecipeDetailResponse.toResponse(
+                recipe, findImages,
+                products, 4500L, false);
 
         // when
         final var response = 레시피_상세_정보_요청(loginCookie, recipeId);
+        final var actual = response.as(RecipeDetailResponse.class);
 
         // then
-        final var recipe = recipeRepository.findById(recipeId).get();
-        final var actual = response.as(RecipeDetailResponse.class);
-        final var expected = RecipeDetailResponse.toResponse(
-                recipe, recipeImageRepository.findByRecipe(recipe),
-                products, 4500L, false);
         STATUS_CODE를_검증한다(response, 정상_처리);
         레시피_상세_정보_조회_결과를_검증한다(actual, expected);
     }

--- a/backend/src/test/java/com/funeat/acceptance/recipe/RecipeSteps.java
+++ b/backend/src/test/java/com/funeat/acceptance/recipe/RecipeSteps.java
@@ -45,7 +45,7 @@ public class RecipeSteps {
                 .extract();
     }
 
-    public static List<MultiPartSpecification> 여러_사진_요청(int count) {
+    public static List<MultiPartSpecification> 여러_사진_요청(final int count) {
         return IntStream.range(0, count)
                 .mapToObj(i -> new MultiPartSpecBuilder("image".getBytes())
                         .fileName("testImage.png")

--- a/backend/src/test/java/com/funeat/acceptance/recipe/RecipeSteps.java
+++ b/backend/src/test/java/com/funeat/acceptance/recipe/RecipeSteps.java
@@ -7,7 +7,6 @@ import io.restassured.builder.MultiPartSpecBuilder;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.MultiPartSpecification;
-import io.restassured.specification.RequestSpecification;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -25,6 +24,24 @@ public class RecipeSteps {
                 .when()
                 .post("/api/recipes")
                 .then()
+                .extract();
+    }
+
+    public static Long 레시피_추가_요청하고_id_반환(final RecipeCreateRequest recipeRequest,
+                                         final List<MultiPartSpecification> imageList,
+                                         final String loginCookie) {
+        final var response = 레시피_추가_요청(recipeRequest, imageList, loginCookie);
+        return Long.parseLong(response.header("Location").split("/")[3]);
+    }
+
+    public static ExtractableResponse<Response> 레시피_상세_정보_요청(final String loginCookie, final Long recipeId) {
+        return given()
+                .cookie("JSESSIONID", loginCookie)
+                .log().all()
+                .when()
+                .get("/api/recipes/{recipeId}", recipeId)
+                .then()
+                .log().all()
                 .extract();
     }
 

--- a/backend/src/test/java/com/funeat/acceptance/recipe/RecipeSteps.java
+++ b/backend/src/test/java/com/funeat/acceptance/recipe/RecipeSteps.java
@@ -37,11 +37,9 @@ public class RecipeSteps {
     public static ExtractableResponse<Response> 레시피_상세_정보_요청(final String loginCookie, final Long recipeId) {
         return given()
                 .cookie("JSESSIONID", loginCookie)
-                .log().all()
                 .when()
                 .get("/api/recipes/{recipeId}", recipeId)
                 .then()
-                .log().all()
                 .extract();
     }
 

--- a/backend/src/test/java/com/funeat/member/persistence/RecipeFavoriteRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/member/persistence/RecipeFavoriteRepositoryTest.java
@@ -67,12 +67,12 @@ class RecipeFavoriteRepositoryTest {
         final var fakeMember = 멤버_추가_요청(new Member("fake", "image.png", "3"));
         레시피_좋아요_요청(new RecipeFavorite(realMember, recipe, true));
 
-        final var realMemberActual = recipeFavoriteRepository.findByMemberAndRecipe(realMember, recipe);
-        final var fakeMemberActual = recipeFavoriteRepository.findByMemberAndRecipe(fakeMember, recipe);
+        final var realMemberActual = recipeFavoriteRepository.existsByMemberAndRecipeAndFavoriteTrue(realMember, recipe);
+        final var fakeMemberActual = recipeFavoriteRepository.existsByMemberAndRecipeAndFavoriteTrue(fakeMember, recipe);
 
         // then
-        assertThat(realMemberActual).isNotEmpty();
-        assertThat(fakeMemberActual).isEmpty();
+        assertThat(realMemberActual).isTrue();
+        assertThat(fakeMemberActual).isFalse();
     }
 
     private Category 카테고리_추가_요청(final Category category) {

--- a/backend/src/test/java/com/funeat/member/persistence/RecipeFavoriteRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/member/persistence/RecipeFavoriteRepositoryTest.java
@@ -57,9 +57,9 @@ class RecipeFavoriteRepositoryTest {
         final var product2 = 상품_추가_요청(new Product("참치 삼김", 2000L, "image.png", "담백한 참치마요 삼김", category));
         final var product3 = 상품_추가_요청(new Product("스트링 치즈", 1500L, "image.png", "고소한 치즈", category));
         final var recipeAuthor = 멤버_추가_요청(new Member("author", "image.png", "1"));
-        List<Product> products = List.of(product1, product2, product3);
+        final var products = List.of(product1, product2, product3);
 
-        Recipe recipe = 레시피_추가_요청(new Recipe("레시피1", "밥 넣고 밥 넣자", recipeAuthor));
+        final var recipe = 레시피_추가_요청(new Recipe("레시피1", "밥 넣고 밥 넣자", recipeAuthor));
         products.forEach(it -> 레시피에_사용된_상품_추가_요청(new ProductRecipe(it, recipe)));
 
         // when
@@ -67,8 +67,8 @@ class RecipeFavoriteRepositoryTest {
         final var fakeMember = 멤버_추가_요청(new Member("fake", "image.png", "3"));
         recipeFavoriteRepository.save(new RecipeFavorite(realMember, recipe, true));
 
-        Optional<RecipeFavorite> realMemberActual = recipeFavoriteRepository.findByMemberAndRecipe(realMember, recipe);
-        Optional<RecipeFavorite> fakeMemberActual = recipeFavoriteRepository.findByMemberAndRecipe(fakeMember, recipe);
+        final var realMemberActual = recipeFavoriteRepository.findByMemberAndRecipe(realMember, recipe);
+        final var fakeMemberActual = recipeFavoriteRepository.findByMemberAndRecipe(fakeMember, recipe);
 
         // then
         assertThat(realMemberActual).isNotEmpty();

--- a/backend/src/test/java/com/funeat/member/persistence/RecipeFavoriteRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/member/persistence/RecipeFavoriteRepositoryTest.java
@@ -60,7 +60,7 @@ class RecipeFavoriteRepositoryTest {
         List<Product> products = List.of(product1, product2, product3);
 
         Recipe recipe = 레시피_추가_요청(new Recipe("레시피1", "밥 넣고 밥 넣자", recipeAuthor));
-        products.forEach(it -> productRecipeRepository.save(new ProductRecipe(it, recipe)));
+        products.forEach(it -> 레시피에_사용된_상품_추가_요청(new ProductRecipe(it, recipe)));
 
         // when
         final var realMember = 멤버_추가_요청(new Member("real", "image.png", "2"));
@@ -89,5 +89,9 @@ class RecipeFavoriteRepositoryTest {
 
     private Recipe 레시피_추가_요청(final Recipe recipe) {
         return recipeRepository.save(recipe);
+    }
+
+    private ProductRecipe 레시피에_사용된_상품_추가_요청(final ProductRecipe productRecipe) {
+        return productRecipeRepository.save(productRecipe);
     }
 }

--- a/backend/src/test/java/com/funeat/member/persistence/RecipeFavoriteRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/member/persistence/RecipeFavoriteRepositoryTest.java
@@ -16,7 +16,6 @@ import com.funeat.product.persistence.ProductRepository;
 import com.funeat.recipe.domain.Recipe;
 import com.funeat.recipe.persistence.RecipeRepository;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -31,6 +30,7 @@ import org.springframework.context.annotation.Import;
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class RecipeFavoriteRepositoryTest {
+
     @Autowired
     private CategoryRepository categoryRepository;
 
@@ -65,7 +65,7 @@ class RecipeFavoriteRepositoryTest {
         // when
         final var realMember = 멤버_추가_요청(new Member("real", "image.png", "2"));
         final var fakeMember = 멤버_추가_요청(new Member("fake", "image.png", "3"));
-        recipeFavoriteRepository.save(new RecipeFavorite(realMember, recipe, true));
+        레시피_좋아요_요청(new RecipeFavorite(realMember, recipe, true));
 
         final var realMemberActual = recipeFavoriteRepository.findByMemberAndRecipe(realMember, recipe);
         final var fakeMemberActual = recipeFavoriteRepository.findByMemberAndRecipe(fakeMember, recipe);
@@ -93,5 +93,9 @@ class RecipeFavoriteRepositoryTest {
 
     private ProductRecipe 레시피에_사용된_상품_추가_요청(final ProductRecipe productRecipe) {
         return productRecipeRepository.save(productRecipe);
+    }
+
+    private RecipeFavorite 레시피_좋아요_요청(final RecipeFavorite recipeFavorite) {
+        return recipeFavoriteRepository.save(recipeFavorite);
     }
 }

--- a/backend/src/test/java/com/funeat/member/persistence/RecipeFavoriteRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/member/persistence/RecipeFavoriteRepositoryTest.java
@@ -1,0 +1,93 @@
+package com.funeat.member.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.funeat.common.DataCleaner;
+import com.funeat.common.DataClearExtension;
+import com.funeat.member.domain.Member;
+import com.funeat.member.domain.favorite.RecipeFavorite;
+import com.funeat.product.domain.Category;
+import com.funeat.product.domain.CategoryType;
+import com.funeat.product.domain.Product;
+import com.funeat.product.domain.ProductRecipe;
+import com.funeat.product.persistence.CategoryRepository;
+import com.funeat.product.persistence.ProductRecipeRepository;
+import com.funeat.product.persistence.ProductRepository;
+import com.funeat.recipe.domain.Recipe;
+import com.funeat.recipe.persistence.RecipeRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(DataCleaner.class)
+@ExtendWith(DataClearExtension.class)
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class RecipeFavoriteRepositoryTest {
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RecipeRepository recipeRepository;
+
+    @Autowired
+    private ProductRecipeRepository productRecipeRepository;
+
+    @Autowired
+    private RecipeFavoriteRepository recipeFavoriteRepository;
+
+    @Test
+    void 사용자의_레시피에_대한_좋아요_현황을_알_수_있다() {
+        // given
+        final var category = 카테고리_추가_요청(new Category("간편식사", CategoryType.FOOD));
+        final var product1 = 상품_추가_요청(new Product("불닭볶음면", 1000L, "image.png", "엄청 매운 불닭", category));
+        final var product2 = 상품_추가_요청(new Product("참치 삼김", 2000L, "image.png", "담백한 참치마요 삼김", category));
+        final var product3 = 상품_추가_요청(new Product("스트링 치즈", 1500L, "image.png", "고소한 치즈", category));
+        final var recipeAuthor = 멤버_추가_요청(new Member("author", "image.png", "1"));
+        List<Product> products = List.of(product1, product2, product3);
+
+        Recipe recipe = 레시피_추가_요청(new Recipe("레시피1", "밥 넣고 밥 넣자", recipeAuthor));
+        products.forEach(it -> productRecipeRepository.save(new ProductRecipe(it, recipe)));
+
+        // when
+        final var realMember = 멤버_추가_요청(new Member("real", "image.png", "2"));
+        final var fakeMember = 멤버_추가_요청(new Member("fake", "image.png", "3"));
+        recipeFavoriteRepository.save(new RecipeFavorite(realMember, recipe, true));
+
+        Optional<RecipeFavorite> realMemberActual = recipeFavoriteRepository.findByMemberAndRecipe(realMember, recipe);
+        Optional<RecipeFavorite> fakeMemberActual = recipeFavoriteRepository.findByMemberAndRecipe(fakeMember, recipe);
+
+        // then
+        assertThat(realMemberActual).isNotEmpty();
+        assertThat(fakeMemberActual).isEmpty();
+    }
+
+    private Category 카테고리_추가_요청(final Category category) {
+        return categoryRepository.save(category);
+    }
+
+    private Product 상품_추가_요청(final Product product) {
+        return productRepository.save(product);
+    }
+
+    private Member 멤버_추가_요청(final Member member) {
+        return memberRepository.save(member);
+    }
+
+    private Recipe 레시피_추가_요청(final Recipe recipe) {
+        return recipeRepository.save(recipe);
+    }
+}

--- a/backend/src/test/java/com/funeat/product/persistence/ProductRecipeRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/product/persistence/ProductRecipeRepositoryTest.java
@@ -50,11 +50,12 @@ class ProductRecipeRepositoryTest {
         final var product1 = 상품_추가_요청(new Product("불닭볶음면", 1000L, "image.png", "엄청 매운 불닭", category));
         final var product2 = 상품_추가_요청(new Product("참치 삼김", 2000L, "image.png", "담백한 참치마요 삼김", category));
         final var product3 = 상품_추가_요청(new Product("스트링 치즈", 1500L, "image.png", "고소한 치즈", category));
+        final var products = List.of(product1, product2, product3);
         final var member = 멤버_추가_요청(new Member("test", "image.png", "1"));
-        final var expected = List.of(product1, product2, product3);
 
         final var recipe = 레시피_추가_요청(new Recipe("레시피1", "밥 넣고 밥 넣자", member));
-        expected.forEach(it -> 레시피에_사용된_상품_추가_요청(new ProductRecipe(it, recipe)));
+        복수_레시피_상품_추가_요청(products, recipe);
+        final var expected = products;
 
         // when
         final var actual = productRecipeRepository.findProductByRecipe(recipe);
@@ -80,7 +81,9 @@ class ProductRecipeRepositoryTest {
         return recipeRepository.save(recipe);
     }
 
-    private ProductRecipe 레시피에_사용된_상품_추가_요청(final ProductRecipe productRecipe) {
-        return productRecipeRepository.save(productRecipe);
+    private void 복수_레시피_상품_추가_요청(final List<Product> products, final Recipe recipe) {
+        for (Product product : products) {
+            productRecipeRepository.save(new ProductRecipe(product, recipe));
+        }
     }
 }

--- a/backend/src/test/java/com/funeat/product/persistence/ProductRecipeRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/product/persistence/ProductRecipeRepositoryTest.java
@@ -51,13 +51,13 @@ class ProductRecipeRepositoryTest {
         final var product2 = 상품_추가_요청(new Product("참치 삼김", 2000L, "image.png", "담백한 참치마요 삼김", category));
         final var product3 = 상품_추가_요청(new Product("스트링 치즈", 1500L, "image.png", "고소한 치즈", category));
         final var member = 멤버_추가_요청(new Member("test", "image.png", "1"));
-        List<Product> expected = List.of(product1, product2, product3);
+        final var expected = List.of(product1, product2, product3);
 
-        Recipe recipe = 레시피_추가_요청(new Recipe("레시피1", "밥 넣고 밥 넣자", member));
+        final var recipe = 레시피_추가_요청(new Recipe("레시피1", "밥 넣고 밥 넣자", member));
         expected.forEach(it -> 레시피에_사용된_상품_추가_요청(new ProductRecipe(it, recipe)));
 
         // when
-        List<Product> actual = productRecipeRepository.findProductByRecipe(recipe);
+        final var actual = productRecipeRepository.findProductByRecipe(recipe);
 
         // then
         assertThat(actual).usingRecursiveComparison()

--- a/backend/src/test/java/com/funeat/product/persistence/ProductRecipeRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/product/persistence/ProductRecipeRepositoryTest.java
@@ -54,7 +54,7 @@ class ProductRecipeRepositoryTest {
         List<Product> expected = List.of(product1, product2, product3);
 
         Recipe recipe = 레시피_추가_요청(new Recipe("레시피1", "밥 넣고 밥 넣자", member));
-        expected.forEach(it -> productRecipeRepository.save(new ProductRecipe(it, recipe)));
+        expected.forEach(it -> 레시피에_사용된_상품_추가_요청(new ProductRecipe(it, recipe)));
 
         // when
         List<Product> actual = productRecipeRepository.findProductByRecipe(recipe);
@@ -78,5 +78,9 @@ class ProductRecipeRepositoryTest {
 
     private Recipe 레시피_추가_요청(final Recipe recipe) {
         return recipeRepository.save(recipe);
+    }
+
+    private ProductRecipe 레시피에_사용된_상품_추가_요청(final ProductRecipe productRecipe) {
+        return productRecipeRepository.save(productRecipe);
     }
 }

--- a/backend/src/test/java/com/funeat/product/persistence/ProductRecipeRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/product/persistence/ProductRecipeRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.funeat.product.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.funeat.common.DataCleaner;
+import com.funeat.common.DataClearExtension;
+import com.funeat.member.domain.Member;
+import com.funeat.member.persistence.MemberRepository;
+import com.funeat.product.domain.Category;
+import com.funeat.product.domain.CategoryType;
+import com.funeat.product.domain.Product;
+import com.funeat.product.domain.ProductRecipe;
+import com.funeat.recipe.domain.Recipe;
+import com.funeat.recipe.persistence.RecipeRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(DataCleaner.class)
+@ExtendWith(DataClearExtension.class)
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class ProductRecipeRepositoryTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RecipeRepository recipeRepository;
+
+    @Autowired
+    private ProductRecipeRepository productRecipeRepository;
+
+    @Test
+    void 레시피에_사용된_상품들을_조회할_수_있다() {
+        // given
+        final var category = 카테고리_추가_요청(new Category("간편식사", CategoryType.FOOD));
+        final var product1 = 상품_추가_요청(new Product("불닭볶음면", 1000L, "image.png", "엄청 매운 불닭", category));
+        final var product2 = 상품_추가_요청(new Product("참치 삼김", 2000L, "image.png", "담백한 참치마요 삼김", category));
+        final var product3 = 상품_추가_요청(new Product("스트링 치즈", 1500L, "image.png", "고소한 치즈", category));
+        final var member = 멤버_추가_요청(new Member("test", "image.png", "1"));
+        List<Product> expected = List.of(product1, product2, product3);
+
+        Recipe recipe = 레시피_추가_요청(new Recipe("레시피1", "밥 넣고 밥 넣자", member));
+        expected.forEach(it -> productRecipeRepository.save(new ProductRecipe(it, recipe)));
+
+        // when
+        List<Product> actual = productRecipeRepository.findProductByRecipe(recipe);
+
+        // then
+        assertThat(actual).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    private Category 카테고리_추가_요청(final Category category) {
+        return categoryRepository.save(category);
+    }
+
+    private Product 상품_추가_요청(final Product product) {
+        return productRepository.save(product);
+    }
+
+    private Member 멤버_추가_요청(final Member member) {
+        return memberRepository.save(member);
+    }
+
+    private Recipe 레시피_추가_요청(final Recipe recipe) {
+        return recipeRepository.save(recipe);
+    }
+}

--- a/backend/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
+++ b/backend/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
@@ -11,7 +11,6 @@ import com.funeat.product.domain.Product;
 import com.funeat.product.persistence.CategoryRepository;
 import com.funeat.product.persistence.ProductRepository;
 import com.funeat.recipe.domain.Recipe;
-import com.funeat.recipe.dto.RecipeAuthorDto;
 import com.funeat.recipe.dto.RecipeCreateRequest;
 import com.funeat.recipe.dto.RecipeDetailResponse;
 import com.funeat.recipe.persistence.RecipeImageRepository;
@@ -86,27 +85,28 @@ class RecipeServiceTest {
         final var product1 = 상품_추가_요청(new Product("불닭볶음면", 1000L, "image.png", "엄청 매운 불닭", category));
         final var product2 = 상품_추가_요청(new Product("참치 삼김", 2000L, "image.png", "담백한 참치마요 삼김", category));
         final var product3 = 상품_추가_요청(new Product("스트링 치즈", 1500L, "image.png", "고소한 치즈", category));
-        final var recipeAuthor = 멤버_추가_요청(new Member("author", "image.png", "1"));
+        final var products = List.of(product1, product2, product3);
+        final var author = 멤버_추가_요청(new Member("author", "image.png", "1"));
+        final var authorId = author.getId();
 
         final var image1 = new MockMultipartFile("image1", "image1.jpg", "image/jpeg", new byte[]{1, 2, 3});
         final var image2 = new MockMultipartFile("image2", "image2.jpg", "image/jpeg", new byte[]{1, 2, 3});
         final var image3 = new MockMultipartFile("image3", "image3.jpg", "image/jpeg", new byte[]{1, 2, 3});
 
-        final var request = new RecipeCreateRequest("제일로 맛있는 레시피",
-                List.of(product1.getId(), product2.getId(), product3.getId()),
+        final var productIds = List.of(product1.getId(), product2.getId(), product3.getId());
+        final var request = new RecipeCreateRequest("제일로 맛있는 레시피", productIds,
                 "우선 밥을 넣어요. 그리고 밥을 또 넣어요. 그리고 밥을 또 넣으면.. 끝!!");
 
-        final var recipeId = recipeService.create(recipeAuthor.getId(), List.of(image1, image2, image3), request);
+        final var recipeId = recipeService.create(authorId, List.of(image1, image2, image3), request);
 
         // when
-        final var actual = recipeService.getRecipeDetail(recipeAuthor.getId(), recipeId);
+        final var actual = recipeService.getRecipeDetail(authorId, recipeId);
 
         // then
         final var recipe = recipeRepository.findById(recipeId).get();
         final var expected = RecipeDetailResponse.toResponse(
                 recipe, recipeImageRepository.findByRecipe(recipe),
-                List.of(product1, product2, product3),
-                4500L, false);
+                products, 4500L, false);
 
         assertThat(actual).usingRecursiveComparison()
                 .isEqualTo(expected);

--- a/backend/src/test/java/com/funeat/recipe/persistence/RecipeImageRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/recipe/persistence/RecipeImageRepositoryTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.mock.web.MockMultipartFile;
 
 @DataJpaTest
 @Import(DataCleaner.class)
@@ -58,10 +57,10 @@ class RecipeImageRepositoryTest {
         final var product2 = 상품_추가_요청(new Product("참치 삼김", 2000L, "image.png", "담백한 참치마요 삼김", category));
         final var product3 = 상품_추가_요청(new Product("스트링 치즈", 1500L, "image.png", "고소한 치즈", category));
         final var member = 멤버_추가_요청(new Member("test", "image.png", "1"));
-        final var expected = List.of(product1, product2, product3);
+        final var products = List.of(product1, product2, product3);
 
         final var recipe = 레시피_추가_요청(new Recipe("레시피1", "밥 넣고 밥 넣자", member));
-        expected.forEach(it -> 레시피에_사용된_상품_추가_요청(new ProductRecipe(it, recipe)));
+        products.forEach(it -> 레시피에_사용된_상품_추가_요청(new ProductRecipe(it, recipe)));
 
         final var image1 = new RecipeImage("1번사진", recipe);
         final var image2 = new RecipeImage("2번사진", recipe);

--- a/backend/src/test/java/com/funeat/recipe/persistence/RecipeImageRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/recipe/persistence/RecipeImageRepositoryTest.java
@@ -56,11 +56,11 @@ class RecipeImageRepositoryTest {
         final var product1 = 상품_추가_요청(new Product("불닭볶음면", 1000L, "image.png", "엄청 매운 불닭", category));
         final var product2 = 상품_추가_요청(new Product("참치 삼김", 2000L, "image.png", "담백한 참치마요 삼김", category));
         final var product3 = 상품_추가_요청(new Product("스트링 치즈", 1500L, "image.png", "고소한 치즈", category));
-        final var member = 멤버_추가_요청(new Member("test", "image.png", "1"));
         final var products = List.of(product1, product2, product3);
+        final var member = 멤버_추가_요청(new Member("test", "image.png", "1"));
 
         final var recipe = 레시피_추가_요청(new Recipe("레시피1", "밥 넣고 밥 넣자", member));
-        products.forEach(it -> 레시피에_사용된_상품_추가_요청(new ProductRecipe(it, recipe)));
+        복수_레시피_상품_추가_요청(products, recipe);
 
         final var image1 = new RecipeImage("1번사진", recipe);
         final var image2 = new RecipeImage("2번사진", recipe);
@@ -90,11 +90,13 @@ class RecipeImageRepositoryTest {
         return recipeRepository.save(recipe);
     }
 
-    private ProductRecipe 레시피에_사용된_상품_추가_요청(final ProductRecipe productRecipe) {
-        return productRecipeRepository.save(productRecipe);
-    }
-
     private void 복수_레시피_이미지_추가_요청(final List<RecipeImage> images) {
         recipeImageRepository.saveAll(images);
+    }
+
+    private void 복수_레시피_상품_추가_요청(final List<Product> products, final Recipe recipe) {
+        for (Product product : products) {
+            productRecipeRepository.save(new ProductRecipe(product, recipe));
+        }
     }
 }

--- a/backend/src/test/java/com/funeat/recipe/persistence/RecipeImageRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/recipe/persistence/RecipeImageRepositoryTest.java
@@ -58,18 +58,18 @@ class RecipeImageRepositoryTest {
         final var product2 = 상품_추가_요청(new Product("참치 삼김", 2000L, "image.png", "담백한 참치마요 삼김", category));
         final var product3 = 상품_추가_요청(new Product("스트링 치즈", 1500L, "image.png", "고소한 치즈", category));
         final var member = 멤버_추가_요청(new Member("test", "image.png", "1"));
-        List<Product> expected = List.of(product1, product2, product3);
+        final var expected = List.of(product1, product2, product3);
 
-        Recipe recipe = 레시피_추가_요청(new Recipe("레시피1", "밥 넣고 밥 넣자", member));
+        final var recipe = 레시피_추가_요청(new Recipe("레시피1", "밥 넣고 밥 넣자", member));
         expected.forEach(it -> 레시피에_사용된_상품_추가_요청(new ProductRecipe(it, recipe)));
 
-        RecipeImage image1 = new RecipeImage("1번사진", recipe);
-        RecipeImage image2 = new RecipeImage("2번사진", recipe);
-        RecipeImage image3 = new RecipeImage("3번사진", recipe);
+        final var image1 = new RecipeImage("1번사진", recipe);
+        final var image2 = new RecipeImage("2번사진", recipe);
+        final var image3 = new RecipeImage("3번사진", recipe);
         복수_레시피_이미지_추가_요청(List.of(image1, image2, image3));
 
         // when
-        List<RecipeImage> images = recipeImageRepository.findByRecipe(recipe);
+        final var images = recipeImageRepository.findByRecipe(recipe);
 
         // then
         assertThat(images.size()).isEqualTo(3);

--- a/backend/src/test/java/com/funeat/recipe/persistence/RecipeImageRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/recipe/persistence/RecipeImageRepositoryTest.java
@@ -1,0 +1,101 @@
+package com.funeat.recipe.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.funeat.common.DataCleaner;
+import com.funeat.common.DataClearExtension;
+import com.funeat.member.domain.Member;
+import com.funeat.member.persistence.MemberRepository;
+import com.funeat.product.domain.Category;
+import com.funeat.product.domain.CategoryType;
+import com.funeat.product.domain.Product;
+import com.funeat.product.domain.ProductRecipe;
+import com.funeat.product.persistence.CategoryRepository;
+import com.funeat.product.persistence.ProductRecipeRepository;
+import com.funeat.product.persistence.ProductRepository;
+import com.funeat.recipe.domain.Recipe;
+import com.funeat.recipe.domain.RecipeImage;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
+
+@DataJpaTest
+@Import(DataCleaner.class)
+@ExtendWith(DataClearExtension.class)
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class RecipeImageRepositoryTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RecipeRepository recipeRepository;
+
+    @Autowired
+    private ProductRecipeRepository productRecipeRepository;
+
+    @Autowired
+    private RecipeImageRepository recipeImageRepository;
+
+    @Test
+    void 레시피에_사용된_이미지들을_조회할_수_있다() {
+        // given
+        final var category = 카테고리_추가_요청(new Category("간편식사", CategoryType.FOOD));
+        final var product1 = 상품_추가_요청(new Product("불닭볶음면", 1000L, "image.png", "엄청 매운 불닭", category));
+        final var product2 = 상품_추가_요청(new Product("참치 삼김", 2000L, "image.png", "담백한 참치마요 삼김", category));
+        final var product3 = 상품_추가_요청(new Product("스트링 치즈", 1500L, "image.png", "고소한 치즈", category));
+        final var member = 멤버_추가_요청(new Member("test", "image.png", "1"));
+        List<Product> expected = List.of(product1, product2, product3);
+
+        Recipe recipe = 레시피_추가_요청(new Recipe("레시피1", "밥 넣고 밥 넣자", member));
+        expected.forEach(it -> 레시피에_사용된_상품_추가_요청(new ProductRecipe(it, recipe)));
+
+        RecipeImage image1 = new RecipeImage("1번사진", recipe);
+        RecipeImage image2 = new RecipeImage("2번사진", recipe);
+        RecipeImage image3 = new RecipeImage("3번사진", recipe);
+        복수_레시피_이미지_추가_요청(List.of(image1, image2, image3));
+
+        // when
+        List<RecipeImage> images = recipeImageRepository.findByRecipe(recipe);
+
+        // then
+        assertThat(images.size()).isEqualTo(3);
+    }
+
+    private Category 카테고리_추가_요청(final Category category) {
+        return categoryRepository.save(category);
+    }
+
+    private Product 상품_추가_요청(final Product product) {
+        return productRepository.save(product);
+    }
+
+    private Member 멤버_추가_요청(final Member member) {
+        return memberRepository.save(member);
+    }
+
+    private Recipe 레시피_추가_요청(final Recipe recipe) {
+        return recipeRepository.save(recipe);
+    }
+
+    private ProductRecipe 레시피에_사용된_상품_추가_요청(final ProductRecipe productRecipe) {
+        return productRecipeRepository.save(productRecipe);
+    }
+
+    private void 복수_레시피_이미지_추가_요청(final List<RecipeImage> images) {
+        recipeImageRepository.saveAll(images);
+    }
+}


### PR DESCRIPTION
## Issue

- close #354 

## ✨ 구현한 기능

꿀조합 상세 정보 조회 기능

## 📢 논의하고 싶은 내용

**Interceptor의 PathPattern**

현상태 : `/api/recipes`로 들어오는 요청이고 `GET`이 아니면 RecipeHandlerInterceptor 작동

<img width="629" alt="image" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/91522259/12f684ef-28f1-4b6c-a9fe-6665c39e30f2">

## 🎸 기타

- `Review` 형식에 맞춰서 `Recipe`에도 `FavoriteCount` 추가
- `Recipe`의 `name` 필드를 `title`로 수정

## ⏰ 일정

- 추정 시간 : 3
- 걸린 시간 : 3.5
