### PR TITLE
[BE] feat: 꿀조합 랭킹 기능 구현

### DIFF
--- a/backend/src/main/java/com/funeat/recipe/dto/RankingRecipeDto.java
+++ b/backend/src/main/java/com/funeat/recipe/dto/RankingRecipeDto.java
@@ -1,0 +1,44 @@
+package com.funeat.recipe.dto;
+
+import com.funeat.recipe.domain.Recipe;
+import com.funeat.recipe.domain.RecipeImage;
+import java.util.List;
+
+public class RankingRecipeDto {
+
+    private final Long id;
+    private final String image;
+    private final RecipeAuthorDto author;
+    private final Long favoriteCount;
+
+    public RankingRecipeDto(final Long id, final String image, final RecipeAuthorDto author, final Long favoriteCount) {
+        this.id = id;
+        this.image = image;
+        this.author = author;
+        this.favoriteCount = favoriteCount;
+    }
+
+    public static RankingRecipeDto toDto(final Recipe recipe, final List<RecipeImage> images,
+                                         final RecipeAuthorDto author) {
+        if (images.isEmpty()) {
+            return new RankingRecipeDto(recipe.getId(), null, author, recipe.getFavoriteCount());
+        }
+        return new RankingRecipeDto(recipe.getId(), images.get(0).getImage(), author, recipe.getFavoriteCount());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public RecipeAuthorDto getAuthor() {
+        return author;
+    }
+
+    public Long getFavoriteCount() {
+        return favoriteCount;
+    }
+}

--- a/backend/src/main/java/com/funeat/recipe/dto/RankingRecipesResponse.java
+++ b/backend/src/main/java/com/funeat/recipe/dto/RankingRecipesResponse.java
@@ -1,0 +1,20 @@
+package com.funeat.recipe.dto;
+
+import java.util.List;
+
+public class RankingRecipesResponse {
+
+    private final List<RankingRecipeDto> recipes;
+
+    public RankingRecipesResponse(final List<RankingRecipeDto> recipes) {
+        this.recipes = recipes;
+    }
+
+    public static RankingRecipesResponse toResponse(final List<RankingRecipeDto> recipes) {
+        return new RankingRecipesResponse(recipes);
+    }
+
+    public List<RankingRecipeDto> getRecipes() {
+        return recipes;
+    }
+}

--- a/backend/src/main/java/com/funeat/recipe/persistence/RecipeRepository.java
+++ b/backend/src/main/java/com/funeat/recipe/persistence/RecipeRepository.java
@@ -2,6 +2,7 @@ package com.funeat.recipe.persistence;
 
 import com.funeat.member.domain.Member;
 import com.funeat.recipe.domain.Recipe;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
     Page<Recipe> findRecipesByMember(final Member member, final Pageable pageable);
 
     Page<Recipe> findAll(final Pageable pageable);
+
+    List<Recipe> findRecipesByOrderByFavoriteCountDesc(final Pageable pageable);
 }

--- a/backend/src/main/java/com/funeat/recipe/presentation/RecipeApiController.java
+++ b/backend/src/main/java/com/funeat/recipe/presentation/RecipeApiController.java
@@ -3,6 +3,7 @@ package com.funeat.recipe.presentation;
 import com.funeat.auth.dto.LoginInfo;
 import com.funeat.auth.util.AuthenticationPrincipal;
 import com.funeat.recipe.application.RecipeService;
+import com.funeat.recipe.dto.RankingRecipesResponse;
 import com.funeat.recipe.dto.RecipeCreateRequest;
 import com.funeat.recipe.dto.RecipeDetailResponse;
 import com.funeat.recipe.dto.RecipeFavoriteRequest;
@@ -64,5 +65,12 @@ public class RecipeApiController implements RecipeController {
         recipeService.likeRecipe(loginInfo.getId(), recipeId, request);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/api/ranks/recipes")
+    public ResponseEntity<RankingRecipesResponse> getRankingRecipes() {
+        final RankingRecipesResponse response = recipeService.getTop3Recipes();
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/funeat/recipe/presentation/RecipeController.java
+++ b/backend/src/main/java/com/funeat/recipe/presentation/RecipeController.java
@@ -2,6 +2,7 @@ package com.funeat.recipe.presentation;
 
 import com.funeat.auth.dto.LoginInfo;
 import com.funeat.auth.util.AuthenticationPrincipal;
+import com.funeat.recipe.dto.RankingRecipesResponse;
 import com.funeat.recipe.dto.RecipeCreateRequest;
 import com.funeat.recipe.dto.RecipeDetailResponse;
 import com.funeat.recipe.dto.RecipeFavoriteRequest;
@@ -60,4 +61,12 @@ public interface RecipeController {
     ResponseEntity<Void> likeRecipe(@AuthenticationPrincipal final LoginInfo loginInfo,
                                     @PathVariable final Long recipeId,
                                     @RequestBody RecipeFavoriteRequest request);
+
+    @Operation(summary = "꿀조합 랭킹 조회", description = "전체 꿀조합들 중에서 랭킹 TOP3를 조회한다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "꿀조합 랭킹 조회 성공."
+    )
+    @GetMapping
+    ResponseEntity<RankingRecipesResponse> getRankingRecipes();
 }

--- a/backend/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
@@ -8,6 +8,7 @@ import static com.funeat.acceptance.common.CommonSteps.정상_생성;
 import static com.funeat.acceptance.common.CommonSteps.정상_처리;
 import static com.funeat.acceptance.common.CommonSteps.정상_처리_NO_CONTENT;
 import static com.funeat.acceptance.common.CommonSteps.찾을수_없음;
+import static com.funeat.acceptance.recipe.RecipeSteps.레시피_랭킹_조회_요청;
 import static com.funeat.acceptance.recipe.RecipeSteps.레시피_목록_요청;
 import static com.funeat.acceptance.recipe.RecipeSteps.레시피_상세_정보_요청;
 import static com.funeat.acceptance.recipe.RecipeSteps.레시피_생성_요청;
@@ -38,6 +39,9 @@ import com.funeat.acceptance.common.AcceptanceTest;
 import com.funeat.common.dto.PageDto;
 import com.funeat.member.domain.Member;
 import com.funeat.product.domain.Product;
+import com.funeat.recipe.domain.Recipe;
+import com.funeat.recipe.dto.RankingRecipeDto;
+import com.funeat.recipe.dto.RecipeAuthorDto;
 import com.funeat.recipe.dto.RecipeCreateRequest;
 import com.funeat.recipe.dto.RecipeDetailResponse;
 import com.funeat.recipe.dto.RecipeDto;
@@ -641,6 +645,33 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
         }
     }
 
+    @Nested
+    class getRankingRecipes_성공_테스트 {
+
+        @Test
+        void 전체_꿀조합들_중에서_랭킹_TOP3를_조회할_수_있다() {
+            // given
+            final var member = 멤버_멤버1_생성();
+            단일_멤버_저장(member);
+
+            final var recipe1 = 레시피_생성(member, 1L);
+            final var recipe2 = 레시피_생성(member, 2L);
+            final var recipe3 = 레시피_생성(member, 3L);
+            final var recipe4 = 레시피_생성(member, 4L);
+            복수_꿀조합_저장(recipe1, recipe2, recipe3, recipe4);
+
+            final var expectedRecipes = List.of(recipe4, recipe3, recipe2);
+            final var expected = 예상_레시피_랭킹_변환(expectedRecipes, member);
+
+            // when
+            final var response = 레시피_랭킹_조회_요청();
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            레시피_랭킹_조회_결과를_검증한다(response, expected);
+        }
+    }
+
     private void 레시피_목록_조회_결과를_검증한다(final ExtractableResponse<Response> response, final List<RecipeDto> recipes,
                                     final PageDto pageDto) {
         페이지를_검증한다(response, pageDto);
@@ -699,5 +730,20 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
         return Stream.of(products)
                 .map(Product::getId)
                 .collect(Collectors.toList());
+    }
+
+    private List<RankingRecipeDto> 예상_레시피_랭킹_변환(final List<Recipe> recipes, final Member member) {
+        return recipes.stream()
+                .map(it -> RankingRecipeDto.toDto(it, Collections.emptyList(), RecipeAuthorDto.toDto(member)))
+                .collect(Collectors.toList());
+    }
+
+    private void 레시피_랭킹_조회_결과를_검증한다(final ExtractableResponse<Response> response,
+                                    final List<RankingRecipeDto> expected) {
+        final var actual = response.jsonPath()
+                .getList("recipes", RankingRecipeDto.class);
+
+        assertThat(actual).usingRecursiveComparison()
+                .isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/com/funeat/acceptance/recipe/RecipeSteps.java
+++ b/backend/src/test/java/com/funeat/acceptance/recipe/RecipeSteps.java
@@ -77,4 +77,12 @@ public class RecipeSteps {
                         .build())
                 .collect(Collectors.toList());
     }
+
+    public static ExtractableResponse<Response> 레시피_랭킹_조회_요청() {
+        return given()
+                .when()
+                .get("/api/ranks/recipes")
+                .then()
+                .extract();
+    }
 }

--- a/backend/src/test/java/com/funeat/recipe/persistence/RecipeRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/recipe/persistence/RecipeRepositoryTest.java
@@ -4,6 +4,7 @@ import static com.funeat.fixture.CategoryFixture.카테고리_간편식사_생�
 import static com.funeat.fixture.MemberFixture.멤버_멤버1_생성;
 import static com.funeat.fixture.MemberFixture.멤버_멤버2_생성;
 import static com.funeat.fixture.MemberFixture.멤버_멤버3_생성;
+import static com.funeat.fixture.PageFixture.페이지요청_기본_생성;
 import static com.funeat.fixture.PageFixture.페이지요청_생성_시간_내림차순_생성;
 import static com.funeat.fixture.PageFixture.페이지요청_생성_시간_오름차순_생성;
 import static com.funeat.fixture.PageFixture.페이지요청_좋아요_내림차순_생성;
@@ -13,14 +14,14 @@ import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격2000�
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격2000원_평점3점_생성;
 import static com.funeat.fixture.RecipeFixture.레시피_생성;
 import static com.funeat.fixture.RecipeFixture.레시피이미지_생성;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.funeat.common.RepositoryTest;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("NonAsciiCharacters")
 class RecipeRepositoryTest extends RepositoryTest {
 
     @Nested
@@ -158,6 +159,33 @@ class RecipeRepositoryTest extends RepositoryTest {
             // then
             assertThat(actual)
                     .usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    class findRecipesByOrderByFavoriteCountDesc_성공_테스트 {
+
+        @Test
+        void 좋아요순으로_상위_3개의_레시피들을_조회한다() {
+            // given
+            final var member = 멤버_멤버1_생성();
+            단일_멤버_저장(member);
+
+            final var recipe1 = 레시피_생성(member, 1L);
+            final var recipe2 = 레시피_생성(member, 2L);
+            final var recipe3 = 레시피_생성(member, 3L);
+            final var recipe4 = 레시피_생성(member, 4L);
+            복수_꿀조합_저장(recipe1, recipe2, recipe3, recipe4);
+
+            final var page = 페이지요청_기본_생성(0, 3);
+            final var expected = List.of(recipe4, recipe3, recipe2);
+
+            // when
+            final var actual = recipeRepository.findRecipesByOrderByFavoriteCountDesc(page);
+
+            // then
+            assertThat(actual).usingRecursiveComparison()
                     .isEqualTo(expected);
         }
     }


### PR DESCRIPTION
## Issue

- close #486 

## ✨ 구현한 기능

### 꿀조합 랭킹 기능 구현

- 좋아요 내림차순으로 TOP 3 꿀조합 목록 반환
- TOP 3 태그 조회 기능과 마찬가지로 Repository 메서드에 `PageRequest.of(0, 3)`를 파라미터로 넘겨주는 방식으로 상위 3개 조회하도록 구현

## 📢 논의하고 싶은 내용

- X

## 🎸 기타

- X

## ⏰ 일정

- 추정 시간 : 2h
- 걸린 시간 : 1.5h
