### PR TITLE
[FE] feat: 상품 상세 페이지 꿀조합 탭 구현

### DIFF
--- a/frontend/src/components/Product/ProductRecipeList/ProductRecipeList.tsx
+++ b/frontend/src/components/Product/ProductRecipeList/ProductRecipeList.tsx
@@ -26,7 +26,7 @@ const ProductRecipeList = ({ productId, productName, selectedOption }: ProductRe
     return (
       <ErrorContainer>
         <ErrorDescription align="center" weight="bold" size="lg">
-          {productName}을 사용해 꿀조합을 만들어보세요 🍯
+          {productName}을 사용한 꿀조합을 만들어보세요 🍯
         </ErrorDescription>
         <RecipeLink as={RouterLink} to={PATH.RECIPE} block>
           꿀조합 작성하러 가기

--- a/frontend/src/components/Product/ProductRecipeList/ProductRecipeList.tsx
+++ b/frontend/src/components/Product/ProductRecipeList/ProductRecipeList.tsx
@@ -1,0 +1,78 @@
+import { Link, Text } from '@fun-eat/design-system';
+import { useRef } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { RecipeItem } from '@/components/Recipe';
+import { PATH } from '@/constants/path';
+import { useIntersectionObserver } from '@/hooks/common';
+import { useInfiniteProductRecipesQuery } from '@/hooks/queries/product';
+import type { SortOption } from '@/types/common';
+
+interface ProductRecipeListProps {
+  productId: number;
+  productName: string;
+  selectedOption: SortOption;
+}
+
+const ProductRecipeList = ({ productId, productName, selectedOption }: ProductRecipeListProps) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const { fetchNextPage, hasNextPage, data } = useInfiniteProductRecipesQuery(productId, selectedOption.value);
+  useIntersectionObserver<HTMLDivElement>(fetchNextPage, scrollRef, hasNextPage);
+
+  const recipes = data.pages.flatMap((page) => page.recipes);
+
+  if (recipes.length === 0) {
+    return (
+      <ErrorContainer>
+        <ErrorDescription align="center" weight="bold" size="lg">
+          {productName}을 사용해 꿀조합을 만들어보세요 🍯
+        </ErrorDescription>
+        <RecipeLink as={RouterLink} to={PATH.RECIPE} block>
+          꿀조합 작성하러 가기
+        </RecipeLink>
+      </ErrorContainer>
+    );
+  }
+
+  return (
+    <>
+      <ProductRecipeListContainer>
+        {recipes.map((recipe) => (
+          <li key={recipe.id}>
+            <Link as={RouterLink} to={`${recipe.id}`}>
+              <RecipeItem recipe={recipe} />
+            </Link>
+          </li>
+        ))}
+      </ProductRecipeListContainer>
+      <div ref={scrollRef} aria-hidden />
+    </>
+  );
+};
+
+export default ProductRecipeList;
+
+const ProductRecipeListContainer = styled.ul`
+  & > li + li {
+    margin-top: 40px;
+  }
+`;
+
+const ErrorContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const ErrorDescription = styled(Text)`
+  padding: 20px 0;
+  white-space: pre-line;
+  word-break: break-all;
+`;
+
+const RecipeLink = styled(Link)`
+  padding: 16px 24px;
+  border: 1px solid ${({ theme }) => theme.colors.gray4};
+  border-radius: 8px;
+`;

--- a/frontend/src/components/Product/ProductRecipeList/ProductRecipeList.tsx
+++ b/frontend/src/components/Product/ProductRecipeList/ProductRecipeList.tsx
@@ -28,7 +28,7 @@ const ProductRecipeList = ({ productId, productName, selectedOption }: ProductRe
         <ErrorDescription align="center" weight="bold" size="lg">
           {productName}을 사용한 꿀조합을 만들어보세요 🍯
         </ErrorDescription>
-        <RecipeLink as={RouterLink} to={PATH.RECIPE} block>
+        <RecipeLink as={RouterLink} to={`PATH.RECIPE`} block>
           꿀조합 작성하러 가기
         </RecipeLink>
       </ErrorContainer>
@@ -40,7 +40,7 @@ const ProductRecipeList = ({ productId, productName, selectedOption }: ProductRe
       <ProductRecipeListContainer>
         {recipes.map((recipe) => (
           <li key={recipe.id}>
-            <Link as={RouterLink} to={`${recipe.id}`}>
+            <Link as={RouterLink} to={`${PATH.RECIPE}/${recipe.id}`}>
               <RecipeItem recipe={recipe} />
             </Link>
           </li>

--- a/frontend/src/components/Product/ProductRecipeList/ProductRecipeList.tsx
+++ b/frontend/src/components/Product/ProductRecipeList/ProductRecipeList.tsx
@@ -26,7 +26,7 @@ const ProductRecipeList = ({ productId, productName, selectedOption }: ProductRe
     return (
       <ErrorContainer>
         <ErrorDescription align="center" weight="bold" size="lg">
-          {productName}을 사용한 꿀조합을 만들어보세요 🍯
+          {productName}을/를 사용한 꿀조합을 만들어보세요 🍯
         </ErrorDescription>
         <RecipeLink as={RouterLink} to={`PATH.RECIPE`} block>
           꿀조합 작성하러 가기

--- a/frontend/src/components/Product/index.ts
+++ b/frontend/src/components/Product/index.ts
@@ -3,3 +3,4 @@ export { default as ProductItem } from './ProductItem/ProductItem';
 export { default as ProductList } from './ProductList/ProductList';
 export { default as ProductOverviewItem } from './ProductOverviewItem/ProductOverviewItem';
 export { default as PBProductList } from './PBProductList/PBProductList';
+export { default as ProductRecipeList } from './ProductRecipeList/ProductRecipeList';

--- a/frontend/src/hooks/queries/product/index.ts
+++ b/frontend/src/hooks/queries/product/index.ts
@@ -2,3 +2,4 @@ export { default as useCategoryQuery } from './useCategoryQuery';
 export { default as useInfiniteProductsQuery } from './useInfiniteProductsQuery';
 export { default as useInfiniteProductReviewsQuery } from './useInfiniteProductReviewsQuery';
 export { default as useProductDetailQuery } from './useProductDetailQuery';
+export { default as useInfiniteProductRecipesQuery } from './useInfiniteProductRecipesQuery';

--- a/frontend/src/hooks/queries/product/useInfiniteProductRecipesQuery.ts
+++ b/frontend/src/hooks/queries/product/useInfiniteProductRecipesQuery.ts
@@ -1,0 +1,30 @@
+import { useSuspendedInfiniteQuery } from '../useSuspendedInfiniteQuery';
+
+import { productApi } from '@/apis';
+import type { RecipeResponse } from '@/types/response';
+
+const fetchProductRecipes = async (pageParam: number, productId: number, sort: string) => {
+  const response = await productApi.get({
+    params: `/${productId}/recipes`,
+    queries: `?sort=${sort}&page=${pageParam}`,
+    credentials: true,
+  });
+  const data: RecipeResponse = await response.json();
+  return data;
+};
+
+const useInfiniteProductRecipesQuery = (productId: number, sort: string) => {
+  return useSuspendedInfiniteQuery(
+    ['product', 'recipes', productId, sort],
+    ({ pageParam = 0 }) => fetchProductRecipes(pageParam, productId, sort),
+    {
+      getNextPageParam: (prevResponse: RecipeResponse) => {
+        const isLast = prevResponse.page.lastPage;
+        const nextPage = prevResponse.page.requestPage + 1;
+        return isLast ? undefined : nextPage;
+      },
+    }
+  );
+};
+
+export default useInfiniteProductRecipesQuery;

--- a/frontend/src/mocks/handlers/recipeHandlers.ts
+++ b/frontend/src/mocks/handlers/recipeHandlers.ts
@@ -19,7 +19,7 @@ export const recipeHandlers = [
     return res(ctx.status(200), ctx.json({ message: '꿀조합이 등록되었습니다.' }), ctx.set('Location', '/recipes/1'));
   }),
 
-  rest.patch('/api/recipes/:recipeId', (req, res, ctx) => {
+  rest.patch('/api/recipes/:recipeId', (_, res, ctx) => {
     return res(ctx.status(200));
   }),
 
@@ -53,6 +53,39 @@ export const recipeHandlers = [
     return res(
       ctx.status(200),
       ctx.json({ page: sortedRecipes.page, recipes: sortedRecipes.recipes.slice(page * 5, (page + 1) * 5) })
+    );
+  }),
+
+  rest.get('/api/products/:productId/recipes', (req, res, ctx) => {
+    const sortOptions = req.url.searchParams.get('sort');
+    const page = Number(req.url.searchParams.get('page'));
+
+    if (sortOptions === null) {
+      return res(ctx.status(400));
+    }
+
+    const [key, sortOrder] = sortOptions.split(',');
+
+    if (!isRecipeSortOption(key) || !isSortOrder(sortOrder)) {
+      return res(ctx.status(400));
+    }
+
+    const sortedRecipes = {
+      ...mockRecipes,
+      recipes: [...mockRecipes.recipes].sort((cur, next) => {
+        if (key === 'createdAt') {
+          return sortOrder === 'asc'
+            ? new Date(cur[key]).getTime() - new Date(next[key]).getTime()
+            : new Date(next[key]).getTime() - new Date(cur[key]).getTime();
+        }
+
+        return sortOrder === 'asc' ? cur[key] - next[key] : next[key] - cur[key];
+      }),
+    };
+
+    return res(
+      ctx.status(200),
+      ctx.json({ ...sortedRecipes, recipes: sortedRecipes.recipes.slice(page * 5, (page + 1) * 5) })
     );
   }),
 ];

--- a/frontend/src/mocks/handlers/reviewHandlers.ts
+++ b/frontend/src/mocks/handlers/reviewHandlers.ts
@@ -11,7 +11,6 @@ export const reviewHandlers = [
   rest.get('/api/products/:productId/reviews', (req, res, ctx) => {
     const { mockSessionId } = req.cookies;
     const sortOptions = req.url.searchParams.get('sort');
-    const page = Number(req.url.searchParams.get('page'));
 
     if (!mockSessionId) {
       return res(ctx.status(401));

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -40,9 +40,9 @@ const ProductDetailPage = () => {
   const [selectedTabMenu, setSelectedTabMenu] = useState(tabMenus[0]);
   const tabRef = useRef<HTMLUListElement>(null);
 
-  const isRecipeTab = selectedTabMenu === tabMenus[1];
-  const initialSortOption = isRecipeTab ? RECIPE_SORT_OPTIONS[0] : REVIEW_SORT_OPTIONS[0];
-  const sortOptions = isRecipeTab ? RECIPE_SORT_OPTIONS : REVIEW_SORT_OPTIONS;
+  const isReviewTab = selectedTabMenu === tabMenus[0];
+  const sortOptions = isReviewTab ? REVIEW_SORT_OPTIONS : RECIPE_SORT_OPTIONS;
+  const initialSortOption = isReviewTab ? REVIEW_SORT_OPTIONS[0] : RECIPE_SORT_OPTIONS[0];
 
   const { selectedOption, selectSortOption } = useSortOption(initialSortOption);
   const { ref, isClosing, handleOpenBottomSheet, handleCloseBottomSheet } = useBottomSheet();
@@ -83,14 +83,14 @@ const ProductDetailPage = () => {
               <SortButton option={selectedOption} onClick={handleOpenSortOptionSheet} />
             </SortButtonWrapper>
             <section>
-              {isRecipeTab ? (
+              {isReviewTab ? (
+                <ReviewList productId={Number(productId)} selectedOption={selectedOption} />
+              ) : (
                 <ProductRecipeList
                   productId={Number(productId)}
                   productName={productDetail.name}
                   selectedOption={selectedOption}
                 />
-              ) : (
-                <ReviewList productId={Number(productId)} selectedOption={selectedOption} />
               )}
             </section>
           </Suspense>
@@ -98,7 +98,7 @@ const ProductDetailPage = () => {
       ) : (
         <ErrorContainer>
           <ErrorDescription align="center" weight="bold" size="lg">
-            {isRecipeTab ? LOGIN_ERROR_MESSAGE_RECIPE : LOGIN_ERROR_MESSAGE_REVIEW}
+            {isReviewTab ? LOGIN_ERROR_MESSAGE_REVIEW : LOGIN_ERROR_MESSAGE_RECIPE}
           </ErrorDescription>
           <LoginLink as={RouterLink} to={PATH.LOGIN} block>
             로그인하러 가기

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -25,7 +25,10 @@ import { useSortOption } from '@/hooks/common';
 import { useMemberQuery } from '@/hooks/queries/members';
 import { useProductDetailQuery } from '@/hooks/queries/product';
 
-const LOGIN_ERROR_MESSAGE = '로그인 후 상품 리뷰를 볼 수 있어요.\n펀잇에 가입하고 편의점 상품의 리뷰를 확인해보세요 😊';
+const LOGIN_ERROR_MESSAGE_REVIEW =
+  '로그인 후 상품 리뷰를 볼 수 있어요.\n펀잇에 가입하고 편의점 상품 리뷰를 확인해보세요 😊';
+const LOGIN_ERROR_MESSAGE_RECIPE =
+  '로그인 후 상품 꿀조합을 볼 수 있어요.\n펀잇에 가입하고 편의점 상품 꿀조합을 확인해보세요 😊';
 
 const ProductDetailPage = () => {
   const { productId } = useParams();
@@ -95,7 +98,7 @@ const ProductDetailPage = () => {
       ) : (
         <ErrorContainer>
           <ErrorDescription align="center" weight="bold" size="lg">
-            {LOGIN_ERROR_MESSAGE}
+            {isRecipeTab ? LOGIN_ERROR_MESSAGE_RECIPE : LOGIN_ERROR_MESSAGE_REVIEW}
           </ErrorDescription>
           <LoginLink as={RouterLink} to={PATH.LOGIN} block>
             로그인하러 가기

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -16,8 +16,7 @@ import {
   RegisterButton,
   SectionTitle,
 } from '@/components/Common';
-import { ProductDetailItem } from '@/components/Product';
-import { RecipeList } from '@/components/Recipe';
+import { ProductDetailItem, ProductRecipeList } from '@/components/Product';
 import { ReviewList, ReviewRegisterForm } from '@/components/Review';
 import { RECIPE_SORT_OPTIONS, REVIEW_SORT_OPTIONS } from '@/constants';
 import { PATH } from '@/constants/path';
@@ -26,8 +25,7 @@ import { useSortOption } from '@/hooks/common';
 import { useMemberQuery } from '@/hooks/queries/members';
 import { useProductDetailQuery } from '@/hooks/queries/product';
 
-const LOGIN_ERROR_MESSAGE =
-  '로그인 해야 상품 리뷰를 볼 수 있어요.\n펀잇에 가입하고 편의점 상품의 리뷰를 확인해보세요 😊';
+const LOGIN_ERROR_MESSAGE = '로그인 후 상품 리뷰를 볼 수 있어요.\n펀잇에 가입하고 편의점 상품의 리뷰를 확인해보세요 😊';
 
 const ProductDetailPage = () => {
   const { productId } = useParams();
@@ -83,7 +81,11 @@ const ProductDetailPage = () => {
             </SortButtonWrapper>
             <section>
               {isRecipeTab ? (
-                <RecipeList selectedOption={selectedOption} />
+                <ProductRecipeList
+                  productId={Number(productId)}
+                  productName={productDetail.name}
+                  selectedOption={selectedOption}
+                />
               ) : (
                 <ReviewList productId={Number(productId)} selectedOption={selectedOption} />
               )}
@@ -147,7 +149,7 @@ const ErrorContainer = styled.div`
 `;
 
 const ErrorDescription = styled(Text)`
-  padding: 40px 0;
+  padding: 40px 0 20px;
   white-space: pre-line;
   word-break: break-all;
 `;

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -17,8 +17,9 @@ import {
   SectionTitle,
 } from '@/components/Common';
 import { ProductDetailItem } from '@/components/Product';
+import { RecipeList } from '@/components/Recipe';
 import { ReviewList, ReviewRegisterForm } from '@/components/Review';
-import { REVIEW_SORT_OPTIONS } from '@/constants';
+import { RECIPE_SORT_OPTIONS, REVIEW_SORT_OPTIONS } from '@/constants';
 import { PATH } from '@/constants/path';
 import ReviewFormProvider from '@/contexts/ReviewFormContext';
 import { useSortOption } from '@/hooks/common';
@@ -28,22 +29,24 @@ import { useProductDetailQuery } from '@/hooks/queries/product';
 const LOGIN_ERROR_MESSAGE =
   '로그인 해야 상품 리뷰를 볼 수 있어요.\n펀잇에 가입하고 편의점 상품의 리뷰를 확인해보세요 😊';
 
-const getProductDetailPageTabMenus = (reviewCount: number) => [`리뷰 ${reviewCount}`, '꿀조합'];
-
 const ProductDetailPage = () => {
   const { productId } = useParams();
-  const { ref, isClosing, handleOpenBottomSheet, handleCloseBottomSheet } = useBottomSheet();
-  const { selectedOption, selectSortOption } = useSortOption(REVIEW_SORT_OPTIONS[0]);
   const { data: member } = useMemberQuery();
+  const { data: productDetail } = useProductDetailQuery(Number(productId));
   const { reset } = useQueryErrorResetBoundary();
 
-  const { data: productDetail } = useProductDetailQuery(Number(productId));
-
-  const tabMenus = getProductDetailPageTabMenus(productDetail.reviewCount);
+  const tabMenus = [`리뷰 ${productDetail.reviewCount}`, '꿀조합'];
   const [selectedTabMenu, setSelectedTabMenu] = useState(tabMenus[0]);
+  const tabRef = useRef<HTMLUListElement>(null);
+
+  const isRecipeTab = selectedTabMenu === tabMenus[1];
+  const initialSortOption = isRecipeTab ? RECIPE_SORT_OPTIONS[0] : REVIEW_SORT_OPTIONS[0];
+  const sortOptions = isRecipeTab ? RECIPE_SORT_OPTIONS : REVIEW_SORT_OPTIONS;
+
+  const { selectedOption, selectSortOption } = useSortOption(initialSortOption);
+  const { ref, isClosing, handleOpenBottomSheet, handleCloseBottomSheet } = useBottomSheet();
 
   const [activeSheet, setActiveSheet] = useState<'registerReview' | 'sortOption'>('sortOption');
-  const tabRef = useRef<HTMLUListElement>(null);
 
   const handleOpenRegisterReviewSheet = () => {
     setActiveSheet('registerReview');
@@ -57,6 +60,7 @@ const ProductDetailPage = () => {
 
   const handleTabMenuSelect: MouseEventHandler<HTMLButtonElement> = (event) => {
     setSelectedTabMenu(event.currentTarget.value);
+    selectSortOption(initialSortOption);
   };
 
   return (
@@ -78,7 +82,11 @@ const ProductDetailPage = () => {
               <SortButton option={selectedOption} onClick={handleOpenSortOptionSheet} />
             </SortButtonWrapper>
             <section>
-              <ReviewList productId={Number(productId)} selectedOption={selectedOption} />
+              {isRecipeTab ? (
+                <RecipeList selectedOption={selectedOption} />
+              ) : (
+                <ReviewList productId={Number(productId)} selectedOption={selectedOption} />
+              )}
             </section>
           </Suspense>
         </ErrorBoundary>
@@ -112,7 +120,7 @@ const ProductDetailPage = () => {
           </ReviewFormProvider>
         ) : (
           <SortOptionList
-            options={REVIEW_SORT_OPTIONS}
+            options={sortOptions}
             selectedOption={selectedOption}
             selectSortOption={selectSortOption}
             close={handleCloseBottomSheet}

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -1,5 +1,5 @@
 import type { SvgIconVariant } from '@/components/Common/Svg/SvgIcon';
-import type { TAG_TITLE, PRODUCT_SORT_OPTIONS, REVIEW_SORT_OPTIONS } from '@/constants';
+import type { TAG_TITLE, PRODUCT_SORT_OPTIONS, REVIEW_SORT_OPTIONS, RECIPE_SORT_OPTIONS } from '@/constants';
 import type { PATH } from '@/constants/path';
 
 export type CategoryVariant = 'food' | 'store';
@@ -30,6 +30,9 @@ export type ReviewSortOption = 'favoriteCount' | 'rating' | 'createdAt';
 
 export type RecipeSortOption = 'favoriteCount' | 'createdAt';
 
-export type SortOption = (typeof PRODUCT_SORT_OPTIONS)[number] | (typeof REVIEW_SORT_OPTIONS)[number];
+export type SortOption =
+  | (typeof PRODUCT_SORT_OPTIONS)[number]
+  | (typeof REVIEW_SORT_OPTIONS)[number]
+  | (typeof RECIPE_SORT_OPTIONS)[number];
 
 export type TagNameOption = keyof typeof TAG_TITLE;


### PR DESCRIPTION
## Issue

- close #453

## ✨ 구현한 기능

- 상품 상세 페이지 꿀조합 탭 UI, 쿼리 추가

## 📢 논의하고 싶은 내용

- 상품을 사용한 꿀조합이 없을 때 작성하러 가라고 하고 싶어요. 꿀조합 작성 바텀시트를 상세 페이지에서 띄우기에 페이지에서 하는 일이 많아질 것 같아 우선 꿀조합 페이지 링크를 추가했습니다. 좋은 의견 주세요.!

## 🎸 기타

|||
|--|--|
|![스크린샷 2023-08-17 오전 1 11 07](https://github.com/woowacourse-teams/2023-fun-eat/assets/78616893/d23bef7d-e67f-4e0a-aa46-bfb3f41bb406)|![스크린샷 2023-08-17 오전 1 11 55](https://github.com/woowacourse-teams/2023-fun-eat/assets/78616893/c3a776de-1740-412b-822e-f1d3ff1656e6)|

## ⏰ 일정

- 추정 시간 : 4시간
- 걸린 시간 : 2시간
