### PR TITLE
[BE] feat: Recipe에 생성 시간 추가

### DIFF
--- a/backend/src/main/java/com/funeat/recipe/domain/Recipe.java
+++ b/backend/src/main/java/com/funeat/recipe/domain/Recipe.java
@@ -1,6 +1,8 @@
 package com.funeat.recipe.domain;
 
 import com.funeat.member.domain.Member;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -18,6 +20,9 @@ public class Recipe {
     private String title;
 
     private String content;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
 
     @ManyToOne
     @JoinColumn(name = "member_id")
@@ -52,5 +57,9 @@ public class Recipe {
 
     public Long getFavoriteCount() {
         return favoriteCount;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
     }
 }

--- a/backend/src/main/java/com/funeat/recipe/dto/RecipeAuthorDto.java
+++ b/backend/src/main/java/com/funeat/recipe/dto/RecipeAuthorDto.java
@@ -5,11 +5,11 @@ import com.funeat.member.domain.Member;
 public class RecipeAuthorDto {
 
     private final String profileImage;
-    private final String nickName;
+    private final String nickname;
 
-    private RecipeAuthorDto(final String profileImage, final String nickName) {
+    private RecipeAuthorDto(final String profileImage, final String nickname) {
         this.profileImage = profileImage;
-        this.nickName = nickName;
+        this.nickname = nickname;
     }
 
     public static RecipeAuthorDto toDto(final Member member) {
@@ -20,7 +20,7 @@ public class RecipeAuthorDto {
         return profileImage;
     }
 
-    public String getNickName() {
-        return nickName;
+    public String getNickname() {
+        return nickname;
     }
 }

--- a/backend/src/main/java/com/funeat/recipe/dto/RecipeDetailResponse.java
+++ b/backend/src/main/java/com/funeat/recipe/dto/RecipeDetailResponse.java
@@ -3,6 +3,7 @@ package com.funeat.recipe.dto;
 import com.funeat.product.domain.Product;
 import com.funeat.recipe.domain.Recipe;
 import com.funeat.recipe.domain.RecipeImage;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,11 +18,13 @@ public class RecipeDetailResponse {
     private final Long totalPrice;
     private final Long favoriteCount;
     private final Boolean favorite;
+    private final LocalDateTime createdAt;
 
-    private RecipeDetailResponse(final Long id, final List<String> images, final String title, final String content,
+    public RecipeDetailResponse(final Long id, final List<String> images, final String title, final String content,
                                 final RecipeAuthorDto author,
                                 final List<ProductRecipeDto> products, final Long totalPrice, final Long favoriteCount,
-                                final Boolean favorite) {
+                                final Boolean favorite,
+                                final LocalDateTime createdAt) {
         this.id = id;
         this.images = images;
         this.title = title;
@@ -31,10 +34,11 @@ public class RecipeDetailResponse {
         this.totalPrice = totalPrice;
         this.favoriteCount = favoriteCount;
         this.favorite = favorite;
+        this.createdAt = createdAt;
     }
 
     public static RecipeDetailResponse toResponse(final Recipe recipe, final List<RecipeImage> recipeImages,
-                                           final List<Product> products, final Long totalPrice, final Boolean favorite) {
+                                                  final List<Product> products, final Long totalPrice, final Boolean favorite) {
         final RecipeAuthorDto authorDto = RecipeAuthorDto.toDto(recipe.getMember());
         final List<ProductRecipeDto> productDtos  = products.stream()
                 .map(ProductRecipeDto::toDto)
@@ -43,7 +47,7 @@ public class RecipeDetailResponse {
                 .map(RecipeImage::getImage)
                 .collect(Collectors.toList());
         return new RecipeDetailResponse(recipe.getId(), images, recipe.getTitle(), recipe.getContent(),
-                authorDto, productDtos, totalPrice, recipe.getFavoriteCount(), favorite);
+                authorDto, productDtos, totalPrice, recipe.getFavoriteCount(), favorite, recipe.getCreatedAt());
     }
 
     public Long getId() {
@@ -80,5 +84,9 @@ public class RecipeDetailResponse {
 
     public Boolean getFavorite() {
         return favorite;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
     }
 }

--- a/backend/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
+++ b/backend/src/test/java/com/funeat/recipe/application/RecipeServiceTest.java
@@ -61,8 +61,9 @@ class RecipeServiceTest extends ServiceTest {
 
             // then
             assertThat(actual).usingRecursiveComparison()
-                    .ignoringFields("id")
+                    .ignoringFields("id", "createdAt")
                     .isEqualTo(expected);
+            assertThat(actual.getCreatedAt()).isNotNull();
         }
     }
 


### PR DESCRIPTION
## Issue

- close #415

## ✨ 구현한 기능

- Recipe에 `createdAt` 컬럼 추가
- 꿀조합 상세 조회 api 반환값 수정
  - `nickName` -> `nickname`
  - `createdAt` 필드 추가

## 📢 논의하고 싶은 내용

X

## 🎸 기타

- DB에 접속해서 Recipe에 `createdAt` 필드 추가 하겠습니다.

## ⏰ 일정

- 추정 시간 : 0.5
- 걸린 시간 : 0.5
