### PR TITLE
[BE] fix: maxFileSize, maxRequestSize 10MB 로 수정

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,6 +4,8 @@ spring:
   servlet:
     multipart:
       enabled: true
+      maxFileSize: 10MB
+      maxRequestSize: 15MB
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## Issue

- close #619 

## ✨ 구현한 기능

- 기존 설정이 1mb 로 되어있는데 10MB 로 넉넉하게 설정해주었습니다.

## 📢 논의하고 싶은 내용

- x

## 🎸 기타

- x

## ⏰ 일정

- 추정 시간 : 5
- 걸린 시간 : 1
