### PR TITLE
[BE] fix: 꿀조합 검색 시 중복 검색되는 버그 해결

### DIFF
--- a/backend/src/main/java/com/funeat/recipe/persistence/RecipeRepository.java
+++ b/backend/src/main/java/com/funeat/recipe/persistence/RecipeRepository.java
@@ -18,12 +18,9 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
     Page<Recipe> findRecipesByMember(final Member member, final Pageable pageable);
 
-    @Query("SELECT r FROM Recipe r "
+    @Query("SELECT DISTINCT r FROM Recipe r "
             + "LEFT JOIN ProductRecipe pr ON pr.recipe.id = r.id "
-            + "WHERE pr.product.name LIKE CONCAT('%', :name, '%') "
-            + "ORDER BY CASE "
-            + "WHEN pr.product.name LIKE CONCAT(:name, '%') THEN 1 "
-            + "ELSE 2 END")
+            + "WHERE pr.product.name LIKE CONCAT('%', :name, '%')")
     Page<Recipe> findAllByProductNameContaining(@Param("name") final String name, final Pageable pageable);
 
     Page<Recipe> findAll(final Pageable pageable);


### PR DESCRIPTION
## Issue

- close #509 

## ✨ 구현한 기능

- 꿀조합 검색 시 중복 제거
  - DISTINCT 구문 추가해서 해결
  - But, DISTINCT랑 ORDER BY 같이 사용 불가
    - 대안 1) ORDER BY 절에 MIN, MAX 등 사용 => ORDER BY CASE WHEN ~ 으로 처리하고 있기 때문에 현재 우리 상황과 다름
    - 대안 2) ORDER BY 절 제거 => 자동 완성에서 사용하기 위한 ORDER BY 절이었고, 이미 자동 완성을 거친 후여서 없어도 괜찮다고 판단. 꿀조합 검색에서 상품명의 순서는 중요하지 않다고 생각

  - 대안 2 선택

## 📢 논의하고 싶은 내용

- 위에 대안으로 적어둔 내용 확인해주세요.

## 🎸 기타

- X

## ⏰ 일정

- 추정 시간 : 15min
- 걸린 시간 : 30min
