### PR TITLE
[BE] 검색 정렬 우선 순위 반대로 적용중 버그 해결

### DIFF
--- a/backend/src/main/java/com/funeat/product/persistence/ProductRepository.java
+++ b/backend/src/main/java/com/funeat/product/persistence/ProductRepository.java
@@ -39,17 +39,16 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     @Query("SELECT p FROM Product p "
             + "WHERE p.name LIKE CONCAT('%', :name, '%') "
-            + "ORDER BY p.id DESC, "
-            + "CASE WHEN p.name LIKE CONCAT(:name, '%') THEN 1 "
-            + "ELSE 2 END")
+            + "ORDER BY "
+            + "(CASE WHEN p.name LIKE CONCAT(:name, '%') THEN 1 ELSE 2 END), "
+            + "p.id DESC")
     Page<Product> findAllByNameContaining(@Param("name") final String name, final Pageable pageable);
 
     @Query("SELECT new com.funeat.product.dto.ProductReviewCountDto(p, COUNT(r.id)) FROM Product p "
             + "LEFT JOIN Review r ON r.product.id = p.id "
             + "WHERE p.name LIKE CONCAT('%', :name, '%') "
             + "GROUP BY p.id "
-            + "ORDER BY p.id DESC, "
-            + "CASE WHEN p.name LIKE CONCAT(:name, '%') THEN 1 "
-            + "ELSE 2 END")
+            + "ORDER BY "
+            + "(CASE WHEN p.name LIKE CONCAT(:name, '%') THEN 1 ELSE 2 END), p.id DESC")
     Page<ProductReviewCountDto> findAllWithReviewCountByNameContaining(@Param("name") final String name, final Pageable pageable);
 }

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
@@ -645,6 +645,39 @@ class ProductAcceptanceTest extends AcceptanceTest {
             // then
             결과값이_이전_요청_결과값에_중복되는지_검증(response1, response2);
         }
+
+        @Test
+        void 페이지가_넘어가도_시작되는_단어_우선_조회한다() {
+            // given
+            final var category = 카테고리_간편식사_생성();
+            단일_카테고리_저장(category);
+
+            final var product1 = 상품_망고빙수_가격5000원_평점4점_생성(category);
+            final var product2 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product3 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product4 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product5 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product6 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product7 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product8 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product9 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product10 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product11 = 상품_망고빙수_가격5000원_평점4점_생성(category);
+            복수_상품_저장(product1, product2, product3, product4, product5, product6, product7, product8, product9,
+                    product10, product11);
+
+            final var pageDto = new PageDto(11L, 2L, true, false, 0L, PAGE_SIZE);
+            final var expectedProducts = List.of(product11, product1, product10, product9, product8, product7, product6,
+                    product5, product4, product3);
+
+            // when
+            final var response = 상품_자동_완성_검색_요청("망고", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            페이지를_검증한다(response, pageDto);
+            상품_자동_완성_검색_결과를_검증한다(response, expectedProducts);
+        }
     }
 
     @Nested
@@ -740,10 +773,53 @@ class ProductAcceptanceTest extends AcceptanceTest {
             // then
             결과값이_이전_요청_결과값에_중복되는지_검증(response1, response2);
         }
+
+        @Test
+        void 페이지가_넘어가도_시작되는_단어_우선_조회한다() {
+            // given
+            final var category = 카테고리_간편식사_생성();
+            단일_카테고리_저장(category);
+
+            final var product1 = 상품_망고빙수_가격5000원_평점4점_생성(category);
+            final var product2 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product3 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product4 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product5 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product6 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product7 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product8 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product9 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product10 = 상품_애플망고_가격3000원_평점5점_생성(category);
+            final var product11 = 상품_망고빙수_가격5000원_평점4점_생성(category);
+            복수_상품_저장(product1, product2, product3, product4, product5, product6, product7, product8, product9,
+                    product10, product11);
+
+            final var pageDto = new PageDto(11L, 2L, true, false, 0L, PAGE_SIZE);
+            final var expectedDto1 = SearchProductResultDto.toDto(product11, 0L);
+            final var expectedDto2 = SearchProductResultDto.toDto(product1, 0L);
+            final var expectedDto3 = SearchProductResultDto.toDto(product10, 0L);
+            final var expectedDto4 = SearchProductResultDto.toDto(product9, 0L);
+            final var expectedDto5 = SearchProductResultDto.toDto(product8, 0L);
+            final var expectedDto6 = SearchProductResultDto.toDto(product7, 0L);
+            final var expectedDto7 = SearchProductResultDto.toDto(product6, 0L);
+            final var expectedDto8 = SearchProductResultDto.toDto(product5, 0L);
+            final var expectedDto9 = SearchProductResultDto.toDto(product4, 0L);
+            final var expectedDto10 = SearchProductResultDto.toDto(product3, 0L);
+            final var expected = List.of(expectedDto1, expectedDto2, expectedDto3, expectedDto4, expectedDto5,
+                    expectedDto6, expectedDto7, expectedDto8, expectedDto9, expectedDto10);
+
+            // when
+            final var response = 상품_검색_결과_조회_요청("망고", 0);
+
+            // then
+            STATUS_CODE를_검증한다(response, 정상_처리);
+            페이지를_검증한다(response, pageDto);
+            상품_검색_결과를_검증한다(response, expected);
+        }
     }
 
     private void 결과값이_이전_요청_결과값에_중복되는지_검증(final ExtractableResponse<Response> response1,
-                           final ExtractableResponse<Response> response2) {
+                                          final ExtractableResponse<Response> response2) {
         final var lastResponses = response1.jsonPath()
                 .getList("products", SearchProductResultDto.class);
         final var currentResponse = response2.jsonPath()


### PR DESCRIPTION
## Issue

- close #549 

## ✨ 구현한 기능

- `검색어로 시작되는 단어 우선`을 먼저 하고, `id 내림차순 정렬` 적용
  - **ORDER BY** 절에서 `p.id DESC`를 뒤로 이동
  - https://github.com/woowacourse-teams/2023-fun-eat/issues/536 
  해당 이슈는 `CASE WHEN ~` 부분만 정렬 조건이었기 때문에 페이징이 넘어갈 때마다 전체 정렬을 다시 하는데, 저 조건이 동일한 경우 이후에는 랜덤 정렬됨
  - 따라서 `CASE WHEN ~`으로도 정렬하고, 이후 정렬 조건으로 id도 줘야 함.

## 📢 논의하고 싶은 내용

- X

## 🎸 기타

- X

## ⏰ 일정

- 추정 시간 : 20min
- 걸린 시간 : 20min

