### PR TITLE
[FE] feat: 하트 색 살리기와 실패 시에도 폼 비우기

### DIFF
--- a/frontend/src/components/Recipe/RecipeItem/RecipeItem.tsx
+++ b/frontend/src/components/Recipe/RecipeItem/RecipeItem.tsx
@@ -40,7 +40,7 @@ const RecipeItem = ({ recipe, isMemberPage = false }: RecipeItemProps) => {
           ))}
         </Text>
         <FavoriteWrapper>
-          <SvgIcon variant="favoriteFilled" width={16} height={16} />
+          <SvgIcon variant="favoriteFilled" width={16} height={16} color={theme.colors.error} />
           <Text as="span" weight="bold">
             {favoriteCount}
           </Text>

--- a/frontend/src/components/Recipe/RecipeRegisterForm/RecipeRegisterForm.tsx
+++ b/frontend/src/components/Recipe/RecipeRegisterForm/RecipeRegisterForm.tsx
@@ -36,16 +36,21 @@ const RecipeRegisterForm = ({ closeRecipeDialog }: RecipeRegisterFormProps) => {
     formContent: recipeFormValue,
   });
 
+  const resetAndCloseForm = () => {
+    deleteImage();
+    resetRecipeFormValue();
+    closeRecipeDialog();
+  };
+
   const handleRecipeFormSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault();
 
     mutate(formData, {
       onSuccess: () => {
-        deleteImage();
-        resetRecipeFormValue();
-        closeRecipeDialog();
+        resetAndCloseForm();
       },
       onError: (error) => {
+        resetAndCloseForm();
         if (error instanceof Error) {
           alert(error.message);
           return;

--- a/frontend/src/components/Review/ReviewRegisterForm/ReviewRegisterForm.tsx
+++ b/frontend/src/components/Review/ReviewRegisterForm/ReviewRegisterForm.tsx
@@ -48,18 +48,22 @@ const ReviewRegisterForm = ({ productId, targetRef, closeReviewDialog }: ReviewR
     formContent: reviewFormValue,
   });
 
+  const resetAndCloseForm = () => {
+    deleteImage();
+    resetReviewFormValue();
+    closeReviewDialog();
+  };
+
   const handleSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault();
 
     mutate(formData, {
       onSuccess: () => {
-        deleteImage();
-        resetReviewFormValue();
-
-        closeReviewDialog();
+        resetAndCloseForm();
         scrollToPosition(targetRef);
       },
       onError: (error) => {
+        resetAndCloseForm();
         if (error instanceof Error) {
           alert(error.message);
           return;


### PR DESCRIPTION
## Issue

- close #498

## ✨ 구현한 기능

하트 색을 빨간색으로 변경하였습니다.
실패 시에도 폼을 비우고 닫도록 하였습니다.

## 📢 논의하고 싶은 내용

x

## 🎸 기타

x

## ⏰ 일정

- 추정 시간 : 10분
- 걸린 시간 : 10분
