### PR TITLE
[BE] feat: 로그인 정보가 존재하지 않을 때, 새로운 세션을 생성하지 않도록 하는 설정 추가

### DIFF
--- a/backend/src/main/java/com/funeat/auth/application/AuthService.java
+++ b/backend/src/main/java/com/funeat/auth/application/AuthService.java
@@ -4,12 +4,15 @@ import com.funeat.auth.dto.SignUserDto;
 import com.funeat.auth.dto.UserInfoDto;
 import com.funeat.auth.util.PlatformUserProvider;
 import com.funeat.member.application.MemberService;
+import javax.servlet.http.Cookie;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
 public class AuthService {
+
+    private static final String COOKIE_NAME = "FUNEAT";
 
     private final MemberService memberService;
     private final PlatformUserProvider platformUserProvider;
@@ -31,5 +34,13 @@ public class AuthService {
     public void logoutWithKakao(final Long memberId) {
         final String platformId = memberService.findPlatformId(memberId);
         platformUserProvider.logout(platformId);
+    }
+
+    public Cookie expireCookie() {
+        final Cookie cookie = new Cookie(COOKIE_NAME, null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        return cookie;
     }
 }

--- a/backend/src/main/java/com/funeat/auth/presentation/AuthApiController.java
+++ b/backend/src/main/java/com/funeat/auth/presentation/AuthApiController.java
@@ -5,7 +5,9 @@ import com.funeat.auth.dto.LoginInfo;
 import com.funeat.auth.dto.SignUserDto;
 import com.funeat.auth.util.AuthenticationPrincipal;
 import java.net.URI;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class AuthApiController implements AuthController {
 
+    private static final String SESSION_ATTRIBUTE_NAME = "member";
     private static final String HOME = "/";
     private static final String MY_PAGE = "/members";
 
@@ -37,7 +40,7 @@ public class AuthApiController implements AuthController {
                                                    final HttpServletRequest request) {
         final SignUserDto signUserDto = authService.loginWithKakao(code);
         final Long memberId = signUserDto.getMember().getId();
-        request.getSession().setAttribute("member", memberId);
+        request.getSession().setAttribute(SESSION_ATTRIBUTE_NAME, memberId);
 
         if (signUserDto.isSignUp()) {
             return ResponseEntity.ok()
@@ -51,9 +54,13 @@ public class AuthApiController implements AuthController {
 
     @PostMapping("/api/logout")
     public ResponseEntity<Void> logout(@AuthenticationPrincipal final LoginInfo loginInfo,
-                                       final HttpServletRequest request) {
-        request.getSession().removeAttribute("member");
+                                       final HttpServletRequest request, final HttpServletResponse response) {
         authService.logoutWithKakao(loginInfo.getId());
+
+        request.getSession().removeAttribute(SESSION_ATTRIBUTE_NAME);
+
+        final Cookie cookie = authService.expireCookie();
+        response.addCookie(cookie);
 
         return ResponseEntity.status(HttpStatus.FOUND)
                 .location(URI.create(HOME))

--- a/backend/src/main/java/com/funeat/auth/presentation/AuthController.java
+++ b/backend/src/main/java/com/funeat/auth/presentation/AuthController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,5 +37,6 @@ public interface AuthController {
             description = "로그아웃 성공."
     )
     @PostMapping
-    ResponseEntity<Void> logout(@AuthenticationPrincipal LoginInfo loginInfo, HttpServletRequest request);
+    ResponseEntity<Void> logout(@AuthenticationPrincipal LoginInfo loginInfo, HttpServletRequest request,
+                                HttpServletResponse response);
 }

--- a/backend/src/main/java/com/funeat/auth/util/AuthArgumentResolver.java
+++ b/backend/src/main/java/com/funeat/auth/util/AuthArgumentResolver.java
@@ -20,10 +20,10 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+    public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+                                  final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
         final HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
-        final HttpSession session = Objects.requireNonNull(request).getSession();
+        final HttpSession session = Objects.requireNonNull(request).getSession(false);
         final String id = String.valueOf(session.getAttribute("member"));
 
         return new LoginInfo(Long.valueOf(id));

--- a/backend/src/main/java/com/funeat/auth/util/AuthArgumentResolver.java
+++ b/backend/src/main/java/com/funeat/auth/util/AuthArgumentResolver.java
@@ -15,7 +15,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
-    public boolean supportsParameter(MethodParameter parameter) {
+    public boolean supportsParameter(final MethodParameter parameter) {
         return parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
     }
 

--- a/backend/src/main/java/com/funeat/auth/util/AuthHandlerInterceptor.java
+++ b/backend/src/main/java/com/funeat/auth/util/AuthHandlerInterceptor.java
@@ -12,11 +12,14 @@ import org.springframework.web.servlet.HandlerInterceptor;
 public class AuthHandlerInterceptor implements HandlerInterceptor {
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        final HttpSession session = request.getSession();
-        if (session.getAttribute("member") == null) {
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response,
+                             final Object handler) {
+        final HttpSession session = request.getSession(false);
+
+        if (session == null) {
             throw new NotLoggedInException(AuthErrorCode.LOGIN_MEMBER_NOT_FOUND);
         }
+
         return true;
     }
 }

--- a/backend/src/main/java/com/funeat/auth/util/AuthHandlerInterceptor.java
+++ b/backend/src/main/java/com/funeat/auth/util/AuthHandlerInterceptor.java
@@ -2,6 +2,7 @@ package com.funeat.auth.util;
 
 import com.funeat.auth.exception.AuthErrorCode;
 import com.funeat.auth.exception.AuthException.NotLoggedInException;
+import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -16,7 +17,7 @@ public class AuthHandlerInterceptor implements HandlerInterceptor {
                              final Object handler) {
         final HttpSession session = request.getSession(false);
 
-        if (session == null) {
+        if (Objects.isNull(session)) {
             throw new NotLoggedInException(AuthErrorCode.LOGIN_MEMBER_NOT_FOUND);
         }
 

--- a/backend/src/main/java/com/funeat/recipe/util/RecipeDetailHandlerInterceptor.java
+++ b/backend/src/main/java/com/funeat/recipe/util/RecipeDetailHandlerInterceptor.java
@@ -12,11 +12,14 @@ import org.springframework.web.servlet.HandlerInterceptor;
 public class RecipeDetailHandlerInterceptor implements HandlerInterceptor {
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        final HttpSession session = request.getSession();
-        if (session.getAttribute("member") == null) {
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response,
+                             final Object handler) {
+        final HttpSession session = request.getSession(false);
+
+        if (session == null) {
             throw new NotLoggedInException(AuthErrorCode.LOGIN_MEMBER_NOT_FOUND);
         }
+
         return true;
     }
 }

--- a/backend/src/main/java/com/funeat/recipe/util/RecipeDetailHandlerInterceptor.java
+++ b/backend/src/main/java/com/funeat/recipe/util/RecipeDetailHandlerInterceptor.java
@@ -2,6 +2,7 @@ package com.funeat.recipe.util;
 
 import com.funeat.auth.exception.AuthErrorCode;
 import com.funeat.auth.exception.AuthException.NotLoggedInException;
+import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -16,7 +17,7 @@ public class RecipeDetailHandlerInterceptor implements HandlerInterceptor {
                              final Object handler) {
         final HttpSession session = request.getSession(false);
 
-        if (session == null) {
+        if (Objects.isNull(session)) {
             throw new NotLoggedInException(AuthErrorCode.LOGIN_MEMBER_NOT_FOUND);
         }
 

--- a/backend/src/main/java/com/funeat/recipe/util/RecipeHandlerInterceptor.java
+++ b/backend/src/main/java/com/funeat/recipe/util/RecipeHandlerInterceptor.java
@@ -2,6 +2,7 @@ package com.funeat.recipe.util;
 
 import com.funeat.auth.exception.AuthErrorCode;
 import com.funeat.auth.exception.AuthException.NotLoggedInException;
+import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -20,7 +21,7 @@ public class RecipeHandlerInterceptor implements HandlerInterceptor {
 
         final HttpSession session = request.getSession(false);
 
-        if (session == null) {
+        if (Objects.isNull(session)) {
             throw new NotLoggedInException(AuthErrorCode.LOGIN_MEMBER_NOT_FOUND);
         }
 

--- a/backend/src/main/java/com/funeat/recipe/util/RecipeHandlerInterceptor.java
+++ b/backend/src/main/java/com/funeat/recipe/util/RecipeHandlerInterceptor.java
@@ -12,14 +12,18 @@ import org.springframework.web.servlet.HandlerInterceptor;
 public class RecipeHandlerInterceptor implements HandlerInterceptor {
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response,
+                             final Object handler) {
         if ("GET".equals(request.getMethod())) {
             return true;
         }
-        final HttpSession session = request.getSession();
-        if (session.getAttribute("member") == null) {
+
+        final HttpSession session = request.getSession(false);
+
+        if (session == null) {
             throw new NotLoggedInException(AuthErrorCode.LOGIN_MEMBER_NOT_FOUND);
         }
+
         return true;
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -14,3 +14,9 @@ springdoc:
 logging:
   file:
     path: { LOG_DIR }
+
+server:
+  servlet:
+    session:
+      cookie:
+        name: FUNEAT

--- a/backend/src/test/java/com/funeat/acceptance/auth/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/auth/AuthAcceptanceTest.java
@@ -19,6 +19,9 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -100,10 +103,12 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @Nested
     class logout_실패_테스트 {
 
-        @Test
-        void 쿠키가_존재하지_않을_때_로그아웃을_하면_예외가_발생해야하는데_통과하고_있다() {
+        @NullSource
+        @ParameterizedTest
+        @ValueSource(strings = "expired")
+        void 쿠키가_존재하지_않을_때_로그아웃을_하면_예외가_발생한다(final String cookie) {
             // given & when
-            final var response = 로그아웃_요청(null);
+            final var response = 로그아웃_요청(cookie);
 
             // then
             STATUS_CODE를_검증한다(response, 인증되지_않음);

--- a/backend/src/test/java/com/funeat/acceptance/auth/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/auth/AuthAcceptanceTest.java
@@ -20,8 +20,7 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullSource;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -103,9 +102,8 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @Nested
     class logout_실패_테스트 {
 
-        @NullSource
         @ParameterizedTest
-        @ValueSource(strings = "expired")
+        @NullAndEmptySource
         void 쿠키가_존재하지_않을_때_로그아웃을_하면_예외가_발생한다(final String cookie) {
             // given & when
             final var response = 로그아웃_요청(cookie);

--- a/backend/src/test/java/com/funeat/acceptance/auth/LoginSteps.java
+++ b/backend/src/test/java/com/funeat/acceptance/auth/LoginSteps.java
@@ -20,7 +20,7 @@ public class LoginSteps {
 
     public static ExtractableResponse<Response> 로그인_시도_요청(final String code, final String loginCookie) {
         return given()
-                .cookie("JSESSIONID", loginCookie)
+                .cookie("FUNEAT", loginCookie)
                 .param("code", code)
                 .when()
                 .get("/api/login/oauth2/code/kakao")
@@ -30,7 +30,7 @@ public class LoginSteps {
 
     public static ExtractableResponse<Response> 로그아웃_요청(final String loginCookie) {
         return given()
-                .cookie("JSESSIONID", loginCookie)
+                .cookie("FUNEAT", loginCookie)
                 .when()
                 .post("/api/logout")
                 .then()
@@ -45,6 +45,6 @@ public class LoginSteps {
                 .then()
                 .extract()
                 .response()
-                .getCookie("JSESSIONID");
+                .getCookie("FUNEAT");
     }
 }

--- a/backend/src/test/java/com/funeat/acceptance/member/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/member/MemberAcceptanceTest.java
@@ -44,8 +44,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.NullSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class MemberAcceptanceTest extends AcceptanceTest {
@@ -73,9 +71,8 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Nested
     class getMemberProfile_실패_테스트 {
 
-        @NullSource
         @ParameterizedTest
-        @ValueSource(strings = "expired")
+        @NullAndEmptySource
         void 로그인_하지않은_사용자가_사용자_정보를_확인시_예외가_발생한다(final String cookie) {
             // given & when
             final var response = 사용자_정보_조회_요청(cookie);
@@ -143,9 +140,8 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Nested
     class putMemberProfile_실패_테스트 {
 
-        @NullSource
         @ParameterizedTest
-        @ValueSource(strings = "expired")
+        @NullAndEmptySource
         void 로그인_하지않은_사용자가_사용자_정보_수정시_예외가_발생한다(final String cookie) {
             // given
             final var image = 사진_명세_요청();
@@ -260,9 +256,8 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Nested
     class getMemberReviews_실패_테스트 {
 
-        @NullSource
         @ParameterizedTest
-        @ValueSource(strings = "expired")
+        @NullAndEmptySource
         void 로그인하지_않은_사용자가_작성한_리뷰를_조회할때_예외가_발생한다(final String cookie) {
             // given & when
             final var response = 사용자_리뷰_조회_요청(cookie, "createdAt,desc", 0);
@@ -438,9 +433,8 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Nested
     class getMemberRecipes_실패_테스트 {
 
-        @NullSource
         @ParameterizedTest
-        @ValueSource(strings = "expired")
+        @NullAndEmptySource
         void 로그인하지_않은_사용자가_작성한_꿀조합을_조회할때_예외가_발생한다(final String cookie) {
             // given & when
             final var response = 사용자_꿀조합_조회_요청(cookie, "createdAt,desc", 0);

--- a/backend/src/test/java/com/funeat/acceptance/member/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/member/MemberAcceptanceTest.java
@@ -44,6 +44,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class MemberAcceptanceTest extends AcceptanceTest {
@@ -71,14 +73,16 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Nested
     class getMemberProfile_실패_테스트 {
 
-        @Test
-        void 로그인_하지않은_사용자가_사용자_정보를_확인시_예외가_발생한다() {
+        @NullSource
+        @ParameterizedTest
+        @ValueSource(strings = "expired")
+        void 로그인_하지않은_사용자가_사용자_정보를_확인시_예외가_발생한다(final String cookie) {
             // given & when
-            final var response = 사용자_정보_조회_요청(null);
+            final var response = 사용자_정보_조회_요청(cookie);
 
             // then
             STATUS_CODE를_검증한다(response, 인증되지_않음);
-            사용자_승인되지_않음을_검증하다(response);
+            비로그인_사용자는_승인되지_않음을_검증하다(response);
         }
     }
 
@@ -139,18 +143,20 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Nested
     class putMemberProfile_실패_테스트 {
 
-        @Test
-        void 로그인_하지않은_사용자가_사용자_정보_수정시_예외가_발생한다() {
+        @NullSource
+        @ParameterizedTest
+        @ValueSource(strings = "expired")
+        void 로그인_하지않은_사용자가_사용자_정보_수정시_예외가_발생한다(final String cookie) {
             // given
             final var image = 사진_명세_요청();
             final var request = new MemberRequest("after");
 
             // when
-            final var response = 사용자_정보_수정_요청(null, image, request);
+            final var response = 사용자_정보_수정_요청(cookie, image, request);
 
             // then
             STATUS_CODE를_검증한다(response, 인증되지_않음);
-            사용자_승인되지_않음을_검증하다(response);
+            비로그인_사용자는_승인되지_않음을_검증하다(response);
         }
 
         @ParameterizedTest
@@ -254,15 +260,16 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Nested
     class getMemberReviews_실패_테스트 {
 
-        @Test
-        void 로그인하지_않은_사용자가_작성한_리뷰를_조회할때_예외가_발생한다() {
+        @NullSource
+        @ParameterizedTest
+        @ValueSource(strings = "expired")
+        void 로그인하지_않은_사용자가_작성한_리뷰를_조회할때_예외가_발생한다(final String cookie) {
             // given & when
-            final var response = 사용자_리뷰_조회_요청(null, "createdAt,desc", 0);
+            final var response = 사용자_리뷰_조회_요청(cookie, "createdAt,desc", 0);
 
             // then
             STATUS_CODE를_검증한다(response, 인증되지_않음);
-            RESPONSE_CODE와_MESSAGE를_검증한다(response, LOGIN_MEMBER_NOT_FOUND.getCode(),
-                    LOGIN_MEMBER_NOT_FOUND.getMessage());
+            비로그인_사용자는_승인되지_않음을_검증하다(response);
         }
     }
 
@@ -431,15 +438,16 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Nested
     class getMemberRecipes_실패_테스트 {
 
-        @Test
-        void 로그인하지_않은_사용자가_작성한_꿀조합을_조회할때_예외가_발생한다() {
+        @NullSource
+        @ParameterizedTest
+        @ValueSource(strings = "expired")
+        void 로그인하지_않은_사용자가_작성한_꿀조합을_조회할때_예외가_발생한다(final String cookie) {
             // given & when
-            final var response = 사용자_꿀조합_조회_요청(null, "createdAt,desc", 0);
+            final var response = 사용자_꿀조합_조회_요청(cookie, "createdAt,desc", 0);
 
             // then
             STATUS_CODE를_검증한다(response, 인증되지_않음);
-            RESPONSE_CODE와_MESSAGE를_검증한다(response, LOGIN_MEMBER_NOT_FOUND.getCode(),
-                    LOGIN_MEMBER_NOT_FOUND.getMessage());
+            비로그인_사용자는_승인되지_않음을_검증하다(response);
         }
     }
 
@@ -503,7 +511,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         });
     }
 
-    private void 사용자_승인되지_않음을_검증하다(final ExtractableResponse<Response> response) {
+    private void 비로그인_사용자는_승인되지_않음을_검증하다(final ExtractableResponse<Response> response) {
         final var expectedCode = LOGIN_MEMBER_NOT_FOUND.getCode();
         final var expectedMessage = LOGIN_MEMBER_NOT_FOUND.getMessage();
 

--- a/backend/src/test/java/com/funeat/acceptance/member/MemberSteps.java
+++ b/backend/src/test/java/com/funeat/acceptance/member/MemberSteps.java
@@ -12,7 +12,7 @@ public class MemberSteps {
 
     public static ExtractableResponse<Response> 사용자_정보_조회_요청(final String loginCookie) {
         return given()
-                .cookie("JSESSIONID", loginCookie)
+                .cookie("FUNEAT", loginCookie)
                 .when()
                 .get("/api/members")
                 .then()
@@ -23,7 +23,7 @@ public class MemberSteps {
                                                              final MultiPartSpecification image,
                                                              final MemberRequest request) {
         final var requestSpec = given()
-                .cookie("JSESSIONID", loginCookie);
+                .cookie("FUNEAT", loginCookie);
 
         if (image != null) {
             requestSpec.multiPart(image);
@@ -42,7 +42,7 @@ public class MemberSteps {
                                                              final Integer page) {
         return given()
                 .when()
-                .cookie("JSESSIONID", loginCookie)
+                .cookie("FUNEAT", loginCookie)
                 .queryParam("sort", sort)
                 .queryParam("page", page)
                 .get("/api/members/reviews")
@@ -54,7 +54,7 @@ public class MemberSteps {
                                                               final Integer page) {
         return given()
                 .when()
-                .cookie("JSESSIONID", loginCookie)
+                .cookie("FUNEAT", loginCookie)
                 .queryParam("sort", sort)
                 .queryParam("page", page)
                 .get("/api/members/recipes")

--- a/backend/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
@@ -59,6 +59,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class RecipeAcceptanceTest extends AcceptanceTest {
@@ -121,8 +123,10 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
     @Nested
     class writeRecipe_실패_테스트 {
 
-        @Test
-        void 로그인_하지않은_사용자가_레시피_작성시_예외가_발생한다() {
+        @NullSource
+        @ParameterizedTest
+        @ValueSource(strings = "expired")
+        void 로그인_하지않은_사용자가_레시피_작성시_예외가_발생한다(final String cookie) {
             // given
             final var category = 카테고리_간편식사_생성();
             단일_카테고리_저장(category);
@@ -138,7 +142,7 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
             final var images = 여러_사진_요청(3);
 
             // when
-            final var response = 레시피_생성_요청(request, images, null);
+            final var response = 레시피_생성_요청(request, images, cookie);
 
             // then
             final var expectedCode = LOGIN_MEMBER_NOT_FOUND.getCode();
@@ -321,8 +325,10 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
     @Nested
     class getRecipeDetail_실패_테스트 {
 
-        @Test
-        void 로그인_하지않은_사용자가_레시피_상세_조회시_예외가_발생한다() {
+        @NullSource
+        @ParameterizedTest
+        @ValueSource(strings = "expired")
+        void 로그인_하지않은_사용자가_레시피_상세_조회시_예외가_발생한다(final String cookie) {
             // given
             final var category = 카테고리_간편식사_생성();
             단일_카테고리_저장(category);
@@ -340,7 +346,7 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
             final var recipeId = 레시피_추가_요청하고_id_반환(createRequest, images, loginCookie);
 
             // when
-            final var response = 레시피_상세_정보_요청(null, recipeId);
+            final var response = 레시피_상세_정보_요청(cookie, recipeId);
 
             // then
             final var expectedCode = LOGIN_MEMBER_NOT_FOUND.getCode();
@@ -436,11 +442,13 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
     @Nested
     class likeRecipe_실패_테스트 {
 
-        @Test
-        void 로그인_하지않은_사용자가_레시피에_좋아요를_할때_예외가_발생한다() {
+        @NullSource
+        @ParameterizedTest
+        @ValueSource(strings = "expired")
+        void 로그인_하지않은_사용자가_레시피에_좋아요를_할때_예외가_발생한다(final String cookie) {
             // given
             final var member = 멤버_멤버1_생성();
-            final var memberId = 단일_멤버_저장(member);
+            단일_멤버_저장(member);
 
             final var category = 카테고리_간편식사_생성();
             단일_카테고리_저장(category);
@@ -460,7 +468,7 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
             final var favoriteRequest = 레시피좋아요요청_생성(true);
 
             // when
-            final var response = 레시피_좋아요_요청(null, recipeId, favoriteRequest);
+            final var response = 레시피_좋아요_요청(cookie, recipeId, favoriteRequest);
 
             // then
             final var expectedCode = LOGIN_MEMBER_NOT_FOUND.getCode();

--- a/backend/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
@@ -123,9 +123,8 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
     @Nested
     class writeRecipe_실패_테스트 {
 
-        @NullSource
         @ParameterizedTest
-        @ValueSource(strings = "expired")
+        @NullAndEmptySource
         void 로그인_하지않은_사용자가_레시피_작성시_예외가_발생한다(final String cookie) {
             // given
             final var category = 카테고리_간편식사_생성();
@@ -325,9 +324,8 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
     @Nested
     class getRecipeDetail_실패_테스트 {
 
-        @NullSource
         @ParameterizedTest
-        @ValueSource(strings = "expired")
+        @NullAndEmptySource
         void 로그인_하지않은_사용자가_레시피_상세_조회시_예외가_발생한다(final String cookie) {
             // given
             final var category = 카테고리_간편식사_생성();
@@ -442,9 +440,8 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
     @Nested
     class likeRecipe_실패_테스트 {
 
-        @NullSource
         @ParameterizedTest
-        @ValueSource(strings = "expired")
+        @NullAndEmptySource
         void 로그인_하지않은_사용자가_레시피에_좋아요를_할때_예외가_발생한다(final String cookie) {
             // given
             final var member = 멤버_멤버1_생성();

--- a/backend/src/test/java/com/funeat/acceptance/recipe/RecipeSteps.java
+++ b/backend/src/test/java/com/funeat/acceptance/recipe/RecipeSteps.java
@@ -20,7 +20,7 @@ public class RecipeSteps {
                                                           final List<MultiPartSpecification> images,
                                                           final String loginCookie) {
         final var requestSpec = given()
-                .cookie("JSESSIONID", loginCookie);
+                .cookie("FUNEAT", loginCookie);
 
         if (Objects.nonNull(images) && !images.isEmpty()) {
             images.forEach(requestSpec::multiPart);
@@ -43,7 +43,7 @@ public class RecipeSteps {
 
     public static ExtractableResponse<Response> 레시피_상세_정보_요청(final String loginCookie, final Long recipeId) {
         return given()
-                .cookie("JSESSIONID", loginCookie)
+                .cookie("FUNEAT", loginCookie)
                 .when()
                 .get("/api/recipes/{recipeId}", recipeId)
                 .then()
@@ -64,7 +64,7 @@ public class RecipeSteps {
     public static ExtractableResponse<Response> 레시피_좋아요_요청(final String loginCookie, final Long recipeId,
                                                            final RecipeFavoriteRequest request) {
         return given()
-                .cookie("JSESSIONID", loginCookie)
+                .cookie("FUNEAT", loginCookie)
                 .contentType("application/json")
                 .body(request)
                 .when()

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -58,6 +58,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @SuppressWarnings("NonAsciiCharacters")
 class ReviewAcceptanceTest extends AcceptanceTest {
@@ -120,8 +122,10 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     @Nested
     class writeReview_실패_테스트 {
 
-        @Test
-        void 로그인_하지않은_사용자가_리뷰_작성시_예외가_발생한다() {
+        @NullSource
+        @ParameterizedTest
+        @ValueSource(strings = "expired")
+        void 로그인_하지않은_사용자가_리뷰_작성시_예외가_발생한다(final String cookie) {
             // given
             final var category = 카테고리_즉석조리_생성();
             단일_카테고리_저장(category);
@@ -139,7 +143,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
             final var request = 리뷰추가요청_재구매O_생성(4L, tagIds);
 
             // when
-            final var response = 단일_리뷰_요청(productId, image, request, null);
+            final var response = 단일_리뷰_요청(productId, image, request, cookie);
 
             // then
             final var expectedCode = LOGIN_MEMBER_NOT_FOUND.getCode();
@@ -448,11 +452,13 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     @Nested
     class toggleLikeReview_실패_테스트 {
 
-        @Test
-        void 로그인_하지않은_사용자가_리뷰에_좋아요를_할때_예외가_발생한다() {
+        @NullSource
+        @ParameterizedTest
+        @ValueSource(strings = "expired")
+        void 로그인_하지않은_사용자가_리뷰에_좋아요를_할때_예외가_발생한다(final String cookie) {
             // given
             final var member = 멤버_멤버1_생성();
-            final var memberId = 단일_멤버_저장(member);
+            단일_멤버_저장(member);
 
             final var category = 카테고리_즉석조리_생성();
             단일_카테고리_저장(category);
@@ -475,7 +481,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
             final var favoriteRequest = 리뷰좋아요요청_true_생성();
 
             // when
-            final var response = 리뷰_좋아요_요청(productId, reviewId, favoriteRequest, null);
+            final var response = 리뷰_좋아요_요청(productId, reviewId, favoriteRequest, cookie);
 
             // then
             final var expectedCode = LOGIN_MEMBER_NOT_FOUND.getCode();
@@ -785,8 +791,10 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     @Nested
     class getSortingReviews_실패_테스트 {
 
-        @Test
-        void 로그인_하지않은_사용자가_리뷰_목록을_조회시_예외가_발생한다() {
+        @NullSource
+        @ParameterizedTest
+        @ValueSource(strings = "expired")
+        void 로그인_하지않은_사용자가_리뷰_목록을_조회시_예외가_발생한다(final String cookie) {
             // given
             final var category = 카테고리_즉석조리_생성();
             단일_카테고리_저장(category);
@@ -805,7 +813,7 @@ class ReviewAcceptanceTest extends AcceptanceTest {
             복수_리뷰_저장(review1, review2, review3);
 
             // when
-            final var response = 정렬된_리뷰_목록_조회_요청(null, productId, "favoriteCount,desc", 0);
+            final var response = 정렬된_리뷰_목록_조회_요청(cookie, productId, "favoriteCount,desc", 0);
 
             // then
             final var expectedCode = LOGIN_MEMBER_NOT_FOUND.getCode();

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewAcceptanceTest.java
@@ -58,8 +58,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.NullSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 @SuppressWarnings("NonAsciiCharacters")
 class ReviewAcceptanceTest extends AcceptanceTest {
@@ -122,9 +120,8 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     @Nested
     class writeReview_실패_테스트 {
 
-        @NullSource
         @ParameterizedTest
-        @ValueSource(strings = "expired")
+        @NullAndEmptySource
         void 로그인_하지않은_사용자가_리뷰_작성시_예외가_발생한다(final String cookie) {
             // given
             final var category = 카테고리_즉석조리_생성();
@@ -452,9 +449,8 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     @Nested
     class toggleLikeReview_실패_테스트 {
 
-        @NullSource
         @ParameterizedTest
-        @ValueSource(strings = "expired")
+        @NullAndEmptySource
         void 로그인_하지않은_사용자가_리뷰에_좋아요를_할때_예외가_발생한다(final String cookie) {
             // given
             final var member = 멤버_멤버1_생성();
@@ -791,9 +787,8 @@ class ReviewAcceptanceTest extends AcceptanceTest {
     @Nested
     class getSortingReviews_실패_테스트 {
 
-        @NullSource
         @ParameterizedTest
-        @ValueSource(strings = "expired")
+        @NullAndEmptySource
         void 로그인_하지않은_사용자가_리뷰_목록을_조회시_예외가_발생한다(final String cookie) {
             // given
             final var category = 카테고리_즉석조리_생성();

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewSteps.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewSteps.java
@@ -14,7 +14,7 @@ public class ReviewSteps {
     public static ExtractableResponse<Response> 단일_리뷰_요청(final Long productId, final MultiPartSpecification image,
                                                          final ReviewCreateRequest request, final String loginCookie) {
         final var requestSpec = given()
-                .cookie("JSESSIONID", loginCookie);
+                .cookie("FUNEAT", loginCookie);
 
         if (image != null) {
             requestSpec.multiPart(image);
@@ -32,7 +32,7 @@ public class ReviewSteps {
                                                           final ReviewFavoriteRequest request,
                                                           final String loginCookie) {
         return given()
-                .cookie("JSESSIONID", loginCookie)
+                .cookie("FUNEAT", loginCookie)
                 .contentType("application/json")
                 .body(request)
                 .when()
@@ -44,7 +44,7 @@ public class ReviewSteps {
     public static ExtractableResponse<Response> 정렬된_리뷰_목록_조회_요청(final String loginCookie, final Long productId,
                                                                 final String sort, final Integer page) {
         return given()
-                .cookie("JSESSIONID", loginCookie)
+                .cookie("FUNEAT", loginCookie)
                 .queryParam("sort", sort)
                 .queryParam("page", page)
                 .when()

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -18,3 +18,9 @@ spring:
 logging:
   level:
     org.hibernate.type.descriptor.sql: trace
+
+server:
+  servlet:
+    session:
+      cookie:
+        name: FUNEAT


### PR DESCRIPTION
## Issue

- close #564 

## ✨ 구현한 기능

1. 중요 사항
- `request.getSession(create = false)`를 통해 세션이 존재하지 않으면 새로운 세션이 생성되지 않도록 합니다.
- 로그아웃시 클라이언트에 저장된 쿠키도 삭제되도록 변경했습니다
- 클라이언트에게 보내주는 쿠키 이름을 `JSESSIONID`에서 `FUNEAT`으로 변경했습니다

2. 리팩터링
- `session == null`을 `Objects.isNull(session)`으로 한 번 감싸주는 로직으로 변경했습니다.
- `interceptor`, `argument resolver`에 `final` 추가했습니다
- 테스트쪽에 사용되지 않는 변수가 있어서 메서드 호출만 하도록 변경했습니다

## 📢 논의하고 싶은 내용

- JSESSIONID 이름도 바꿀 수 있는데, 다른 이름으로 변경하는건 어떤가요? → `FUNEAT`으로 변경

## 🎸 기타

- x

## ⏰ 일정

- 추정 시간 : 0.5
- 걸린 시간 : 2
