### PR TITLE
[FE] feat: 프로필 타이틀 컴포넌트 구현

### DIFF
--- a/frontend/.storybook/preview-body.html
+++ b/frontend/.storybook/preview-body.html
@@ -90,5 +90,10 @@
     <symbol id="plus" viewBox="0 0 24 24">
       <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2Z" />
     </symbol>
+    <symbol viewBox="0 0 24 24" id="pencil">
+      <path
+        d="m19.3 8.925l-4.25-4.2l1.4-1.4q.575-.575 1.413-.575t1.412.575l1.4 1.4q.575.575.6 1.388t-.55 1.387L19.3 8.925ZM17.85 10.4L7.25 21H3v-4.25l10.6-10.6l4.25 4.25Z"
+      />
+    </symbol>
   </svg>
 </div>

--- a/frontend/src/components/Common/Svg/SvgIcon.tsx
+++ b/frontend/src/components/Common/Svg/SvgIcon.tsx
@@ -19,6 +19,7 @@ export const SVG_ICON_VARIANTS = [
   'close',
   'triangle',
   'plus',
+  'pencil',
 ] as const;
 export type SvgIconVariant = (typeof SVG_ICON_VARIANTS)[number];
 

--- a/frontend/src/components/Common/Svg/SvgSprite.tsx
+++ b/frontend/src/components/Common/Svg/SvgSprite.tsx
@@ -68,6 +68,9 @@ const SvgSprite = () => {
       <symbol id="plus" viewBox="0 0 24 24">
         <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2Z" />
       </symbol>
+      <symbol viewBox="0 0 24 24" id="pencil">
+        <path d="m19.3 8.925l-4.25-4.2l1.4-1.4q.575-.575 1.413-.575t1.412.575l1.4 1.4q.575.575.6 1.388t-.55 1.387L19.3 8.925ZM17.85 10.4L7.25 21H3v-4.25l10.6-10.6l4.25 4.25Z" />
+      </symbol>
     </svg>
   );
 };

--- a/frontend/src/components/Members/MembersTitle/MembersTitle.tsx
+++ b/frontend/src/components/Members/MembersTitle/MembersTitle.tsx
@@ -1,5 +1,5 @@
 import { Button, Heading, theme } from '@fun-eat/design-system';
-import { styled } from 'styled-components';
+import styled from 'styled-components';
 
 import { SvgIcon } from '@/components/Common';
 import type { Member } from '@/types/member';

--- a/frontend/src/components/Members/MembersTitle/MembersTitle.tsx
+++ b/frontend/src/components/Members/MembersTitle/MembersTitle.tsx
@@ -1,7 +1,9 @@
-import { Button, Heading, theme } from '@fun-eat/design-system';
+import { Button, Heading, Link, theme } from '@fun-eat/design-system';
+import { Link as RouterLink } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { SvgIcon } from '@/components/Common';
+import { PATH } from '@/constants/path';
 import type { Member } from '@/types/member';
 
 interface MembersTitleProps {
@@ -18,11 +20,11 @@ const MembersTitle = ({ member }: MembersTitleProps) => {
         <Heading size="xl" weight="bold">
           {nickname} 님
         </Heading>
-        <MemberModifyButton type="button" variant="transparent">
+        <MemberModifyLink as={RouterLink} to={`${PATH.PROFILE}/modify`}>
           <SvgIcon variant="pencil" width={20} height={24} color={theme.colors.gray3} />
-        </MemberModifyButton>
+        </MemberModifyLink>
       </MemberTitleInfoWrapper>
-      <Button textColor="disabled" variant="transparent">
+      <Button type="button" textColor="disabled" variant="transparent">
         로그아웃
       </Button>
     </MembersTitleContainer>
@@ -42,7 +44,7 @@ const MemberTitleInfoWrapper = styled.div`
   align-items: center;
 `;
 
-const MemberModifyButton = styled(Button)`
+const MemberModifyLink = styled(Link)`
   margin-left: 5px;
   transform: translateY(1px);
 `;

--- a/frontend/src/components/Members/MembersTitle/MembersTitle.tsx
+++ b/frontend/src/components/Members/MembersTitle/MembersTitle.tsx
@@ -1,0 +1,54 @@
+import { Button, Heading, theme } from '@fun-eat/design-system';
+import { styled } from 'styled-components';
+
+import { SvgIcon } from '@/components/Common';
+import type { Member } from '@/types/member';
+
+interface MembersTitleProps {
+  member: Member;
+}
+
+const MembersTitle = ({ member }: MembersTitleProps) => {
+  const { nickname, profileImage } = member;
+
+  return (
+    <MembersTitleContainer>
+      <MemberTitleInfoWrapper>
+        <MembersImage src={profileImage} width={45} height={45} alt={`${nickname}의 프로필`} />
+        <Heading size="xl" weight="bold">
+          {nickname} 님
+        </Heading>
+        <MemberModifyButton type="button" variant="transparent">
+          <SvgIcon variant="pencil" width={20} height={24} color={theme.colors.gray3} />
+        </MemberModifyButton>
+      </MemberTitleInfoWrapper>
+      <Button textColor="disabled" variant="transparent">
+        로그아웃
+      </Button>
+    </MembersTitleContainer>
+  );
+};
+
+export default MembersTitle;
+
+const MembersTitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const MemberTitleInfoWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const MemberModifyButton = styled(Button)`
+  margin-left: 5px;
+  transform: translateY(1px);
+`;
+
+const MembersImage = styled.img`
+  margin-right: 16px;
+  border-radius: 50%;
+  border: 2px solid ${({ theme }) => theme.colors.primary};
+`;

--- a/frontend/src/components/Members/MembersTitle/MyPageTitle.stories.tsx
+++ b/frontend/src/components/Members/MembersTitle/MyPageTitle.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import MembersTitle from './MembersTitle';
+
+import member from '@/mocks/data/members.json';
+
+const meta: Meta<typeof MembersTitle> = {
+  title: 'Members/MembersTitle',
+  component: MembersTitle,
+  args: {
+    member: member,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MembersTitle>;
+
+export const Default: Story = {};

--- a/frontend/src/components/Product/PBProductList/PBProductList.tsx
+++ b/frontend/src/components/Product/PBProductList/PBProductList.tsx
@@ -31,7 +31,9 @@ const PBProductList = ({ isHome }: PBProductListProps) => {
             </Link>
           </li>
         ))}
-        <MoreButton />
+        <li>
+          <MoreButton />
+        </li>
       </PBProductListContainer>
     </>
   );

--- a/frontend/src/mocks/data/members.json
+++ b/frontend/src/mocks/data/members.json
@@ -1,0 +1,4 @@
+{
+  "nickname": "펀잇",
+  "profileImage": "https://github.com/woowacourse-teams/2023-fun-eat/assets/78616893/1f0fd418-131c-4cf8-b540-112d762b7c34"
+}

--- a/frontend/src/pages/ProfileModifyPage.tsx
+++ b/frontend/src/pages/ProfileModifyPage.tsx
@@ -1,0 +1,5 @@
+const ProfileModifyPage = () => {
+  return <div>ProfileModifyPage</div>;
+};
+
+export default ProfileModifyPage;

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -11,6 +11,7 @@ import LoginPage from '@/pages/LoginPage';
 import NotFoundPage from '@/pages/NotFoundPage';
 import ProductDetailPage from '@/pages/ProductDetailPage';
 import ProductListPage from '@/pages/ProductListPage';
+import ProfileModifyPage from '@/pages/ProfileModifyPage';
 import ProfilePage from '@/pages/ProfilePage';
 import RecipePage from '@/pages/RecipePage';
 import SearchPage from '@/pages/SearchPage';
@@ -52,6 +53,10 @@ const router = createBrowserRouter([
       {
         path: PATH.PROFILE,
         element: <ProfilePage />,
+      },
+      {
+        path: `${PATH.PROFILE}/modify`,
+        element: <ProfileModifyPage />,
       },
     ],
   },


### PR DESCRIPTION
## Issue

- close #392 

## ✨ 구현한 기능

프로필의 타이틀 컴포넌트를 구현하였습니다.

<img width="1064" alt="스크린샷 2023-08-11 오후 7 30 38" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/80464961/ea75c4bf-0df0-4f07-aeeb-bac30780219f">


## 📢 논의하고 싶은 내용

SectionTitle이랑 구조 비슷하게 구현하였습니다.

## 🎸 기타

x

## ⏰ 일정

- 추정 시간 : 1시간
- 걸린 시간 : 1시간 반
