### PR TITLE
[FE] refactor: Input의 IconWrapper을 button에서 div로 변경

### DIFF
--- a/frontend/src/components/Common/Input/Input.tsx
+++ b/frontend/src/components/Common/Input/Input.tsx
@@ -31,7 +31,7 @@ const Input = forwardRef(
       <>
         <InputContainer customWidth={customWidth}>
           <CustomInput ref={ref} isError={isError} {...props} />
-          {rightIcon && <IconWrapper variant="transparent">{rightIcon}</IconWrapper>}
+          {rightIcon && <IconWrapper>{rightIcon}</IconWrapper>}
         </InputContainer>
         {isError && <ErrorMessage>{errorMessage}</ErrorMessage>}
       </>
@@ -76,7 +76,9 @@ const CustomInput = styled.input<CustomInputStyleProps>`
   }
 `;
 
-const IconWrapper = styled(Button)`
+const IconWrapper = styled.div`
+  display: flex;
+  align-items: center;
   position: absolute;
   top: 0;
   right: 0;


### PR DESCRIPTION
## Issue

- close #533

## ✨ 구현한 기능

- Input의 IconWrapper을 button에서 div로 변경

## 📢 논의하고 싶은 내용

x

## 🎸 기타

x

## ⏰ 일정

- 추정 시간 :
- 걸린 시간 :
