### PR TITLE
[FE] refactor: 꿀조합 버튼 변경

### DIFF
--- a/frontend/src/components/Common/ScrollButton/ScrollButton.tsx
+++ b/frontend/src/components/Common/ScrollButton/ScrollButton.tsx
@@ -6,7 +6,11 @@ import SvgIcon from '../Svg/SvgIcon';
 
 import { useScroll } from '@/hooks/common';
 
-const ScrollButton = () => {
+interface ScrollButtonProps {
+  isRecipePage?: boolean;
+}
+
+const ScrollButton = ({ isRecipePage = false }: ScrollButtonProps) => {
   const { scrollToTop } = useScroll();
   const [scrollTop, setScrollTop] = useState(false);
 
@@ -23,7 +27,14 @@ const ScrollButton = () => {
   }, [scrollTop]);
 
   return (
-    <ScrollButtonWrapper customWidth="45px" customHeight="45px" variant="filled" color="gray5" onClick={handleScroll}>
+    <ScrollButtonWrapper
+      isRecipePage={isRecipePage}
+      customWidth="45px"
+      customHeight="45px"
+      variant="filled"
+      color="gray5"
+      onClick={handleScroll}
+    >
       <SvgIcon variant="triangle" color="white" width={16} height={14} />
     </ScrollButtonWrapper>
   );
@@ -31,9 +42,9 @@ const ScrollButton = () => {
 
 export default ScrollButton;
 
-const ScrollButtonWrapper = styled(Button)`
+const ScrollButtonWrapper = styled(Button)<ScrollButtonProps>`
   position: fixed;
-  bottom: 90px;
+  bottom: ${({ isRecipePage }) => (isRecipePage ? '150px' : '90px')};
   right: 20px;
   border-radius: 50%;
 

--- a/frontend/src/pages/RecipePage.tsx
+++ b/frontend/src/pages/RecipePage.tsx
@@ -63,7 +63,7 @@ const RecipePage = () => {
           onClick={handleOpenRegisterRecipeSheet}
         />
       </RecipeRegisterButtonWrapper>
-      <ScrollButton />
+      <ScrollButton isRecipePage />
       <BottomSheet ref={ref} isClosing={isClosing} maxWidth="600px" close={handleCloseBottomSheet}>
         {activeSheet === 'sortOption' ? (
           <SortOptionList
@@ -102,11 +102,12 @@ const SortButtonWrapper = styled.div`
 
 const RecipeRegisterButtonWrapper = styled.div`
   position: fixed;
-  bottom: 80px;
+  bottom: 60px;
   left: 20px;
-  width: calc(100% - 100px);
-  max-width: 500px;
-  height: 60px;
+  width: calc(100% - 40px);
+  max-width: 560px;
+  height: 80px;
+  background: ${({ theme }) => theme.backgroundColors.default};
 
   @media screen and (min-width: 600px) {
     left: calc(50% - 280px);


### PR DESCRIPTION
## Issue

- close #516 

## ✨ 구현한 기능

꿀조합 버튼을 100%로 만들고, 스크롤 버튼을 꿀조합 페이지일 때만 위로 올렸습니다.
그리고 꿀조합 버튼의 뒷 배경을 주어 보이지 않도록 하였습니다.

<img width="710" alt="스크린샷 2023-08-17 오후 5 50 34" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/80464961/a12fba94-c925-4b31-99c9-e7317b706f73">


## 📢 논의하고 싶은 내용

- 논의하고 싶은 내용을 작성합니다.

## 🎸 기타

- 특이 사항이 있으면 작성합니다.

## ⏰ 일정

- 추정 시간 : 1시간
- 걸린 시간 : 30분
