### PR TITLE
[BE] fix: 검색 페이징 시 데이터 중복 버그 해결

### DIFF
--- a/backend/src/main/java/com/funeat/product/persistence/ProductRepository.java
+++ b/backend/src/main/java/com/funeat/product/persistence/ProductRepository.java
@@ -39,8 +39,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     @Query("SELECT p FROM Product p "
             + "WHERE p.name LIKE CONCAT('%', :name, '%') "
-            + "ORDER BY CASE "
-            + "WHEN p.name LIKE CONCAT(:name, '%') THEN 1 "
+            + "ORDER BY p.id DESC, "
+            + "CASE WHEN p.name LIKE CONCAT(:name, '%') THEN 1 "
             + "ELSE 2 END")
     Page<Product> findAllByNameContaining(@Param("name") final String name, final Pageable pageable);
 
@@ -48,8 +48,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             + "LEFT JOIN Review r ON r.product.id = p.id "
             + "WHERE p.name LIKE CONCAT('%', :name, '%') "
             + "GROUP BY p.id "
-            + "ORDER BY CASE "
-            + "WHEN p.name LIKE CONCAT(:name, '%') THEN 1 "
+            + "ORDER BY p.id DESC, "
+            + "CASE WHEN p.name LIKE CONCAT(:name, '%') THEN 1 "
             + "ELSE 2 END")
     Page<ProductReviewCountDto> findAllWithReviewCountByNameContaining(@Param("name") final String name, final Pageable pageable);
 }

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
@@ -617,6 +617,34 @@ class ProductAcceptanceTest extends AcceptanceTest {
             페이지를_검증한다(response, pageDto);
             상품_자동_완성_검색_결과를_검증한다(response, expectedProducts);
         }
+
+        @Test
+        void 페이지가_넘어가도_중복없이_결과를_조회한다() {
+            // given
+            final var category = 카테고리_간편식사_생성();
+            단일_카테고리_저장(category);
+
+            final var product1 = 상품_망고빙수_가격5000원_평점4점_생성(category);
+            final var product2 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product3 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product4 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product5 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product6 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product7 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product8 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product9 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product10 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product11 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            복수_상품_저장(product1, product2, product3, product4, product5, product6, product7, product8, product9,
+                    product10, product11);
+
+            // when
+            final var response1 = 상품_자동_완성_검색_요청("망고", 0);
+            final var response2 = 상품_자동_완성_검색_요청("망고", 1);
+
+            // then
+            결과값이_이전_요청_결과값에_중복되는지_검증(response1, response2);
+        }
     }
 
     @Nested
@@ -684,6 +712,45 @@ class ProductAcceptanceTest extends AcceptanceTest {
             페이지를_검증한다(response, pageDto);
             상품_검색_결과를_검증한다(response, expected);
         }
+
+        @Test
+        void 페이지가_넘어가도_중복없이_상품_결과를_조회한다() {
+            // given
+            final var category = 카테고리_간편식사_생성();
+            단일_카테고리_저장(category);
+
+            final var product1 = 상품_망고빙수_가격5000원_평점4점_생성(category);
+            final var product2 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product3 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product4 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product5 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product6 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product7 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product8 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product9 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product10 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product11 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            복수_상품_저장(product1, product2, product3, product4, product5, product6, product7, product8, product9,
+                    product10, product11);
+
+            // when
+            final var response1 = 상품_검색_결과_조회_요청("망고", 0);
+            final var response2 = 상품_검색_결과_조회_요청("망고", 1);
+
+            // then
+            결과값이_이전_요청_결과값에_중복되는지_검증(response1, response2);
+        }
+    }
+
+    private void 결과값이_이전_요청_결과값에_중복되는지_검증(final ExtractableResponse<Response> response1,
+                           final ExtractableResponse<Response> response2) {
+        final var lastResponses = response1.jsonPath()
+                .getList("products", SearchProductResultDto.class);
+        final var currentResponse = response2.jsonPath()
+                .getList("products", SearchProductResultDto.class).get(0);
+
+        assertThat(lastResponses).usingRecursiveFieldByFieldElementComparator()
+                .doesNotContain(currentResponse);
     }
 
     @Nested


### PR DESCRIPTION
## Issue

- close #536 

## ✨ 구현한 기능

- 상품 검색 쿼리에 `ORDER BY p.id DESC` 절 추가
  - 페이징 요청을 두 번 보냈을 때, 중복된 값이 있는지 검증하는 테스트 추가

## 📢 논의하고 싶은 내용

- X

## 🎸 기타

- X

## ⏰ 일정

- 추정 시간 : 30min
- 걸린 시간 : 30min
