### PR TITLE
[BE] feat: 상품 검색 기능 구현

### DIFF
--- a/backend/src/main/java/com/funeat/product/application/ProductService.java
+++ b/backend/src/main/java/com/funeat/product/application/ProductService.java
@@ -12,6 +12,10 @@ import com.funeat.product.dto.ProductReviewCountDto;
 import com.funeat.product.dto.ProductsInCategoryResponse;
 import com.funeat.product.dto.RankingProductDto;
 import com.funeat.product.dto.RankingProductsResponse;
+import com.funeat.product.dto.SearchProductDto;
+import com.funeat.product.dto.SearchProductResultDto;
+import com.funeat.product.dto.SearchProductResultsResponse;
+import com.funeat.product.dto.SearchProductsResponse;
 import com.funeat.product.exception.CategoryException.CategoryNotFoundException;
 import com.funeat.product.exception.ProductException.ProductNotFoundException;
 import com.funeat.product.persistence.CategoryRepository;
@@ -92,5 +96,27 @@ public class ProductService {
                 .collect(Collectors.toList());
 
         return RankingProductsResponse.toResponse(rankingProductDtos);
+    }
+
+    public SearchProductsResponse searchProducts(final String query, final Pageable pageable) {
+        final Page<Product> products = productRepository.findAllByNameContaining(query, pageable);
+
+        final PageDto pageDto = PageDto.toDto(products);
+        final List<SearchProductDto> productDtos = products.stream()
+                .map(SearchProductDto::toDto)
+                .collect(Collectors.toList());
+
+        return SearchProductsResponse.toResponse(pageDto, productDtos);
+    }
+
+    public SearchProductResultsResponse getSearchResults(final String query, final Pageable pageable) {
+        final Page<ProductReviewCountDto> products = productRepository.findAllWithReviewCountByNameContaining(query, pageable);
+
+        final PageDto pageDto = PageDto.toDto(products);
+        final List<SearchProductResultDto> resultDtos = products.stream()
+                .map(it -> SearchProductResultDto.toDto(it.getProduct(), it.getReviewCount()))
+                .collect(Collectors.toList());
+
+        return SearchProductResultsResponse.toResponse(pageDto, resultDtos);
     }
 }

--- a/backend/src/main/java/com/funeat/product/dto/SearchProductDto.java
+++ b/backend/src/main/java/com/funeat/product/dto/SearchProductDto.java
@@ -1,0 +1,32 @@
+package com.funeat.product.dto;
+
+import com.funeat.product.domain.Product;
+
+public class SearchProductDto {
+
+    private final Long id;
+    private final String name;
+    private final String categoryType;
+
+    public SearchProductDto(final Long id, final String name, final String categoryType) {
+        this.id = id;
+        this.name = name;
+        this.categoryType = categoryType;
+    }
+
+    public static SearchProductDto toDto(final Product product) {
+        return new SearchProductDto(product.getId(), product.getName(), product.getCategory().getType().getName());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getCategoryType() {
+        return categoryType;
+    }
+}

--- a/backend/src/main/java/com/funeat/product/dto/SearchProductResultDto.java
+++ b/backend/src/main/java/com/funeat/product/dto/SearchProductResultDto.java
@@ -1,0 +1,58 @@
+package com.funeat.product.dto;
+
+import com.funeat.product.domain.Product;
+
+public class SearchProductResultDto {
+
+    private final Long id;
+    private final String name;
+    private final Long price;
+    private final String image;
+    private final Double averageRating;
+    private final Long reviewCount;
+    private final String categoryType;
+
+    public SearchProductResultDto(final Long id, final String name, final Long price, final String image,
+                                  final Double averageRating, final Long reviewCount, final String categoryType) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+        this.image = image;
+        this.averageRating = averageRating;
+        this.reviewCount = reviewCount;
+        this.categoryType = categoryType;
+    }
+
+    public static SearchProductResultDto toDto(final Product product, final Long reviewCount) {
+        return new SearchProductResultDto(product.getId(), product.getName(), product.getPrice(), product.getImage(),
+                product.getAverageRating(), reviewCount, product.getCategory().getType().getName());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Long getPrice() {
+        return price;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public Double getAverageRating() {
+        return averageRating;
+    }
+
+    public Long getReviewCount() {
+        return reviewCount;
+    }
+
+    public String getCategoryType() {
+        return categoryType;
+    }
+}

--- a/backend/src/main/java/com/funeat/product/dto/SearchProductResultsResponse.java
+++ b/backend/src/main/java/com/funeat/product/dto/SearchProductResultsResponse.java
@@ -1,0 +1,28 @@
+package com.funeat.product.dto;
+
+import com.funeat.common.dto.PageDto;
+import java.util.List;
+
+public class SearchProductResultsResponse {
+
+    private final PageDto page;
+    private final List<SearchProductResultDto> products;
+
+    public SearchProductResultsResponse(final PageDto page, final List<SearchProductResultDto> products) {
+        this.page = page;
+        this.products = products;
+    }
+
+    public static SearchProductResultsResponse toResponse(final PageDto page,
+                                                          final List<SearchProductResultDto> products) {
+        return new SearchProductResultsResponse(page, products);
+    }
+
+    public PageDto getPage() {
+        return page;
+    }
+
+    public List<SearchProductResultDto> getProducts() {
+        return products;
+    }
+}

--- a/backend/src/main/java/com/funeat/product/dto/SearchProductsResponse.java
+++ b/backend/src/main/java/com/funeat/product/dto/SearchProductsResponse.java
@@ -1,0 +1,27 @@
+package com.funeat.product.dto;
+
+import com.funeat.common.dto.PageDto;
+import java.util.List;
+
+public class SearchProductsResponse {
+
+    private final PageDto page;
+    private final List<SearchProductDto> products;
+
+    public SearchProductsResponse(final PageDto page, final List<SearchProductDto> products) {
+        this.page = page;
+        this.products = products;
+    }
+
+    public static SearchProductsResponse toResponse(final PageDto page, final List<SearchProductDto> products) {
+        return new SearchProductsResponse(page, products);
+    }
+
+    public PageDto getPage() {
+        return page;
+    }
+
+    public List<SearchProductDto> getProducts() {
+        return products;
+    }
+}

--- a/backend/src/main/java/com/funeat/product/persistence/ProductRepository.java
+++ b/backend/src/main/java/com/funeat/product/persistence/ProductRepository.java
@@ -36,4 +36,20 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             + "WHERE p.averageRating > 3.0 "
             + "GROUP BY p.id")
     List<ProductReviewCountDto> findAllByAverageRatingGreaterThan3();
+
+    @Query("SELECT p FROM Product p "
+            + "WHERE p.name LIKE CONCAT('%', :name, '%') "
+            + "ORDER BY CASE "
+            + "WHEN p.name LIKE CONCAT(:name, '%') THEN 1 "
+            + "ELSE 2 END")
+    Page<Product> findAllByNameContaining(@Param("name") final String name, final Pageable pageable);
+
+    @Query("SELECT new com.funeat.product.dto.ProductReviewCountDto(p, COUNT(r.id)) FROM Product p "
+            + "LEFT JOIN Review r ON r.product.id = p.id "
+            + "WHERE p.name LIKE CONCAT('%', :name, '%') "
+            + "GROUP BY p.id "
+            + "ORDER BY CASE "
+            + "WHEN p.name LIKE CONCAT(:name, '%') THEN 1 "
+            + "ELSE 2 END")
+    Page<ProductReviewCountDto> findAllWithReviewCountByNameContaining(@Param("name") final String name, final Pageable pageable);
 }

--- a/backend/src/main/java/com/funeat/product/presentation/ProductApiController.java
+++ b/backend/src/main/java/com/funeat/product/presentation/ProductApiController.java
@@ -4,12 +4,16 @@ import com.funeat.product.application.ProductService;
 import com.funeat.product.dto.ProductResponse;
 import com.funeat.product.dto.ProductsInCategoryResponse;
 import com.funeat.product.dto.RankingProductsResponse;
+import com.funeat.product.dto.SearchProductResultsResponse;
+import com.funeat.product.dto.SearchProductsResponse;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -38,6 +42,20 @@ public class ProductApiController implements ProductController {
     @GetMapping("/ranks/products")
     public ResponseEntity<RankingProductsResponse> getRankingProducts() {
         final RankingProductsResponse response = productService.getTop3Products();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/search/products")
+    public ResponseEntity<SearchProductsResponse> searchProducts(@RequestParam final String query, @PageableDefault final Pageable pageable) {
+        final PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+        final SearchProductsResponse response = productService.searchProducts(query, pageRequest);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/search/products/results")
+    public ResponseEntity<SearchProductResultsResponse> getSearchResults(@RequestParam final String query, @PageableDefault final Pageable pageable) {
+        final PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+        final SearchProductResultsResponse response = productService.getSearchResults(query, pageRequest);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/funeat/product/presentation/ProductApiController.java
+++ b/backend/src/main/java/com/funeat/product/presentation/ProductApiController.java
@@ -46,14 +46,16 @@ public class ProductApiController implements ProductController {
     }
 
     @GetMapping("/search/products")
-    public ResponseEntity<SearchProductsResponse> searchProducts(@RequestParam final String query, @PageableDefault final Pageable pageable) {
+    public ResponseEntity<SearchProductsResponse> searchProducts(@RequestParam final String query,
+                                                                 @PageableDefault final Pageable pageable) {
         final PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
         final SearchProductsResponse response = productService.searchProducts(query, pageRequest);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/search/products/results")
-    public ResponseEntity<SearchProductResultsResponse> getSearchResults(@RequestParam final String query, @PageableDefault final Pageable pageable) {
+    public ResponseEntity<SearchProductResultsResponse> getSearchResults(@RequestParam final String query,
+                                                                         @PageableDefault final Pageable pageable) {
         final PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
         final SearchProductResultsResponse response = productService.getSearchResults(query, pageRequest);
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/com/funeat/product/presentation/ProductController.java
+++ b/backend/src/main/java/com/funeat/product/presentation/ProductController.java
@@ -3,6 +3,8 @@ package com.funeat.product.presentation;
 import com.funeat.product.dto.ProductResponse;
 import com.funeat.product.dto.ProductsInCategoryResponse;
 import com.funeat.product.dto.RankingProductsResponse;
+import com.funeat.product.dto.SearchProductResultsResponse;
+import com.funeat.product.dto.SearchProductsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -11,6 +13,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "01.Product", description = "상품 기능")
 public interface ProductController {
@@ -40,4 +43,24 @@ public interface ProductController {
     )
     @GetMapping
     ResponseEntity<RankingProductsResponse> getRankingProducts();
+
+    @Operation(summary = "상품 자동 완성 검색", description = "공통 상품 및 PB 상품들의 이름 중에 해당하는 문자열이 포함되어 있는지 검색한다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "상품 검색 성공."
+    )
+    @GetMapping
+    ResponseEntity<SearchProductsResponse> searchProducts(
+            @RequestParam final String query, @PageableDefault final Pageable pageable
+    );
+
+    @Operation(summary = "상품 검색 결과 조회", description = "문자열을 받아 상품을 검색하고 검색 결과들을 조회한다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "상품 검색 결과 조회 성공."
+    )
+    @GetMapping
+    ResponseEntity<SearchProductResultsResponse> getSearchResults(
+            @RequestParam final String query, @PageableDefault final Pageable pageable
+    );
 }

--- a/backend/src/main/java/com/funeat/product/presentation/ProductController.java
+++ b/backend/src/main/java/com/funeat/product/presentation/ProductController.java
@@ -50,9 +50,8 @@ public interface ProductController {
             description = "상품 검색 성공."
     )
     @GetMapping
-    ResponseEntity<SearchProductsResponse> searchProducts(
-            @RequestParam final String query, @PageableDefault final Pageable pageable
-    );
+    ResponseEntity<SearchProductsResponse> searchProducts(@RequestParam final String query,
+                                                          @PageableDefault final Pageable pageable);
 
     @Operation(summary = "상품 검색 결과 조회", description = "문자열을 받아 상품을 검색하고 검색 결과들을 조회한다.")
     @ApiResponse(
@@ -60,7 +59,6 @@ public interface ProductController {
             description = "상품 검색 결과 조회 성공."
     )
     @GetMapping
-    ResponseEntity<SearchProductResultsResponse> getSearchResults(
-            @RequestParam final String query, @PageableDefault final Pageable pageable
-    );
+    ResponseEntity<SearchProductResultsResponse> getSearchResults(@RequestParam final String query,
+                                                                  @PageableDefault final Pageable pageable);
 }

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
@@ -4,8 +4,10 @@ import static com.funeat.acceptance.auth.LoginSteps.로그인_쿠키를_얻는�
 import static com.funeat.acceptance.common.CommonSteps.STATUS_CODE를_검증한다;
 import static com.funeat.acceptance.common.CommonSteps.정상_처리;
 import static com.funeat.acceptance.common.CommonSteps.찾을수_없음;
+import static com.funeat.acceptance.product.ProductSteps.상품_검색_결과_조회_요청;
 import static com.funeat.acceptance.product.ProductSteps.상품_랭킹_조회_요청;
 import static com.funeat.acceptance.product.ProductSteps.상품_상세_조회_요청;
+import static com.funeat.acceptance.product.ProductSteps.상품_자동_완성_검색_요청;
 import static com.funeat.acceptance.product.ProductSteps.카테고리별_상품_목록_조회_요청;
 import static com.funeat.acceptance.review.ReviewSteps.단일_리뷰_요청;
 import static com.funeat.acceptance.review.ReviewSteps.리뷰_사진_명세_요청;
@@ -13,6 +15,7 @@ import static com.funeat.fixture.CategoryFixture.카테고리_간편식사_생�
 import static com.funeat.fixture.MemberFixture.멤버_멤버1_생성;
 import static com.funeat.fixture.MemberFixture.멤버_멤버2_생성;
 import static com.funeat.fixture.MemberFixture.멤버_멤버3_생성;
+import static com.funeat.fixture.ProductFixture.상품_망고빙수_가격5000원_평점4점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000원_평점1점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000원_평점2점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000원_평점3점_생성;
@@ -29,6 +32,7 @@ import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격4000�
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격5000원_평점1점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격5000원_평점3점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격5000원_평점4점_생성;
+import static com.funeat.fixture.ProductFixture.상품_애플망고_가격3000원_평점5점_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test1_평점1점_재구매X_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test2_평점2점_재구매X_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test3_평점3점_재구매O_생성;
@@ -50,10 +54,13 @@ import com.funeat.product.domain.Product;
 import com.funeat.product.dto.ProductInCategoryDto;
 import com.funeat.product.dto.ProductResponse;
 import com.funeat.product.dto.RankingProductDto;
+import com.funeat.product.dto.SearchProductDto;
+import com.funeat.product.dto.SearchProductResultDto;
 import com.funeat.tag.domain.Tag;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Nested;
@@ -559,6 +566,121 @@ class ProductAcceptanceTest extends AcceptanceTest {
         }
     }
 
+    @Nested
+    class searchProducts_성공_테스트 {
+
+        @Test
+        void 검색어가_포함된_상품들을_검색한다() {
+            // given
+            final var category = 카테고리_간편식사_생성();
+            단일_카테고리_저장(category);
+
+            final var product1 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product2 = 상품_망고빙수_가격5000원_평점4점_생성(category);
+            복수_상품_저장(product1, product2);
+
+            final var pageDto = new PageDto(2L, 1L, true, true, FIRST_PAGE, PAGE_SIZE);
+            final var expectedProducts = List.of(product2, product1);
+
+            // when
+            final var response = 상품_자동_완성_검색_요청("망고", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            페이지를_검증한다(response, pageDto);
+            상품_자동_완성_검색_결과를_검증한다(response, expectedProducts);
+        }
+
+        @Test
+        void 검색어가_포함된_상품이_없으면_빈_리스트를_반환한다() {
+            // given
+            final var category = 카테고리_간편식사_생성();
+            단일_카테고리_저장(category);
+
+            final var product1 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product2 = 상품_망고빙수_가격5000원_평점4점_생성(category);
+            복수_상품_저장(product1, product2);
+
+            final var pageDto = new PageDto(0L, 0L, true, true, FIRST_PAGE, PAGE_SIZE);
+            final var expectedProducts = Collections.emptyList();
+
+            // when
+            final var response = 상품_자동_완성_검색_요청("김밥", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            페이지를_검증한다(response, pageDto);
+            상품_자동_완성_검색_결과를_검증한다(response, expectedProducts);
+        }
+    }
+
+    @Nested
+    class getSearchResults_성공_테스트 {
+
+        @Test
+        void 상품_검색_결과들을_조회한다() {
+            // given
+            final var category = 카테고리_간편식사_생성();
+            단일_카테고리_저장(category);
+
+            final var product1 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product2 = 상품_망고빙수_가격5000원_평점4점_생성(category);
+            복수_상품_저장(product1, product2);
+
+            final var tag1 = 태그_맛있어요_TASTE_생성();
+            final var tag2 = 태그_간식_ETC_생성();
+            복수_태그_저장(tag1, tag2);
+
+            final var image = 리뷰_사진_명세_요청();
+
+            final var request1 = 리뷰추가요청_재구매X_생성(5L, 태그_아이디_변환(tag1, tag2));
+            final var request2 = 리뷰추가요청_재구매X_생성(5L, 태그_아이디_변환(tag1));
+            final var request3 = 리뷰추가요청_재구매X_생성(4L, 태그_아이디_변환(tag2));
+
+            final var loginCookie = 로그인_쿠키를_얻는다();
+
+            단일_리뷰_요청(product1.getId(), image, request1, loginCookie);
+            단일_리뷰_요청(product1.getId(), image, request2, loginCookie);
+            단일_리뷰_요청(product2.getId(), image, request3, loginCookie);
+
+            final var pageDto = new PageDto(2L, 1L, true, true, FIRST_PAGE, PAGE_SIZE);
+
+            final var expectedDto1 = SearchProductResultDto.toDto(product1, 2L);
+            final var expectedDto2 = SearchProductResultDto.toDto(product2, 1L);
+            final var expected = List.of(expectedDto2, expectedDto1);
+
+            // when
+            final var response = 상품_검색_결과_조회_요청("망고", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            페이지를_검증한다(response, pageDto);
+            상품_검색_결과를_검증한다(response, expected);
+        }
+
+        @Test
+        void 검색_결과에_상품이_없으면_빈_리스트를_반환한다() {
+            // given
+            final var category = 카테고리_간편식사_생성();
+            단일_카테고리_저장(category);
+
+            final var product1 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product2 = 상품_망고빙수_가격5000원_평점4점_생성(category);
+            복수_상품_저장(product1, product2);
+
+            final var pageDto = new PageDto(0L, 0L, true, true, FIRST_PAGE, PAGE_SIZE);
+            final var expected = Collections.emptyList();
+
+            // when
+            final var response = 상품_검색_결과_조회_요청("김밥", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            페이지를_검증한다(response, pageDto);
+            상품_검색_결과를_검증한다(response, expected);
+        }
+    }
+
     private List<Long> 태그_아이디_변환(final Tag... tags) {
         return Arrays.stream(tags)
                 .map(Tag::getId)
@@ -600,6 +722,25 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 .collect(Collectors.toList());
         final var actual = response.jsonPath()
                 .getList("products", RankingProductDto.class);
+
+        assertThat(actual).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    private <T> void 상품_자동_완성_검색_결과를_검증한다(final ExtractableResponse<Response> response, final List<T> products) {
+        final var expected = products.stream()
+                .map(product -> SearchProductDto.toDto((Product) product))
+                .collect(Collectors.toList());
+        final var actual = response.jsonPath()
+                .getList("products", SearchProductDto.class);
+
+        assertThat(actual).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    private <T> void 상품_검색_결과를_검증한다(final ExtractableResponse<Response> response, final List<T> expected) {
+        final var actual = response.jsonPath()
+                .getList("products", SearchProductResultDto.class);
 
         assertThat(actual).usingRecursiveComparison()
                 .isEqualTo(expected);

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductSteps.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductSteps.java
@@ -34,4 +34,24 @@ public class ProductSteps {
                 .then()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 상품_자동_완성_검색_요청(final String query, final int page) {
+        return given()
+                .queryParam("query", query)
+                .queryParam("page", page)
+                .when()
+                .get("/api/search/products")
+                .then()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 상품_검색_결과_조회_요청(final String query, final int page) {
+        return given()
+                .queryParam("query", query)
+                .queryParam("page", page)
+                .when()
+                .get("/api/search/products/results")
+                .then()
+                .extract();
+    }
 }

--- a/backend/src/test/java/com/funeat/fixture/ProductFixture.java
+++ b/backend/src/test/java/com/funeat/fixture/ProductFixture.java
@@ -108,6 +108,14 @@ public class ProductFixture {
         return new Product("삼각김밥", 5000L, "image.png", "맛있는 삼각김밥", 5.0, category);
     }
 
+    public static Product 상품_망고빙수_가격5000원_평점4점_생성(final Category category) {
+        return new Product("망고빙수", 5000L, "image.png", "맛있는 망고빙수", 4.0, category);
+    }
+
+    public static Product 상품_애플망고_가격3000원_평점5점_생성(final Category category) {
+        return new Product("애플망고", 3000L, "image.png", "맛있는 애플망고", 5.0, category);
+    }
+
     public static ProductRecipe 레시피_안에_들어가는_상품_생성(final Product product, final Recipe recipe) {
         return new ProductRecipe(product, recipe);
     }

--- a/backend/src/test/java/com/funeat/product/persistence/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/product/persistence/ProductRepositoryTest.java
@@ -9,6 +9,7 @@ import static com.funeat.fixture.PageFixture.페이지요청_가격_오름차순
 import static com.funeat.fixture.PageFixture.페이지요청_기본_생성;
 import static com.funeat.fixture.PageFixture.페이지요청_평균_평점_내림차순_생성;
 import static com.funeat.fixture.PageFixture.페이지요청_평균_평점_오름차순_생성;
+import static com.funeat.fixture.ProductFixture.상품_망고빙수_가격5000원_평점4점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000원_평점1점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000원_평점2점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000원_평점3점_생성;
@@ -21,6 +22,7 @@ import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격3000�
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격4000원_평점1점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격4000원_평점2점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격5000원_평점1점_생성;
+import static com.funeat.fixture.ProductFixture.상품_애플망고_가격3000원_평점5점_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test1_평점1점_재구매X_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test2_평점2점_재구매X_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test3_평점3점_재구매O_생성;
@@ -234,6 +236,69 @@ class ProductRepositoryTest extends RepositoryTest {
 
             // when
             final var actual = productRepository.findAllByAverageRatingGreaterThan3();
+
+            // then
+            assertThat(actual).usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    class findAllByNameContaining_성공_테스트 {
+
+        @Test
+        void 상품명에_검색어가_포함된_상품들을_조회한다() {
+            // given
+            final var category = 카테고리_간편식사_생성();
+            단일_카테고리_저장(category);
+
+            final var product1 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product2 = 상품_망고빙수_가격5000원_평점4점_생성(category);
+            복수_상품_저장(product1, product2);
+
+            final var page = 페이지요청_기본_생성(0, 10);
+
+            final var expected = List.of(product2, product1);
+
+            // when
+            final var actual = productRepository.findAllByNameContaining("망고", page).getContent();
+
+            // then
+            assertThat(actual).usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    class findAllWithReviewCountByNameContaining_성공_테스트 {
+
+        @Test
+        void 상품명에_검색어가_포함된_상품들과_리뷰_수를_조회한다() {
+            // given
+            final var category = 카테고리_간편식사_생성();
+            단일_카테고리_저장(category);
+
+            final var product1 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product2 = 상품_망고빙수_가격5000원_평점4점_생성(category);
+            복수_상품_저장(product1, product2);
+
+            final var member1 = 멤버_멤버1_생성();
+            final var member2 = 멤버_멤버2_생성();
+            복수_멤버_저장(member1, member2);
+
+            final var review1_1 = 리뷰_이미지test1_평점1점_재구매X_생성(member1, product1, 0L);
+            final var review1_2 = 리뷰_이미지test5_평점5점_재구매O_생성(member2, product1, 0L);
+            final var review2_1 = 리뷰_이미지test3_평점3점_재구매O_생성(member1, product2, 0L);
+            복수_리뷰_저장(review1_1, review1_2, review2_1);
+
+            final var page = 페이지요청_기본_생성(0, 10);
+
+            final var expectedDto1 = new ProductReviewCountDto(product1, 2L);
+            final var expectedDto2 = new ProductReviewCountDto(product2, 1L);
+            final var expected = List.of(expectedDto2, expectedDto1);
+
+            // when
+            final var actual = productRepository.findAllWithReviewCountByNameContaining("망고", page).getContent();
 
             // then
             assertThat(actual).usingRecursiveComparison()


### PR DESCRIPTION
## Issue

- close #402 

## ✨ 구현한 기능

### 상품 검색 기능 구현

- 공통 상품, PB 상품 같이 통합해서 검색하도록 구현
- `자동 완성 API`, `검색 결과 API` 분리
  - 자동 완성의 경우에는 API 호출을 자주하고, 모든 상품 정보를 반환할 필요가 없음
  - `자동 완성 API` : 상품 정보에서 id, name, categoryType만 반환
  - `검색 결과 API` : 필요한 상품 정보 전부 반환
- 페이징 처리 (size : 10, sort : X)

### 검색 관련 쿼리

```sql
SELECT *
FROM product
WHERE name LIKE '%망고%';
```

```sql
SELECT *
FROM product
WHERE name LIKE '%망고%'
ORDER BY CASE WHEN name LIKE '망고%' THEN 1 ELSE 2 END;
```

위 방식은 순서에 상관없이 '망고'라는 문자열이 포함된 상품명을 다 조회하기 때문에, 사용자의 의도에 맞는 정확한 검색과는 거리가 멀다.
=> '망고'라는 검색어로 시작하는 문자열이 먼저 출력될 수 있도록 `ORDER BY` + `CASE WHEN ~` 사용
ex)
**망고**주스
**망고**푸딩
애플**망고**

## 📢 논의하고 싶은 내용

- controller에서 PageRequest 재정의하고 service로 넘겨주는 이유
  - `CustomPageableHandlerMethodArgumentResolver`로 인해서 `Pageable`에 id로 정렬하는 sort 옵션이 기본으로 들어가있음
  - 따라서 `ORDER BY` 절을 포함시켜서 쿼리를 날리게 되는데, 위 `ORDER BY` 절과 중복돼서 에러 발생
  => controller에서 service로 `Pageable` 넘기기 전에 `PageRequest.of()`로 재정의

## 🎸 기타

- 위 SQL문과 실제 구현한 JPQL 쿼리문이 다른 이유
  - `@Query`에서 `WHERE p.name LIKE %:name%`처럼 `% + 파라미터` 형태로 사용하려면, `CONCAT('%', :name, '%')` 형태로 바꿔서 사용하는 것이 좋다.
  - 하나의 쿼리에서 한 번만 사용하는 경우는 괜찮지만, 여러 번 사용하는 경우 race condition이 발생할 수 있기 때문
  - reference: https://github.com/spring-projects/spring-data-jpa/issues/2939

## ⏰ 일정

- 추정 시간 : 3h
- 걸린 시간 : 6h
