### PR TITLE
[BE] fix: 리뷰, 레시피 좋아요 데드락, 동시성 이슈 수정

### DIFF
--- a/backend/src/main/java/com/funeat/member/domain/favorite/RecipeFavorite.java
+++ b/backend/src/main/java/com/funeat/member/domain/favorite/RecipeFavorite.java
@@ -12,7 +12,7 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
 @Entity
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "review_id"}))
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "recipe_id"}))
 public class RecipeFavorite {
 
     @Id

--- a/backend/src/main/java/com/funeat/member/domain/favorite/RecipeFavorite.java
+++ b/backend/src/main/java/com/funeat/member/domain/favorite/RecipeFavorite.java
@@ -8,8 +8,11 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 
 @Entity
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "review_id"}))
 public class RecipeFavorite {
 
     @Id

--- a/backend/src/main/java/com/funeat/member/domain/favorite/ReviewFavorite.java
+++ b/backend/src/main/java/com/funeat/member/domain/favorite/ReviewFavorite.java
@@ -8,8 +8,11 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 
 @Entity
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "review_id"}))
 public class ReviewFavorite {
 
     @Id

--- a/backend/src/main/java/com/funeat/member/exception/MemberErrorCode.java
+++ b/backend/src/main/java/com/funeat/member/exception/MemberErrorCode.java
@@ -6,6 +6,7 @@ public enum MemberErrorCode {
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다. 회원 id를 확인하세요.", "5001"),
     MEMBER_UPDATE_ERROR(HttpStatus.BAD_REQUEST, "닉네임 또는 이미지를 확인하세요.", "5002"),
+    MEMBER_DUPLICATE_FAVORITE(HttpStatus.CONFLICT, "이미 좋아요를 누른 상태입니다.", "5003"),
     ;
 
     private final HttpStatus status;

--- a/backend/src/main/java/com/funeat/member/exception/MemberException.java
+++ b/backend/src/main/java/com/funeat/member/exception/MemberException.java
@@ -21,4 +21,10 @@ public class MemberException extends GlobalException {
             super(errorCode.getStatus(), new ErrorCode<>(errorCode.getCode(), errorCode.getMessage()));
         }
     }
+
+    public static class MemberDuplicateFavoriteException extends MemberException {
+        public MemberDuplicateFavoriteException(final MemberErrorCode errorCode, final Long memberId) {
+            super(errorCode.getStatus(), new ErrorCode<>(errorCode.getCode(), errorCode.getMessage(), memberId));
+        }
+    }
 }

--- a/backend/src/main/java/com/funeat/recipe/application/RecipeService.java
+++ b/backend/src/main/java/com/funeat/recipe/application/RecipeService.java
@@ -147,7 +147,7 @@ public class RecipeService {
     public void likeRecipe(final Long memberId, final Long recipeId, final RecipeFavoriteRequest request) {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND, memberId));
-        final Recipe recipe = recipeRepository.findById(recipeId)
+        final Recipe recipe = recipeRepository.findByIdForUpdate(recipeId)
                 .orElseThrow(() -> new RecipeNotFoundException(RECIPE_NOT_FOUND, recipeId));
 
         final RecipeFavorite recipeFavorite = recipeFavoriteRepository.findByMemberAndRecipe(member, recipe)

--- a/backend/src/main/java/com/funeat/recipe/application/RecipeService.java
+++ b/backend/src/main/java/com/funeat/recipe/application/RecipeService.java
@@ -1,5 +1,6 @@
 package com.funeat.recipe.application;
 
+import static com.funeat.member.exception.MemberErrorCode.MEMBER_DUPLICATE_FAVORITE;
 import static com.funeat.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
 import static com.funeat.product.exception.ProductErrorCode.PRODUCT_NOT_FOUND;
 import static com.funeat.recipe.exception.RecipeErrorCode.RECIPE_NOT_FOUND;
@@ -11,6 +12,7 @@ import com.funeat.member.domain.favorite.RecipeFavorite;
 import com.funeat.member.dto.MemberRecipeDto;
 import com.funeat.member.dto.MemberRecipeProductDto;
 import com.funeat.member.dto.MemberRecipesResponse;
+import com.funeat.member.exception.MemberException.MemberDuplicateFavoriteException;
 import com.funeat.member.exception.MemberException.MemberNotFoundException;
 import com.funeat.member.persistence.MemberRepository;
 import com.funeat.member.persistence.RecipeFavoriteRepository;
@@ -32,6 +34,7 @@ import com.funeat.recipe.persistence.RecipeRepository;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -157,7 +160,11 @@ public class RecipeService {
     }
 
     private RecipeFavorite createAndSaveRecipeFavorite(final Member member, final Recipe recipe) {
-        final RecipeFavorite recipeFavorite = RecipeFavorite.create(member, recipe);
-        return recipeFavoriteRepository.save(recipeFavorite);
+        try {
+            final RecipeFavorite recipeFavorite = RecipeFavorite.create(member, recipe);
+            return recipeFavoriteRepository.save(recipeFavorite);
+        } catch (final DataIntegrityViolationException e) {
+            throw new MemberDuplicateFavoriteException(MEMBER_DUPLICATE_FAVORITE, member.getId());
+        }
     }
 }

--- a/backend/src/main/java/com/funeat/recipe/persistence/RecipeRepository.java
+++ b/backend/src/main/java/com/funeat/recipe/persistence/RecipeRepository.java
@@ -1,14 +1,23 @@
 package com.funeat.recipe.persistence;
 
+import static javax.persistence.LockModeType.PESSIMISTIC_WRITE;
+
 import com.funeat.member.domain.Member;
 import com.funeat.recipe.domain.Recipe;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
     Page<Recipe> findRecipesByMember(final Member member, final Pageable pageable);
 
     Page<Recipe> findAll(final Pageable pageable);
+
+    @Lock(PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM Recipe r WHERE r.id=:id")
+    Optional<Recipe> findByIdForUpdate(final Long id);
 }

--- a/backend/src/main/java/com/funeat/review/application/ReviewService.java
+++ b/backend/src/main/java/com/funeat/review/application/ReviewService.java
@@ -100,7 +100,7 @@ public class ReviewService {
     public void likeReview(final Long reviewId, final Long memberId, final ReviewFavoriteRequest request) {
         final Member findMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND, memberId));
-        final Review findReview = reviewRepository.findById(reviewId)
+        final Review findReview = reviewRepository.findByIdForUpdate(reviewId)
                 .orElseThrow(() -> new ReviewNotFoundException(REVIEW_NOT_FOUND, reviewId));
 
         final ReviewFavorite savedReviewFavorite = reviewFavoriteRepository.findByMemberAndReview(findMember,

--- a/backend/src/main/java/com/funeat/review/application/ReviewService.java
+++ b/backend/src/main/java/com/funeat/review/application/ReviewService.java
@@ -1,5 +1,6 @@
 package com.funeat.review.application;
 
+import static com.funeat.member.exception.MemberErrorCode.MEMBER_DUPLICATE_FAVORITE;
 import static com.funeat.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
 import static com.funeat.product.exception.ProductErrorCode.PRODUCT_NOT_FOUND;
 import static com.funeat.review.exception.ReviewErrorCode.REVIEW_NOT_FOUND;
@@ -10,6 +11,7 @@ import com.funeat.member.domain.Member;
 import com.funeat.member.domain.favorite.ReviewFavorite;
 import com.funeat.member.dto.MemberReviewDto;
 import com.funeat.member.dto.MemberReviewsResponse;
+import com.funeat.member.exception.MemberException.MemberDuplicateFavoriteException;
 import com.funeat.member.exception.MemberException.MemberNotFoundException;
 import com.funeat.member.persistence.MemberRepository;
 import com.funeat.member.persistence.ReviewFavoriteRepository;
@@ -32,6 +34,7 @@ import com.funeat.tag.persistence.TagRepository;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -110,10 +113,13 @@ public class ReviewService {
     }
 
     private ReviewFavorite saveReviewFavorite(final Member member, final Review review, final Boolean favorite) {
-        final ReviewFavorite reviewFavorite = ReviewFavorite.createReviewFavoriteByMemberAndReview(member, review,
-                favorite);
-
-        return reviewFavoriteRepository.save(reviewFavorite);
+        try {
+            final ReviewFavorite reviewFavorite = ReviewFavorite.createReviewFavoriteByMemberAndReview(member, review,
+                    favorite);
+            return reviewFavoriteRepository.save(reviewFavorite);
+        } catch (final DataIntegrityViolationException e) {
+            throw new MemberDuplicateFavoriteException(MEMBER_DUPLICATE_FAVORITE, member.getId());
+        }
     }
 
     public SortingReviewsResponse sortingReviews(final Long productId, final Pageable pageable, final Long memberId) {

--- a/backend/src/main/java/com/funeat/review/persistence/ReviewRepository.java
+++ b/backend/src/main/java/com/funeat/review/persistence/ReviewRepository.java
@@ -1,12 +1,17 @@
 package com.funeat.review.persistence;
 
+import static javax.persistence.LockModeType.PESSIMISTIC_WRITE;
+
 import com.funeat.member.domain.Member;
 import com.funeat.product.domain.Product;
 import com.funeat.review.domain.Review;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
@@ -17,4 +22,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Long countByProduct(final Product product);
 
     Page<Review> findReviewsByMember(final Member findMember, final Pageable pageable);
+
+    @Lock(PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM Review r WHERE r.id=:id")
+    Optional<Review> findByIdForUpdate(final Long id);
 }


### PR DESCRIPTION
## Issue

- close #329

## ✨ 구현한 기능

- 리뷰(`likeReview`)랑 레시피(`likeRecipe`)에 비관적 락을 걸었습니다.
  - X Lock은 성능상 좋지 않으므로 레벨 4에서 스케줄러로 수정할 예정
- 리뷰좋아요(`ReviewFavorite`), 레시피좋아요(`RecipeFavorite`)는 유니크 제약 조건 추가했습니다.
  - DB에 유니크 제약 조건 추가하면 될 것 같아요

## 📢 논의하고 싶은 내용

- x

## 🎸 기타

- 낙관적 락 적용시 500개 좋아요가 동시에 들어오면 50개~60개만 처리됩니다. (`likeReview` 기준)

## ⏰ 일정

- 추정 시간 : 모름
- 걸린 시간 : 48
