### PR TITLE
[BE] refactor: @ManyToOne의 FetchType을 LAZY로 수정

### DIFF
--- a/backend/src/main/java/com/funeat/member/domain/favorite/RecipeFavorite.java
+++ b/backend/src/main/java/com/funeat/member/domain/favorite/RecipeFavorite.java
@@ -3,6 +3,7 @@ package com.funeat.member.domain.favorite;
 import com.funeat.member.domain.Member;
 import com.funeat.recipe.domain.Recipe;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -19,11 +20,11 @@ public class RecipeFavorite {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recipe_id")
     private Recipe recipe;
 

--- a/backend/src/main/java/com/funeat/member/domain/favorite/ReviewFavorite.java
+++ b/backend/src/main/java/com/funeat/member/domain/favorite/ReviewFavorite.java
@@ -3,6 +3,7 @@ package com.funeat.member.domain.favorite;
 import com.funeat.member.domain.Member;
 import com.funeat.review.domain.Review;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -19,11 +20,11 @@ public class ReviewFavorite {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id")
     private Review review;
 

--- a/backend/src/main/java/com/funeat/product/domain/Product.java
+++ b/backend/src/main/java/com/funeat/product/domain/Product.java
@@ -5,6 +5,7 @@ import com.funeat.review.domain.Review;
 import java.util.List;
 import java.util.Objects;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -29,7 +30,7 @@ public class Product {
 
     private Double averageRating = 0.0;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
 

--- a/backend/src/main/java/com/funeat/product/domain/ProductRecipe.java
+++ b/backend/src/main/java/com/funeat/product/domain/ProductRecipe.java
@@ -2,6 +2,7 @@ package com.funeat.product.domain;
 
 import com.funeat.recipe.domain.Recipe;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -15,11 +16,11 @@ public class ProductRecipe {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recipe_id")
     private Recipe recipe;
 

--- a/backend/src/main/java/com/funeat/recipe/domain/Recipe.java
+++ b/backend/src/main/java/com/funeat/recipe/domain/Recipe.java
@@ -4,6 +4,7 @@ import com.funeat.member.domain.Member;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -24,7 +25,7 @@ public class Recipe {
     @Column(nullable = false)
     private LocalDateTime createdAt = LocalDateTime.now();
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/backend/src/main/java/com/funeat/recipe/domain/RecipeImage.java
+++ b/backend/src/main/java/com/funeat/recipe/domain/RecipeImage.java
@@ -1,6 +1,7 @@
 package com.funeat.recipe.domain;
 
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -16,7 +17,7 @@ public class RecipeImage {
 
     private String image;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recipe_id")
     private Recipe recipe;
 

--- a/backend/src/main/java/com/funeat/recipe/persistence/RecipeRepository.java
+++ b/backend/src/main/java/com/funeat/recipe/persistence/RecipeRepository.java
@@ -16,6 +16,10 @@ import org.springframework.data.repository.query.Param;
 
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
+    @Query("SELECT r FROM Recipe r "
+            + "JOIN FETCH r.member m")
+    Recipe findRecipeWithMemberById(final Long id);
+
     Page<Recipe> findRecipesByMember(final Member member, final Pageable pageable);
 
     @Query("SELECT DISTINCT r FROM Recipe r "

--- a/backend/src/main/java/com/funeat/review/domain/Review.java
+++ b/backend/src/main/java/com/funeat/review/domain/Review.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -34,11 +35,11 @@ public class Review {
     @Column(nullable = false)
     private LocalDateTime createdAt = LocalDateTime.now();
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/backend/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/recipe/RecipeAcceptanceTest.java
@@ -300,7 +300,7 @@ public class RecipeAcceptanceTest extends AcceptanceTest {
             final var createRequest = 레시피추가요청_생성(productIds);
             final var recipeId = 레시피_추가_요청하고_id_반환(createRequest, loginCookie);
 
-            final var recipe = recipeRepository.findById(recipeId).get();
+            final var recipe = recipeRepository.findRecipeWithMemberById(recipeId);
             final var findImages = recipeImageRepository.findByRecipe(recipe);
 
             final var expected = RecipeDetailResponse.toResponse(recipe, findImages, products, totalPrice, false);


### PR DESCRIPTION
## Issue

- close #584 

## ✨ 구현한 기능

- `@ManyToOne`의 디폴트 FetchType인 EAGER를 LAZY로 수정

## 📢 논의하고 싶은 내용

- X

## 🎸 기타

LAZY 설정 후 `RecipeAcceptanceTest`의 `레시피의_상세_정보를_조회한다` 테스트 실패
- 문제 원인
  - Recipe의 `@ManyToOne` 매핑 필드였던 Member를 Lazy Loading으로 수정
  - recipeRepository.findById(recipeId); 의 결과에 Member 세팅 X
  - member가 필요한 파트(RecipeDetailResponse.toResponse)에서 LazyInitializationException 발생
- 해결 : Member를 fetchJoin으로 Recipe와 함께 가져오는 `findRecipeWithMemberById` 메소드 생성
  - 해당 테스트에 `@Transactional`을 붙여 LazyInitializationException은 피할 수 있지만, RestAssured 특성상 테스트 트랜잭션과 RestAssured 트랜잭션이 분리되어 또다른 문제 발생

## ⏰ 일정

- 추정 시간 : 15m
- 걸린 시간 : 1h
