### PR TITLE
[FE] refactor: scroll button bottom 이동

### DIFF
--- a/frontend/src/components/Common/ScrollButton/ScrollButton.tsx
+++ b/frontend/src/components/Common/ScrollButton/ScrollButton.tsx
@@ -44,7 +44,7 @@ export default ScrollButton;
 
 const ScrollButtonWrapper = styled(Button)<ScrollButtonProps>`
   position: fixed;
-  bottom: ${({ isRecipePage }) => (isRecipePage ? '150px' : '90px')};
+  bottom: ${({ isRecipePage }) => (isRecipePage ? '210px' : '90px')};
   right: 20px;
   border-radius: 50%;
 


### PR DESCRIPTION
## Issue

- close #545 

## ✨ 구현한 기능

scroll button bottom 이동하였습니다.
채널톡 버튼은 옮기기 힘들어서 둘의 순서를 바꾸었습니다.

<img width="350" alt="스크린샷 2023-08-18 오전 11 03 06" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/80464961/c787bc8d-7dce-490b-8914-8ae5fbe2bb34">


## 📢 논의하고 싶은 내용

x

## 🎸 기타

x

## ⏰ 일정

- 추정 시간 : 1시간
- 걸린 시간 : 1분
