### PR TITLE
[BE] feat: 특정 상품의 꿀조합 목록 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/funeat/product/presentation/ProductApiController.java
+++ b/backend/src/main/java/com/funeat/product/presentation/ProductApiController.java
@@ -64,7 +64,7 @@ public class ProductApiController implements ProductController {
 
     @GetMapping("/products/{productId}/recipes")
     public ResponseEntity<SortingRecipesResponse> getProductRecipes(@PathVariable final Long productId,
-                                                             @PageableDefault Pageable pageable) {
+                                                                    @PageableDefault final Pageable pageable) {
         final SortingRecipesResponse response = productService.getProductRecipes(productId, pageable);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/funeat/product/presentation/ProductApiController.java
+++ b/backend/src/main/java/com/funeat/product/presentation/ProductApiController.java
@@ -6,6 +6,7 @@ import com.funeat.product.dto.ProductsInCategoryResponse;
 import com.funeat.product.dto.RankingProductsResponse;
 import com.funeat.product.dto.SearchProductResultsResponse;
 import com.funeat.product.dto.SearchProductsResponse;
+import com.funeat.recipe.dto.SortingRecipesResponse;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -58,6 +59,13 @@ public class ProductApiController implements ProductController {
                                                                          @PageableDefault final Pageable pageable) {
         final PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
         final SearchProductResultsResponse response = productService.getSearchResults(query, pageRequest);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/products/{productId}/recipes")
+    public ResponseEntity<SortingRecipesResponse> getProductRecipes(@PathVariable final Long productId,
+                                                             @PageableDefault Pageable pageable) {
+        final SortingRecipesResponse response = productService.getProductRecipes(productId, pageable);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/funeat/product/presentation/ProductController.java
+++ b/backend/src/main/java/com/funeat/product/presentation/ProductController.java
@@ -70,5 +70,5 @@ public interface ProductController {
     )
     @GetMapping
     ResponseEntity<SortingRecipesResponse> getProductRecipes(@PathVariable final Long productId,
-                                                             @PageableDefault Pageable pageable);
+                                                             @PageableDefault final Pageable pageable);
 }

--- a/backend/src/main/java/com/funeat/product/presentation/ProductController.java
+++ b/backend/src/main/java/com/funeat/product/presentation/ProductController.java
@@ -5,6 +5,7 @@ import com.funeat.product.dto.ProductsInCategoryResponse;
 import com.funeat.product.dto.RankingProductsResponse;
 import com.funeat.product.dto.SearchProductResultsResponse;
 import com.funeat.product.dto.SearchProductsResponse;
+import com.funeat.recipe.dto.SortingRecipesResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -61,4 +62,13 @@ public interface ProductController {
     @GetMapping
     ResponseEntity<SearchProductResultsResponse> getSearchResults(@RequestParam final String query,
                                                                   @PageableDefault final Pageable pageable);
+
+    @Operation(summary = "해당 상품 꿀조합 목록 조회", description = "해당 상품이 포함된 꿀조합 목록을 조회한다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "해당 상품 꿀조합 목록 조회 성공."
+    )
+    @GetMapping
+    ResponseEntity<SortingRecipesResponse> getProductRecipes(@PathVariable final Long productId,
+                                                             @PageableDefault Pageable pageable);
 }

--- a/backend/src/main/java/com/funeat/recipe/persistence/RecipeRepository.java
+++ b/backend/src/main/java/com/funeat/recipe/persistence/RecipeRepository.java
@@ -1,14 +1,19 @@
 package com.funeat.recipe.persistence;
 
 import com.funeat.member.domain.Member;
+import com.funeat.product.domain.Product;
 import com.funeat.recipe.domain.Recipe;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
     Page<Recipe> findRecipesByMember(final Member member, final Pageable pageable);
 
     Page<Recipe> findAll(final Pageable pageable);
+
+    @Query("SELECT r FROM Recipe r LEFT JOIN ProductRecipe pr ON pr.product = :product WHERE pr.recipe.id = r.id")
+    Page<Recipe> findRecipesByProduct(final Product product, final Pageable pageable);
 }

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
@@ -6,6 +6,7 @@ import static com.funeat.acceptance.common.CommonSteps.정상_처리;
 import static com.funeat.acceptance.common.CommonSteps.찾을수_없음;
 import static com.funeat.acceptance.product.ProductSteps.상품_검색_결과_조회_요청;
 import static com.funeat.acceptance.product.ProductSteps.상품_랭킹_조회_요청;
+import static com.funeat.acceptance.product.ProductSteps.상품_레시피_목록_요청;
 import static com.funeat.acceptance.product.ProductSteps.상품_상세_조회_요청;
 import static com.funeat.acceptance.product.ProductSteps.상품_자동_완성_검색_요청;
 import static com.funeat.acceptance.product.ProductSteps.카테고리별_상품_목록_조회_요청;
@@ -15,6 +16,7 @@ import static com.funeat.fixture.CategoryFixture.카테고리_간편식사_생�
 import static com.funeat.fixture.MemberFixture.멤버_멤버1_생성;
 import static com.funeat.fixture.MemberFixture.멤버_멤버2_생성;
 import static com.funeat.fixture.MemberFixture.멤버_멤버3_생성;
+import static com.funeat.fixture.ProductFixture.레시피_안에_들어가는_상품_생성;
 import static com.funeat.fixture.ProductFixture.상품_망고빙수_가격5000원_평점4점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000원_평점1점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000원_평점2점_생성;
@@ -33,6 +35,8 @@ import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격5000�
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격5000원_평점3점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격5000원_평점4점_생성;
 import static com.funeat.fixture.ProductFixture.상품_애플망고_가격3000원_평점5점_생성;
+import static com.funeat.fixture.RecipeFixture.레시피_생성;
+import static com.funeat.fixture.RecipeFixture.레시피이미지_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test1_평점1점_재구매X_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test2_평점2점_재구매X_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test3_평점3점_재구매O_생성;
@@ -56,6 +60,7 @@ import com.funeat.product.dto.ProductResponse;
 import com.funeat.product.dto.RankingProductDto;
 import com.funeat.product.dto.SearchProductDto;
 import com.funeat.product.dto.SearchProductResultDto;
+import com.funeat.recipe.dto.RecipeDto;
 import com.funeat.tag.domain.Tag;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -681,6 +686,148 @@ class ProductAcceptanceTest extends AcceptanceTest {
         }
     }
 
+    @Nested
+    class getProductRecipes_성공_테스트 {
+
+        @Test
+        void 해당_상품의_꿀조합_목록을_좋아요가_많은_순으로_조회할_수_있다() {
+            // given
+            final var member = 멤버_멤버1_생성();
+            단일_멤버_저장(member);
+
+            final var category = 카테고리_간편식사_생성();
+            단일_카테고리_저장(category);
+
+            final var product1 = 상품_삼각김밥_가격1000원_평점5점_생성(category);
+            final var product2 = 상품_삼각김밥_가격2000원_평점3점_생성(category);
+            final var product3 = 상품_삼각김밥_가격2000원_평점1점_생성(category);
+            복수_상품_저장(product1, product2, product3);
+
+            final var recipe1 = 레시피_생성(member, 1L);
+            final var recipe2 = 레시피_생성(member, 3L);
+            final var recipe3 = 레시피_생성(member, 2L);
+            복수_꿀조합_저장(recipe1, recipe2, recipe3);
+
+            final var product_recipe_1_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1);
+            final var product_recipe_1_2 = 레시피_안에_들어가는_상품_생성(product1, recipe2);
+            final var product_recipe_2_1 = 레시피_안에_들어가는_상품_생성(product2, recipe1);
+            final var product_recipe_3_1 = 레시피_안에_들어가는_상품_생성(product3, recipe1);
+            final var product_recipe_3_2 = 레시피_안에_들어가는_상품_생성(product3, recipe2);
+            복수_꿀조합_상품_저장(product_recipe_1_1, product_recipe_2_1, product_recipe_3_1, product_recipe_1_2,
+                    product_recipe_3_2);
+
+            final var recipeImage1_1 = 레시피이미지_생성(recipe1);
+            final var recipeImage2_1 = 레시피이미지_생성(recipe2);
+            final var recipeImage2_2 = 레시피이미지_생성(recipe2);
+            복수_꿀조합_이미지_저장(recipeImage1_1, recipeImage2_1, recipeImage2_2);
+
+            final var pageDto = new PageDto(2L, 1L, true, true, 0L, 10L);
+            final var sortingRecipes = List.of(
+                    RecipeDto.toDto(recipe2, List.of(recipeImage2_1, recipeImage2_2), List.of(product1, product3)),
+                    RecipeDto.toDto(recipe1, List.of(recipeImage1_1), List.of(product1, product2, product3))
+            );
+
+            // when
+            final var response = 상품_레시피_목록_요청(product1.getId(), "favoriteCount", "desc", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            상품_레시피_목록_조회_결과를_검증한다(response, sortingRecipes, pageDto);
+        }
+
+        @Test
+        void 해당_상품의_꿀조합_목록을_최신순으로_조회할_수_있다() {
+            // given
+            final var member = 멤버_멤버1_생성();
+            단일_멤버_저장(member);
+
+            final var category = 카테고리_간편식사_생성();
+            단일_카테고리_저장(category);
+
+            final var product1 = 상품_삼각김밥_가격1000원_평점5점_생성(category);
+            final var product2 = 상품_삼각김밥_가격2000원_평점3점_생성(category);
+            final var product3 = 상품_삼각김밥_가격2000원_평점1점_생성(category);
+            복수_상품_저장(product1, product2, product3);
+
+            final var recipe1 = 레시피_생성(member, 1L);
+            final var recipe2 = 레시피_생성(member, 3L);
+            final var recipe3 = 레시피_생성(member, 2L);
+            복수_꿀조합_저장(recipe1, recipe2, recipe3);
+
+            final var product_recipe_1_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1);
+            final var product_recipe_1_2 = 레시피_안에_들어가는_상품_생성(product1, recipe2);
+            final var product_recipe_2_1 = 레시피_안에_들어가는_상품_생성(product2, recipe1);
+            final var product_recipe_3_1 = 레시피_안에_들어가는_상품_생성(product3, recipe1);
+            final var product_recipe_3_2 = 레시피_안에_들어가는_상품_생성(product3, recipe2);
+            복수_꿀조합_상품_저장(product_recipe_1_1, product_recipe_2_1, product_recipe_3_1, product_recipe_1_2,
+                    product_recipe_3_2);
+
+            final var recipeImage1_1 = 레시피이미지_생성(recipe1);
+            final var recipeImage2_1 = 레시피이미지_생성(recipe2);
+            final var recipeImage2_2 = 레시피이미지_생성(recipe2);
+            복수_꿀조합_이미지_저장(recipeImage1_1, recipeImage2_1, recipeImage2_2);
+
+            final var pageDto = new PageDto(2L, 1L, true, true, 0L, 10L);
+            final var sortingRecipes = List.of(
+                    RecipeDto.toDto(recipe2, List.of(recipeImage2_1, recipeImage2_2), List.of(product1, product3)),
+                    RecipeDto.toDto(recipe1, List.of(recipeImage1_1), List.of(product1, product2, product3))
+            );
+
+            // when
+            final var response = 상품_레시피_목록_요청(product1.getId(), "createdAt", "desc", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            상품_레시피_목록_조회_결과를_검증한다(response, sortingRecipes, pageDto);
+        }
+
+        @Test
+        void 해당_상품의_꿀조합_목록을_오래된순으로_조회할_수_있다() {
+            // given
+            final var member = 멤버_멤버1_생성();
+            단일_멤버_저장(member);
+
+            final var category = 카테고리_간편식사_생성();
+            단일_카테고리_저장(category);
+
+            final var product1 = 상품_삼각김밥_가격1000원_평점5점_생성(category);
+            final var product2 = 상품_삼각김밥_가격2000원_평점3점_생성(category);
+            final var product3 = 상품_삼각김밥_가격2000원_평점1점_생성(category);
+            복수_상품_저장(product1, product2, product3);
+
+            final var recipe1 = 레시피_생성(member, 1L);
+            final var recipe2 = 레시피_생성(member, 3L);
+            final var recipe3 = 레시피_생성(member, 2L);
+            복수_꿀조합_저장(recipe1, recipe2, recipe3);
+
+            final var product_recipe_1_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1);
+            final var product_recipe_1_2 = 레시피_안에_들어가는_상품_생성(product1, recipe2);
+            final var product_recipe_2_1 = 레시피_안에_들어가는_상품_생성(product2, recipe1);
+            final var product_recipe_3_1 = 레시피_안에_들어가는_상품_생성(product3, recipe1);
+            final var product_recipe_3_2 = 레시피_안에_들어가는_상품_생성(product3, recipe2);
+            복수_꿀조합_상품_저장(product_recipe_1_1, product_recipe_2_1, product_recipe_3_1, product_recipe_1_2,
+                    product_recipe_3_2);
+
+            final var recipeImage1_1 = 레시피이미지_생성(recipe1);
+            final var recipeImage2_1 = 레시피이미지_생성(recipe2);
+            final var recipeImage2_2 = 레시피이미지_생성(recipe2);
+            복수_꿀조합_이미지_저장(recipeImage1_1, recipeImage2_1, recipeImage2_2);
+
+            final var pageDto = new PageDto(2L, 1L, true, true, 0L, 10L);
+            final var sortingRecipes = List.of(
+                    RecipeDto.toDto(recipe1, List.of(recipeImage1_1), List.of(product1, product2, product3)),
+                    RecipeDto.toDto(recipe2, List.of(recipeImage2_1, recipeImage2_2), List.of(product1, product3))
+            );
+
+            // when
+            final var response = 상품_레시피_목록_요청(product1.getId(), "createdAt", "asc", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            상품_레시피_목록_조회_결과를_검증한다(response, sortingRecipes, pageDto);
+        }
+    }
+
     private List<Long> 태그_아이디_변환(final Tag... tags) {
         return Arrays.stream(tags)
                 .map(Tag::getId)
@@ -741,6 +888,19 @@ class ProductAcceptanceTest extends AcceptanceTest {
     private <T> void 상품_검색_결과를_검증한다(final ExtractableResponse<Response> response, final List<T> expected) {
         final var actual = response.jsonPath()
                 .getList("products", SearchProductResultDto.class);
+
+        assertThat(actual).usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    private void 상품_레시피_목록_조회_결과를_검증한다(final ExtractableResponse<Response> response, final List<RecipeDto> recipes,
+                                       final PageDto pageDto) {
+        페이지를_검증한다(response, pageDto);
+        상품_레시피_목록을_검증한다(response, recipes);
+    }
+
+    private void 상품_레시피_목록을_검증한다(final ExtractableResponse<Response> response, final List<RecipeDto> expected) {
+        final var actual = response.jsonPath().getList("recipes", RecipeDto.class);
 
         assertThat(actual).usingRecursiveComparison()
                 .isEqualTo(expected);

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductSteps.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductSteps.java
@@ -54,4 +54,15 @@ public class ProductSteps {
                 .then()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 상품_레시피_목록_요청(final Long productId, final String sortType,
+                                                             final String sortOrderType, final int page) {
+        return given()
+                .queryParam("sort", sortType + "," + sortOrderType)
+                .queryParam("page", page)
+                .when()
+                .get("/api/products/{productId}/recipes", productId)
+                .then()
+                .extract();
+    }
 }

--- a/backend/src/test/java/com/funeat/product/persistence/ProductRecipeRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/product/persistence/ProductRecipeRepositoryTest.java
@@ -1,89 +1,51 @@
 package com.funeat.product.persistence;
 
+import static com.funeat.fixture.CategoryFixture.카테고리_간편식사_생성;
+import static com.funeat.fixture.MemberFixture.멤버_멤버1_생성;
+import static com.funeat.fixture.ProductFixture.레시피_안에_들어가는_상품_생성;
+import static com.funeat.fixture.ProductFixture.상품_망고빙수_가격5000원_평점4점_생성;
+import static com.funeat.fixture.ProductFixture.상품_애플망고_가격3000원_평점5점_생성;
+import static com.funeat.fixture.RecipeFixture.레시피_생성;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.funeat.common.DataCleaner;
-import com.funeat.common.DataClearExtension;
-import com.funeat.member.domain.Member;
-import com.funeat.member.persistence.MemberRepository;
-import com.funeat.product.domain.Category;
-import com.funeat.product.domain.CategoryType;
-import com.funeat.product.domain.Product;
-import com.funeat.product.domain.ProductRecipe;
-import com.funeat.recipe.domain.Recipe;
-import com.funeat.recipe.persistence.RecipeRepository;
+import com.funeat.common.RepositoryTest;
 import java.util.List;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
-@DataJpaTest
-@Import(DataCleaner.class)
-@ExtendWith(DataClearExtension.class)
-@SuppressWarnings("NonAsciiCharacters")
-@DisplayNameGeneration(ReplaceUnderscores.class)
-class ProductRecipeRepositoryTest {
+class ProductRecipeRepositoryTest extends RepositoryTest {
 
-    @Autowired
-    private CategoryRepository categoryRepository;
+    @Nested
+    class findProductByRecipe_성공_테스트 {
 
-    @Autowired
-    private ProductRepository productRepository;
+        @Test
+        void 레시피에_사용된_상품들을_조회할_수_있다() {
+            // given
+            final var category = 카테고리_간편식사_생성();
+            단일_카테고리_저장(category);
 
-    @Autowired
-    private MemberRepository memberRepository;
+            final var product1 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product2 = 상품_망고빙수_가격5000원_평점4점_생성(category);
+            복수_상품_저장(product1, product2);
 
-    @Autowired
-    private RecipeRepository recipeRepository;
+            final var member = 멤버_멤버1_생성();
+            단일_멤버_저장(member);
 
-    @Autowired
-    private ProductRecipeRepository productRecipeRepository;
+            final var recipe = 레시피_생성(member, 1L);
+            단일_꿀조합_저장(recipe);
 
-    @Test
-    void 레시피에_사용된_상품들을_조회할_수_있다() {
-        // given
-        final var category = 카테고리_추가_요청(new Category("간편식사", CategoryType.FOOD));
-        final var product1 = 상품_추가_요청(new Product("불닭볶음면", 1000L, "image.png", "엄청 매운 불닭", category));
-        final var product2 = 상품_추가_요청(new Product("참치 삼김", 2000L, "image.png", "담백한 참치마요 삼김", category));
-        final var product3 = 상품_추가_요청(new Product("스트링 치즈", 1500L, "image.png", "고소한 치즈", category));
-        final var products = List.of(product1, product2, product3);
-        final var member = 멤버_추가_요청(new Member("test", "image.png", "1"));
+            final var product_recipe_1 = 레시피_안에_들어가는_상품_생성(product1, recipe);
+            final var product_recipe_2 = 레시피_안에_들어가는_상품_생성(product2, recipe);
+            복수_꿀조합_상품_저장(product_recipe_1, product_recipe_2);
 
-        final var recipe = 레시피_추가_요청(new Recipe("레시피1", "밥 넣고 밥 넣자", member));
-        복수_레시피_상품_추가_요청(products, recipe);
-        final var expected = products;
+            final var expected = List.of(product1, product2);
 
-        // when
-        final var actual = productRecipeRepository.findProductByRecipe(recipe);
+            // when
+            final var actual = productRecipeRepository.findProductByRecipe(recipe);
 
-        // then
-        assertThat(actual).usingRecursiveComparison()
-                .isEqualTo(expected);
-    }
-
-    private Category 카테고리_추가_요청(final Category category) {
-        return categoryRepository.save(category);
-    }
-
-    private Product 상품_추가_요청(final Product product) {
-        return productRepository.save(product);
-    }
-
-    private Member 멤버_추가_요청(final Member member) {
-        return memberRepository.save(member);
-    }
-
-    private Recipe 레시피_추가_요청(final Recipe recipe) {
-        return recipeRepository.save(recipe);
-    }
-
-    private void 복수_레시피_상품_추가_요청(final List<Product> products, final Recipe recipe) {
-        for (Product product : products) {
-            productRecipeRepository.save(new ProductRecipe(product, recipe));
+            // then
+            assertThat(actual).usingRecursiveComparison()
+                    .isEqualTo(expected);
         }
     }
 }

--- a/backend/src/test/java/com/funeat/recipe/persistence/RecipeRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/recipe/persistence/RecipeRepositoryTest.java
@@ -13,11 +13,10 @@ import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격2000�
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격2000원_평점3점_생성;
 import static com.funeat.fixture.RecipeFixture.레시피_생성;
 import static com.funeat.fixture.RecipeFixture.레시피이미지_생성;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.funeat.common.RepositoryTest;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -158,6 +157,52 @@ class RecipeRepositoryTest extends RepositoryTest {
             // then
             assertThat(actual)
                     .usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    class findRecipesByProduct_성공_테스트 {
+
+        @Test
+        void 상품이_포함된_레시피들을_조회할_수_있다() {
+            // given
+            final var member = 멤버_멤버1_생성();
+            단일_멤버_저장(member);
+
+            final var category = 카테고리_간편식사_생성();
+            단일_카테고리_저장(category);
+
+            final var product1 = 상품_삼각김밥_가격1000원_평점5점_생성(category);
+            final var product2 = 상품_삼각김밥_가격2000원_평점3점_생성(category);
+            final var product3 = 상품_삼각김밥_가격2000원_평점1점_생성(category);
+            복수_상품_저장(product1, product2, product3);
+
+            final var recipe1 = 레시피_생성(member, 1L);
+            final var recipe2 = 레시피_생성(member, 3L);
+            final var recipe3 = 레시피_생성(member, 2L);
+            복수_꿀조합_저장(recipe1, recipe2, recipe3);
+
+            final var product_recipe_1_1 = 레시피_안에_들어가는_상품_생성(product1, recipe1);
+            final var product_recipe_1_2 = 레시피_안에_들어가는_상품_생성(product1, recipe2);
+            final var product_recipe_2_1 = 레시피_안에_들어가는_상품_생성(product2, recipe1);
+            final var product_recipe_3_1 = 레시피_안에_들어가는_상품_생성(product3, recipe1);
+            final var product_recipe_3_2 = 레시피_안에_들어가는_상품_생성(product3, recipe2);
+            복수_꿀조합_상품_저장(product_recipe_1_1, product_recipe_2_1, product_recipe_3_1, product_recipe_1_2,
+                    product_recipe_3_2);
+
+            final var recipeImage1_1 = 레시피이미지_생성(recipe1);
+            final var recipeImage2_1 = 레시피이미지_생성(recipe2);
+            final var recipeImage2_2 = 레시피이미지_생성(recipe2);
+            복수_꿀조합_이미지_저장(recipeImage1_1, recipeImage2_1, recipeImage2_2);
+            final var page = 페이지요청_좋아요_내림차순_생성(0, 10);
+            final var expected = List.of(recipe2, recipe1);
+
+            // when
+            final var actual = recipeRepository.findRecipesByProduct(product1, page).getContent();
+
+            // then
+            assertThat(actual).usingRecursiveComparison()
                     .isEqualTo(expected);
         }
     }


### PR DESCRIPTION
## Issue

- close #487 

## ✨ 구현한 기능

### 특정 상품의 꿀조합 목록 조회 기능

- 상품으로 해당 상품이 포함된 꿀조합 목록 조회하는 기능 구현

## 📢 논의하고 싶은 내용

- `ProductService` vs `RecipeService`
  - 상품 상세 정보 페이지에서 해당 상품의 꿀조합 목록을 조회하는 기능이고, uri도 `ProductController`에 가깝다고 생각해서 `ProductController` - `ProductService`로 구현했습니다.
- `ProductRecipeRepository` vs `RecipeRepository` vs `ProductRepository`
  - `ProductRecipeRepository` : 여기에서 처리하는 게 맞다고 생각했는데, 좋아요순 정렬을 할 때 favoriteCount를 ProductRecipe 엔티티에서 찾을 수 없어서 다른 repository로 옮겼습니다.
  - `RecipeRepository` vs `ProductRepository` : Recipe를 반환하기 때문에 RecipeRepository에서 처리하도록 했는데 어떻게 생각하시나요?

## 🎸 기타

- X

## ⏰ 일정

- 추정 시간 : 2h
- 걸린 시간 : 1.5h
