### PR TITLE
[BE] feat: 세븐일레븐 테스트 데이터 추가

### DIFF
--- a/backend/src/test/java/com/funeat/fixture/CategoryFixture.java
+++ b/backend/src/test/java/com/funeat/fixture/CategoryFixture.java
@@ -42,5 +42,7 @@ public class CategoryFixture {
         return new Category("EMART24", CategoryType.STORE);
     }
 
-
+    public static Category 카테고리_세븐일레븐_생성() {
+        return new Category("세븐일레븐", CategoryType.STORE);
+    }
 }

--- a/backend/src/test/java/com/funeat/product/persistence/CategoryRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/product/persistence/CategoryRepositoryTest.java
@@ -5,6 +5,7 @@ import static com.funeat.fixture.CategoryFixture.카테고리_EMART24_생성;
 import static com.funeat.fixture.CategoryFixture.카테고리_GS25_생성;
 import static com.funeat.fixture.CategoryFixture.카테고리_간편식사_생성;
 import static com.funeat.fixture.CategoryFixture.카테고리_과자류_생성;
+import static com.funeat.fixture.CategoryFixture.카테고리_세븐일레븐_생성;
 import static com.funeat.fixture.CategoryFixture.카테고리_식품_생성;
 import static com.funeat.fixture.CategoryFixture.카테고리_아이스크림_생성;
 import static com.funeat.fixture.CategoryFixture.카테고리_음료_생성;
@@ -35,7 +36,8 @@ public class CategoryRepositoryTest extends RepositoryTest {
             final var CU = 카테고리_CU_생성();
             final var GS25 = 카테고리_GS25_생성();
             final var EMART24 = 카테고리_EMART24_생성();
-            복수_카테고리_저장(간편식사, 즉석조리, 과자류, 아이스크림, 식품, 음료, CU, GS25, EMART24);
+            final var 세븐일레븐 = 카테고리_세븐일레븐_생성();
+            복수_카테고리_저장(간편식사, 즉석조리, 과자류, 아이스크림, 식품, 음료, CU, GS25, EMART24, 세븐일레븐);
 
             final var expected = List.of(간편식사, 즉석조리, 과자류, 아이스크림, 식품, 음료);
 
@@ -59,9 +61,10 @@ public class CategoryRepositoryTest extends RepositoryTest {
             final var CU = 카테고리_CU_생성();
             final var GS25 = 카테고리_GS25_생성();
             final var EMART24 = 카테고리_EMART24_생성();
-            복수_카테고리_저장(간편식사, 즉석조리, 과자류, 아이스크림, 식품, 음료, CU, GS25, EMART24);
+            final var 세븐일레븐 = 카테고리_세븐일레븐_생성();
+            복수_카테고리_저장(간편식사, 즉석조리, 과자류, 아이스크림, 식품, 음료, CU, GS25, EMART24, 세븐일레븐);
 
-            final var expected = List.of(CU, GS25, EMART24);
+            final var expected = List.of(CU, GS25, EMART24, 세븐일레븐);
 
             // when
             final var actual = categoryRepository.findAllByType(CategoryType.STORE);


### PR DESCRIPTION
## Issue

- close #535

## ✨ 구현한 기능

- 세븐일레븐 테스트 데이터를 추가합니다.
- 노션에 내일 아침에 쿼리 추가할거 남겼어요

## 📢 논의하고 싶은 내용

- CU, GS25 신상품 추가해야함
  - [문제점]: NEW 태그가 붙어있는데, 이미 예전에 추가한 상품들도 존재해서 일일이 존재하는지 검사하면서 쿼리 추가 필요
  - 신상품이 몇 개 없을줄 알고 다 추가하려고 했는데, 너무 많아서 필요한 것만 노션에 적음

## 🎸 기타

- x

## ⏰ 일정

- 추정 시간 : 3? 4?
- 걸린 시간 : 3
