### PR TITLE
[FE] feat: MemberTitle 컴포넌트 구현

### DIFF
--- a/frontend/src/components/Memebers/MembersTitle/MembersTitle.stories.tsx
+++ b/frontend/src/components/Memebers/MembersTitle/MembersTitle.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import MembersTitle from './MembersTitle';
+
+const meta: Meta<typeof MembersTitle> = {
+  title: 'members/MembersTitle',
+  component: MembersTitle,
+  args: {
+    title: '내가 작성한 리뷰 (12개)',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MembersTitle>;
+
+export const Default: Story = {};

--- a/frontend/src/components/Memebers/MembersTitle/MembersTitle.tsx
+++ b/frontend/src/components/Memebers/MembersTitle/MembersTitle.tsx
@@ -1,0 +1,31 @@
+import { Heading, Link, theme } from '@fun-eat/design-system';
+import { styled } from 'styled-components';
+
+import { SvgIcon } from '@/components/Common';
+
+interface MembersTitleProps {
+  title: string;
+}
+
+const MembersTitle = ({ title }: MembersTitleProps) => {
+  return (
+    <MemberTitleContainer>
+      <Heading size="xl">{title}</Heading>
+      <Link>
+        <ArrowIcon variant="arrow" color={theme.colors.gray5} width={18} height={18} />
+      </Link>
+    </MemberTitleContainer>
+  );
+};
+
+export default MembersTitle;
+
+const MemberTitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const ArrowIcon = styled(SvgIcon)`
+  transform: translateY(3px) rotate(180deg);
+`;

--- a/frontend/src/components/Memebers/MembersTitle/MembersTitle.tsx
+++ b/frontend/src/components/Memebers/MembersTitle/MembersTitle.tsx
@@ -10,7 +10,9 @@ interface MembersTitleProps {
 const MembersTitle = ({ title }: MembersTitleProps) => {
   return (
     <MemberTitleContainer>
-      <Heading size="xl">{title}</Heading>
+      <Heading as="h2" size="xl">
+        {title}
+      </Heading>
       <Link>
         <ArrowIcon variant="arrow" color={theme.colors.gray5} width={18} height={18} />
       </Link>

--- a/frontend/src/components/Memebers/MembersTitle/MembersTitle.tsx
+++ b/frontend/src/components/Memebers/MembersTitle/MembersTitle.tsx
@@ -1,19 +1,22 @@
 import { Heading, Link, theme } from '@fun-eat/design-system';
+import { Link as RouterLink } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { SvgIcon } from '@/components/Common';
+import { PATH } from '@/constants/path';
 
 interface MembersTitleProps {
   title: string;
+  routeDestination: string;
 }
 
-const MembersTitle = ({ title }: MembersTitleProps) => {
+const MembersTitle = ({ title, routeDestination }: MembersTitleProps) => {
   return (
     <MemberTitleContainer>
       <Heading as="h2" size="xl">
         {title}
       </Heading>
-      <Link>
+      <Link as={RouterLink} to={`${PATH.PROFILE}/${routeDestination}`}>
         <ArrowIcon variant="arrow" color={theme.colors.gray5} width={18} height={18} />
       </Link>
     </MemberTitleContainer>


### PR DESCRIPTION
## Issue

- close #405

## ✨ 구현한 기능

memberTitle 컴포넌트를 구현하였습니다.
페이지 더 붙이고 구체적인 내용을 덧 붙일 예정입니다.
title props로 받는건 추후 api 논의 후 달라질 듯 합니다.
마크업만 봐주세요!

<img width="787" alt="스크린샷 2023-08-12 오후 3 01 58" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/80464961/bbab5530-25ed-4a8d-be8a-d5e850910b1f">


## 📢 논의하고 싶은 내용

x

## 🎸 기타

x

## ⏰ 일정

- 추정 시간 : 2시간
- 걸린 시간 : 20분
