### PR TITLE
[FE] feat: 채널톡 구현

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -6,8 +6,15 @@ import { CategoryMenu, SvgIcon, ScrollButton } from '@/components/Common';
 import { PBProductList, ProductList } from '@/components/Product';
 import { ProductRankingList, ReviewRankingList } from '@/components/Rank';
 import { PATH } from '@/constants/path';
+import channelTalk from '@/service/channelTalk';
 
 const HomePage = () => {
+  channelTalk.loadScript();
+
+  channelTalk.boot({
+    pluginKey: process.env.CHANNEL_TALK_KEY ?? '',
+  });
+
   return (
     <>
       <section>

--- a/frontend/src/service/channelTalk.ts
+++ b/frontend/src/service/channelTalk.ts
@@ -1,0 +1,202 @@
+declare global {
+  interface Window {
+    ChannelIO?: IChannelIO;
+    ChannelIOInitialized?: boolean;
+  }
+}
+
+interface IChannelIO {
+  c?: (...args: any) => void;
+  q?: [methodName: string, ...args: any[]][];
+  (...args: any): void;
+}
+
+interface BootOption {
+  appearance?: string;
+  customLauncherSelector?: string;
+  hideChannelButtonOnBoot?: boolean;
+  hidePopup?: boolean;
+  language?: string;
+  memberHash?: string;
+  memberId?: string;
+  pluginKey: string;
+  profile?: Profile;
+  trackDefaultEvent?: boolean;
+  trackUtmSource?: boolean;
+  unsubscribe?: boolean;
+  unsubscribeEmail?: boolean;
+  unsubscribeTexting?: boolean;
+  zIndex?: number;
+}
+
+interface Callback {
+  (error: Error | null, user: CallbackUser | null): void;
+}
+
+interface CallbackUser {
+  alert: number;
+  avatarUrl: string;
+  id: string;
+  language: string;
+  memberId: string;
+  name?: string;
+  profile?: Profile | null;
+  tags?: string[] | null;
+  unsubscribeEmail: boolean;
+  unsubscribeTexting: boolean;
+}
+
+interface UpdateUserInfo {
+  language?: string;
+  profile?: Profile | null;
+  profileOnce?: Profile;
+  tags?: string[] | null;
+  unsubscribeEmail?: boolean;
+  unsubscribeTexting?: boolean;
+}
+
+interface Profile {
+  [key: string]: string | number | boolean | null | undefined;
+}
+
+interface FollowUpProfile {
+  name?: string | null;
+  mobileNumber?: string | null;
+  email?: string | null;
+}
+
+interface EventProperty {
+  [key: string]: string | number | boolean | null | undefined;
+}
+
+type Appearance = 'light' | 'dark' | 'system' | null;
+
+class ChannelService {
+  constructor() {
+    this.loadScript();
+  }
+
+  loadScript() {
+    (function () {
+      const w = window;
+      if (w.ChannelIO) {
+        return w.console.error('ChannelIO script included twice.');
+      }
+      const ch: IChannelIO = function () {
+        // eslint-disable-next-line prefer-rest-params
+        ch.c?.(arguments);
+      };
+      ch.q = [];
+      ch.c = function (args) {
+        ch.q?.push(args);
+      };
+      w.ChannelIO = ch;
+      function l() {
+        if (w.ChannelIOInitialized) {
+          return;
+        }
+        w.ChannelIOInitialized = true;
+        const s = document.createElement('script');
+        s.type = 'text/javascript';
+        s.async = true;
+        s.src = 'https://cdn.channel.io/plugin/ch-plugin-web.js';
+        const x = document.getElementsByTagName('script')[0];
+        if (x.parentNode) {
+          x.parentNode.insertBefore(s, x);
+        }
+      }
+      if (document.readyState === 'complete') {
+        l();
+      } else {
+        w.addEventListener('DOMContentLoaded', l);
+        w.addEventListener('load', l);
+      }
+    })();
+  }
+
+  boot(option: BootOption, callback?: Callback) {
+    window.ChannelIO?.('boot', option, callback);
+  }
+
+  shutdown() {
+    window.ChannelIO?.('shutdown');
+  }
+
+  showMessenger() {
+    window.ChannelIO?.('showMessenger');
+  }
+
+  hideMessenger() {
+    window.ChannelIO?.('hideMessenger');
+  }
+
+  openChat(chatId?: string | number, message?: string) {
+    window.ChannelIO?.('openChat', chatId, message);
+  }
+
+  track(eventName: string, eventProperty?: EventProperty) {
+    window.ChannelIO?.('track', eventName, eventProperty);
+  }
+
+  onShowMessenger(callback: () => void) {
+    window.ChannelIO?.('onShowMessenger', callback);
+  }
+
+  onHideMessenger(callback: () => void) {
+    window.ChannelIO?.('onHideMessenger', callback);
+  }
+
+  onBadgeChanged(callback: (unread: number, alert: number) => void) {
+    window.ChannelIO?.('onBadgeChanged', callback);
+  }
+
+  onChatCreated(callback: () => void) {
+    window.ChannelIO?.('onChatCreated', callback);
+  }
+
+  onFollowUpChanged(callback: (profile: FollowUpProfile) => void) {
+    window.ChannelIO?.('onFollowUpChanged', callback);
+  }
+
+  onUrlClicked(callback: (url: string) => void) {
+    window.ChannelIO?.('onUrlClicked', callback);
+  }
+
+  clearCallbacks() {
+    window.ChannelIO?.('clearCallbacks');
+  }
+
+  updateUser(userInfo: UpdateUserInfo, callback?: Callback) {
+    window.ChannelIO?.('updateUser', userInfo, callback);
+  }
+
+  addTags(tags: string[], callback?: Callback) {
+    window.ChannelIO?.('addTags', tags, callback);
+  }
+
+  removeTags(tags: string[], callback?: Callback) {
+    window.ChannelIO?.('removeTags', tags, callback);
+  }
+
+  setPage(page: string) {
+    window.ChannelIO?.('setPage', page);
+  }
+
+  resetPage() {
+    window.ChannelIO?.('resetPage');
+  }
+
+  showChannelButton() {
+    window.ChannelIO?.('showChannelButton');
+  }
+
+  hideChannelButton() {
+    window.ChannelIO?.('hideChannelButton');
+  }
+
+  setAppearance(appearance: Appearance) {
+    window.ChannelIO?.('setAppearance', appearance);
+  }
+}
+
+export default new ChannelService();


### PR DESCRIPTION
## Issue

- close #432

## ✨ 구현한 기능

채널톡을 구현하였습니다.
현재 env 파일에 key를 넣었는데 젠킨스에 넣어야 한다고 하네용
그래서 아마 merge 되도 안 뜰 듯??

## 📢 논의하고 싶은 내용

참고로 channelTalk.ts는 채널톡 페이지에 있는 거 그대로 가져왔는데 any가 있구요...

```js
// eslint-disable-next-line prefer-rest-params
ch.c?.(arguments);
````
여기에 arguments도 저 주석을 안하면 사용을 못해서 이렇게 씁니도...

위치는 데스크톱에는 

<img width="1436" alt="스크린샷 2023-08-13 오후 7 06 29" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/80464961/9065cf05-23cf-4e18-867c-8b600e068267">

이렇게 떠요. ㅠ
이게 커스텀 할 수 있대서 해봤는데, 안 먹습니다.
내부 홈페이지에서 옮겼는데 그거는 한계가 있습니다.

그래서 결론은 위치가 어쩔 수가 없어요 🥲
그냥 모바일 기준으로만 맞췄습니다!

<img width="358" alt="스크린샷 2023-08-13 오후 6 59 32" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/80464961/3907c58f-885a-4305-86d5-9d51c1a3166f">


## 🎸 기타

x

## ⏰ 일정

- 추정 시간 : 2시간
- 걸린 시간 : 1시간
