### PR TITLE
[FE] fix: 상품 상세 페이지에서 무한스크롤 안되는 버그 수정

### DIFF
--- a/frontend/src/components/Product/ProductList/ProductList.tsx
+++ b/frontend/src/components/Product/ProductList/ProductList.tsx
@@ -17,16 +17,18 @@ interface ProductListProps {
 
 const ProductList = ({ category, productList }: ProductListProps, ref: ForwardedRef<HTMLDivElement>) => {
   return (
-    <ProductListContainer>
-      {productList.map((product) => (
-        <li key={product.id}>
-          <Link as={RouterLink} to={`${PATH.PRODUCT_LIST}/${category}/${product.id}`}>
-            <ProductItem product={product} />
-          </Link>
-        </li>
-      ))}
+    <>
+      <ProductListContainer>
+        {productList.map((product) => (
+          <li key={product.id}>
+            <Link as={RouterLink} to={`${PATH.PRODUCT_LIST}/${category}/${product.id}`}>
+              <ProductItem product={product} />
+            </Link>
+          </li>
+        ))}
+      </ProductListContainer>
       <div ref={ref} aria-hidden />
-    </ProductListContainer>
+    </>
   );
 };
 export default forwardRef(ProductList);

--- a/frontend/src/hooks/useIntersectionObserver.ts
+++ b/frontend/src/hooks/useIntersectionObserver.ts
@@ -10,19 +10,13 @@ const defaultOptions = {
 const useIntersectionObserver = <T extends HTMLElement>(
   callback: () => void,
   targetRef: RefObject<T>,
-  isLastPage: boolean | undefined
+  hasNextPage: boolean | undefined
 ) => {
-  let isInitial = true;
-
   const observer = useRef(
     new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
-          if (isInitial) {
-            isInitial = false;
-          } else {
-            callback();
-          }
+          callback();
         }
       });
     }, defaultOptions)
@@ -41,7 +35,7 @@ const useIntersectionObserver = <T extends HTMLElement>(
       return;
     }
 
-    if (isLastPage) {
+    if (!hasNextPage) {
       unobserve(targetRef.current);
       return;
     }
@@ -51,7 +45,7 @@ const useIntersectionObserver = <T extends HTMLElement>(
     return () => {
       observer.current.disconnect();
     };
-  }, [targetRef.current]);
+  }, [targetRef.current, hasNextPage]);
 };
 
 export default useIntersectionObserver;

--- a/frontend/src/mocks/handlers/reviewHandlers.ts
+++ b/frontend/src/mocks/handlers/reviewHandlers.ts
@@ -11,6 +11,7 @@ export const reviewHandlers = [
   rest.get('/api/products/:productId/reviews', (req, res, ctx) => {
     const { mockSessionId } = req.cookies;
     const sortOptions = req.url.searchParams.get('sort');
+    const page = Number(req.url.searchParams.get('page'));
 
     if (!mockSessionId) {
       return res(ctx.status(403));
@@ -33,7 +34,10 @@ export const reviewHandlers = [
       ),
     };
 
-    return res(ctx.status(200), ctx.json(sortedReviews));
+    return res(
+      ctx.status(200),
+      ctx.json({ page: sortedReviews.page, reviews: sortedReviews.reviews.slice(page * 5, (page + 1) * 5) })
+    );
   }),
 
   rest.post('/api/products/:productId/reviews', (req, res, ctx) => {


### PR DESCRIPTION
## Issue

- close #363 

## ✨ 구현한 기능

- `isLastPage` 랑 `hasNextPage` 랑 혼동되어 있어 조건을 수정했습니다.
- `isInitial` 선언했던것 때문에 안되는 것 같아서 삭제했습니다.

## 📢 논의하고 싶은 내용

x

## 🎸 기타

x

## ⏰ 일정

- 추정 시간 :
- 걸린 시간 : 0.5
