### PR TITLE
[FE] feat: 구글 애널리틱스 js에서 처리하도록 이동

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "dayjs": "^1.11.9",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-ga4": "^2.1.0",
     "react-router-dom": "^6.14.2",
     "styled-components": "^6.0.2"
   },

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -19,17 +19,6 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32x32.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-icon-180x180.png" />
     <title>펀잇</title>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=%GOOGLE_ANALYTICS_ID%"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-
-      gtag('config', '%GOOGLE_ANALYTICS_ID%');
-    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/hooks/common/index.ts
+++ b/frontend/src/hooks/common/index.ts
@@ -7,3 +7,4 @@ export { default as useSortOption } from './useSortOption';
 export { default as useImageUploader } from './useImageUploader';
 export { default as useFormData } from './useFormData';
 export { default as useTimeout } from './useTimeout';
+export { default as useRouteChangeTracker } from './useRouteChangeTracker';

--- a/frontend/src/hooks/common/useRouteChangeTracker.ts
+++ b/frontend/src/hooks/common/useRouteChangeTracker.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import ReactGA from 'react-ga4';
+import { useLocation } from 'react-router-dom';
+
+const useRouteChangeTracker = () => {
+  const location = useLocation();
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      ReactGA.initialize(process.env.GOOGLE_ANALYTICS_ID as string);
+    }
+    setInitialized(true);
+  }, []);
+
+  useEffect(() => {
+    if (initialized) {
+      ReactGA.send({ hitType: 'pageview', location: location.pathname });
+    }
+  }, [initialized, location]);
+};
+
+export default useRouteChangeTracker;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -3,11 +3,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import ReactGA from 'react-ga4';
 import { RouterProvider } from 'react-router-dom';
 
 import { SvgSprite } from './components/Common';
 import router from './router';
 import GlobalStyle from './styles';
+
+ReactGA.initialize(process.env.GOOGLE_ANALYTICS_ID as string);
 
 const main = async () => {
   if (process.env.NODE_ENV === 'development') {

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -2,6 +2,7 @@ import { BottomSheet, Spacing, useBottomSheet, Text, Link } from '@fun-eat/desig
 import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 import type { MouseEventHandler } from 'react';
 import { useState, useRef, Suspense } from 'react';
+import ReactGA from 'react-ga4';
 import { useParams, Link as RouterLink } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -66,6 +67,12 @@ const ProductDetailPage = () => {
   const handleTabMenuSelect: MouseEventHandler<HTMLButtonElement> = (event) => {
     setSelectedTabMenu(event.currentTarget.value);
     selectSortOption(initialSortOption);
+
+    ReactGA.event({
+      category: '버튼',
+      action: '카테고리 이동 클릭 액션',
+      label: 'category',
+    });
   };
 
   return (

--- a/frontend/src/router/App.tsx
+++ b/frontend/src/router/App.tsx
@@ -4,6 +4,7 @@ import { Outlet } from 'react-router-dom';
 
 import { ErrorBoundary, ErrorComponent, Loading } from '@/components/Common';
 import { MinimalLayout, DefaultLayout, HeaderOnlyLayout } from '@/components/Layout';
+import { useRouteChangeTracker } from '@/hooks/common';
 
 interface AppProps {
   layout?: 'default' | 'headerOnly' | 'minimal';
@@ -11,6 +12,8 @@ interface AppProps {
 
 const App = ({ layout = 'default' }: AppProps) => {
   const { reset } = useQueryErrorResetBoundary();
+
+  useRouteChangeTracker();
 
   if (layout === 'minimal') {
     return (

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9011,6 +9011,11 @@ react-element-to-jsx-string@^15.0.0:
     is-plain-object "5.0.0"
     react-is "18.1.0"
 
+react-ga4@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-2.1.0.tgz#56601f59d95c08466ebd6edfbf8dede55c4678f9"
+  integrity sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==
+
 react-inspector@^6.0.0:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-6.0.2.tgz#aa3028803550cb6dbd7344816d5c80bf39d07e9d"


### PR DESCRIPTION
## Issue

- close #566

## ✨ 구현한 기능

- 황펭이 알려준 https://github.com/codler/react-ga4 라이브러리를 사용했습니다.
- `useRouteChangeTracker` hook을 통해 페이지 이동이 일어나는 것을 추적하게 됩니다.

## 📢 논의하고 싶은 내용

x

## 🎸 기타

현재 테스트로 카테고리 선택하는 버튼에 이벤트를 달아놨습니다!

## ⏰ 일정

- 추정 시간 : 2
- 걸린 시간 : 2
