### PR TITLE
[BE] API에 대한 로깅 기능 추가

### DIFF
--- a/backend/src/main/java/com/funeat/common/logging/Logging.java
+++ b/backend/src/main/java/com/funeat/common/logging/Logging.java
@@ -1,0 +1,11 @@
+package com.funeat.common.logging;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Logging {
+}

--- a/backend/src/main/java/com/funeat/common/logging/LoggingAspect.java
+++ b/backend/src/main/java/com/funeat/common/logging/LoggingAspect.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
 import java.util.Map;
 import org.aspectj.lang.JoinPoint;
-import org.aspectj.lang.Signature;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
@@ -15,6 +14,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 
 @Aspect
 @Component
@@ -35,12 +36,30 @@ public class LoggingAspect {
 
     @Before("allPresentation() && logging()")
     public void requestLogging(final JoinPoint joinPoint) {
-        final Signature signature = joinPoint.getSignature();
-        final String classAndMethodName = signature.toShortString();
-
+        final Class<?> clazz = joinPoint.getTarget().getClass();
         final Map<String, Object> args = getSpecificParameters(joinPoint);
 
-        printLog("[REQUEST] method={} args={}", classAndMethodName, args);
+        printRequestLog(clazz, args);
+    }
+
+    private String getRequestMethod(final Class<?> clazz) {
+        final RequestMapping requestMapping = clazz.getDeclaredAnnotation(RequestMapping.class);
+        final RequestMethod[] requestMethods = requestMapping.method();
+        if (requestMethods.length > 0) {
+            return requestMethods[0].name();
+        }
+        log.warn("[LOGGING ERROR] Request Method가 존재하지 않습니다.");
+        return "";
+    }
+
+    private String getRequestUrl(final Class<?> clazz) {
+        final RequestMapping requestMapping = clazz.getDeclaredAnnotation(RequestMapping.class);
+        final String[] requestUrls = requestMapping.path();
+        if (requestUrls.length > 0) {
+            return requestUrls[0];
+        }
+        log.warn("[LOGGING ERROR] Request URL이 존재하지 않습니다.");
+        return "";
     }
 
     private Map<String, Object> getSpecificParameters(final JoinPoint joinPoint) {
@@ -58,20 +77,27 @@ public class LoggingAspect {
         return params;
     }
 
-    private void printLog(final String logFormat, final String classAndMethodName, final Object value) {
+    private void printRequestLog(final Class<?> clazz, final Object value) {
         try {
-            log.info(logFormat, classAndMethodName, objectMapper.writeValueAsString(value));
+            final String requestMethod = getRequestMethod(clazz);
+            final String requestUrl = getRequestUrl(clazz);
+            log.info("[REQUEST] {}, {}, {}", requestMethod, requestUrl, objectMapper.writeValueAsString(value));
         } catch (final JsonProcessingException e) {
-            log.warn("로깅에 실패했습니다");
+            log.warn("[LOGGING ERROR] Request 로깅에 실패했습니다");
         }
     }
 
     @AfterReturning(value = "allPresentation() && logging()", returning = "responseEntity")
     public void requestLogging(final JoinPoint joinPoint, final ResponseEntity<?> responseEntity) {
-        final Signature signature = joinPoint.getSignature();
-        final String classAndMethodName = signature.toShortString();
-
-        printLog("[RESPONSE] method={} responseBody={}", classAndMethodName, responseEntity.getClass());
+        printResponseLog(responseEntity);
     }
 
+    private void printResponseLog(final ResponseEntity<?> responseEntity) {
+        try {
+            final String responseStatus = responseEntity.getStatusCode().toString();
+            log.info("[RESPONSE] {} {}", responseStatus, objectMapper.writeValueAsString(responseEntity.getBody()));
+        } catch (final JsonProcessingException e) {
+            log.warn("[LOGGING ERROR] Response 로깅에 실패했습니다");
+        }
+    }
 }

--- a/backend/src/main/java/com/funeat/common/logging/LoggingAspect.java
+++ b/backend/src/main/java/com/funeat/common/logging/LoggingAspect.java
@@ -24,7 +24,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @Component
 public class LoggingAspect {
 
-    private static final List<String> excludeNames = Arrays.asList("image", "request");
+    private static final List<String> excludeNames = Arrays.asList("image", "images", "request");
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final Logger log = LoggerFactory.getLogger(this.getClass());
@@ -72,6 +72,7 @@ public class LoggingAspect {
                     request.getMethod(), request.getRequestURI(), objectMapper.writeValueAsString(value));
         } catch (final JsonProcessingException e) {
             log.warn("[LOGGING ERROR] Request 로깅에 실패했습니다");
+            e.printStackTrace();
         }
     }
 

--- a/backend/src/main/java/com/funeat/common/logging/LoggingAspect.java
+++ b/backend/src/main/java/com/funeat/common/logging/LoggingAspect.java
@@ -72,7 +72,6 @@ public class LoggingAspect {
                     request.getMethod(), request.getRequestURI(), objectMapper.writeValueAsString(value));
         } catch (final JsonProcessingException e) {
             log.warn("[LOGGING ERROR] Request 로깅에 실패했습니다");
-            e.printStackTrace();
         }
     }
 

--- a/backend/src/main/java/com/funeat/common/logging/LoggingAspect.java
+++ b/backend/src/main/java/com/funeat/common/logging/LoggingAspect.java
@@ -1,0 +1,58 @@
+package com.funeat.common.logging;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.Signature;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.CodeSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class LoggingAspect {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String IMAGE = "image";
+
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    @Pointcut("execution(public * com.funeat.*.presentation.*.*(..))")
+    private void allPresentation() {
+    }
+
+    @Pointcut("@annotation(com.funeat.common.logging.Logging)")
+    private void logging() {
+    }
+
+    @Before("allPresentation() && logging()")
+    public void requestLogging(final JoinPoint joinPoint) throws JsonProcessingException {
+        final Signature signature = joinPoint.getSignature();
+        final String classAndMethodName = signature.toShortString();
+
+        final Map<String, Object> args = getSpecificParameters(joinPoint);
+
+        log.info("method={} args={}", classAndMethodName, objectMapper.writeValueAsString(args));
+    }
+
+    private Map<String, Object> getSpecificParameters(final JoinPoint joinPoint) {
+        final CodeSignature codeSignature = (CodeSignature) joinPoint.getSignature();
+        final String[] parameterNames = codeSignature.getParameterNames();
+        final Object[] args = joinPoint.getArgs();
+
+        final Map<String, Object> params = new HashMap<>();
+        for (int i = 0; i < parameterNames.length; i++) {
+            if (!parameterNames[i].equals(IMAGE)) {
+                params.put(parameterNames[i], args[i]);
+            }
+        }
+
+        return params;
+    }
+}

--- a/backend/src/main/java/com/funeat/member/presentation/MemberApiController.java
+++ b/backend/src/main/java/com/funeat/member/presentation/MemberApiController.java
@@ -2,6 +2,7 @@ package com.funeat.member.presentation;
 
 import com.funeat.auth.dto.LoginInfo;
 import com.funeat.auth.util.AuthenticationPrincipal;
+import com.funeat.common.logging.Logging;
 import com.funeat.member.application.MemberService;
 import com.funeat.member.dto.MemberProfileResponse;
 import com.funeat.member.dto.MemberRecipesResponse;
@@ -45,6 +46,7 @@ public class MemberApiController implements MemberController {
         return ResponseEntity.ok(response);
     }
 
+    @Logging
     @PutMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<Void> putMemberProfile(@AuthenticationPrincipal final LoginInfo loginInfo,
                                                  @RequestPart(required = false) final MultipartFile image,

--- a/backend/src/main/java/com/funeat/recipe/presentation/RecipeApiController.java
+++ b/backend/src/main/java/com/funeat/recipe/presentation/RecipeApiController.java
@@ -2,6 +2,7 @@ package com.funeat.recipe.presentation;
 
 import com.funeat.auth.dto.LoginInfo;
 import com.funeat.auth.util.AuthenticationPrincipal;
+import com.funeat.common.logging.Logging;
 import com.funeat.recipe.application.RecipeService;
 import com.funeat.recipe.dto.RankingRecipesResponse;
 import com.funeat.recipe.dto.RecipeCreateRequest;
@@ -36,6 +37,7 @@ public class RecipeApiController implements RecipeController {
         this.recipeService = recipeService;
     }
 
+    @Logging
     @PostMapping(value = "/api/recipes", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
             MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<Void> writeRecipe(@AuthenticationPrincipal final LoginInfo loginInfo,
@@ -61,6 +63,7 @@ public class RecipeApiController implements RecipeController {
         return ResponseEntity.ok(response);
     }
 
+    @Logging
     @PatchMapping(value = "/api/recipes/{recipeId}")
     public ResponseEntity<Void> likeRecipe(@AuthenticationPrincipal final LoginInfo loginInfo,
                                            @PathVariable final Long recipeId,

--- a/backend/src/main/java/com/funeat/review/presentation/ReviewApiController.java
+++ b/backend/src/main/java/com/funeat/review/presentation/ReviewApiController.java
@@ -2,6 +2,7 @@ package com.funeat.review.presentation;
 
 import com.funeat.auth.dto.LoginInfo;
 import com.funeat.auth.util.AuthenticationPrincipal;
+import com.funeat.common.logging.Logging;
 import com.funeat.review.application.ReviewService;
 import com.funeat.review.dto.RankingReviewsResponse;
 import com.funeat.review.dto.ReviewCreateRequest;
@@ -31,6 +32,7 @@ public class ReviewApiController implements ReviewController {
         this.reviewService = reviewService;
     }
 
+    @Logging
     @PostMapping(value = "/api/products/{productId}/reviews", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
             MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<Void> writeReview(@PathVariable final Long productId,
@@ -42,6 +44,7 @@ public class ReviewApiController implements ReviewController {
         return ResponseEntity.created(URI.create("/api/products/" + productId)).build();
     }
 
+    @Logging
     @PatchMapping("/api/products/{productId}/reviews/{reviewId}")
     public ResponseEntity<Void> toggleLikeReview(@PathVariable Long reviewId,
                                                  @AuthenticationPrincipal LoginInfo loginInfo,


### PR DESCRIPTION
## Issue

- close #563

## ✨ 구현한 기능

### 1. 주요 기능
- Spring AOP를 통해 API에 대한 로깅 기능을 추가했습니다.
- 로그로 남겨두고 싶은 곳에 `@Logging`을 사용하면 됩니다.
  - 로깅하지 않는 내용
    - 이미지 파일 - 이미지는 직렬화 불가 + 회의를 통해 이미지 이름도 로깅하지 않도록 함 (아래에 회의 내용 적음)
    - HttpServletRequest - 현재 `AuthController`만 파라미터로 가지고 있는데, 다른 데이터를 로깅할 상황이 있을 수도 있으므로 + 실수 방지
- 현재 데이터 추가 / 생성에 대한 API만 적용해야해서 이게 5개뿐이라 `@Logging`을 적용했습니다.
  - 나중에 로깅할 곳이 더 많아지면 `@NoLogging`으로 바꾸면 됩니다.

---

### 2. Spring AOP를 선택한 이유

[1] Spring AOP
- `Aspect` 클래스 하나로 관리 가능
- `@Logging`을 통해 로깅하고 싶은 메서드만 추가해주면 되서 유지보수하기 좋음

[2] Log4Jdbc (2013년이 최신 버전)
- `Log4Jdbc`를 사용하려면 `datasource driver-class-name`, `url`을 형식에 맞게 수정해야합니다
- `logback xml`에서 설정을 해주면 모든 쿼리문을 로깅할 수 있습니다. 근데 특정 쿼리문만 로깅하려면 따로 자바 코드를 추가해야한다고 합니다.
- 간단하게 적용해보니 관리 포인트가 `Spring AOP`보다 많아져서 패스

[3] Janino
- `logback`에서 조건부 처리를 할 수 있다고 합니다.
- 라이브러리 소개가 자바 코드를 바이트 코드로 빠르게 변환하는 컴파일러 라이브러리라서 목적에 맞지 않게 쓰이는 느낌이에요
- `Janino`는 한글 자료가 적은 편인데, 대다수가 `logback` 조건부 처리 방법만 써두고, 아무도 자세한 라이브러리 설명을 안해줘서 안쓰는게 좋을 것 같습니다.

---

### 3. 이미지 이름이라도 로깅을 해야할까? 회의 내용

[1] 회의 결과
- 이미지에 대한 로그는 제외하고 진행

[2] 이유
- 이미지도 로깅을 한다면 DTO를 만들어서 따로 이미지 파일 이름을 로깅할 수 있음
- 하지만 현재 이미지를 저장할 때, 이미지 이름이 같을 수도 있으니 UUID + 이미지 이름으로 재생성해서 저장하고 있음
- 그래서 실제 S3에 저장된 이미지와는 다른 이미지 이름을 로깅하게 되어버림

굳이 이미지 로깅을 해서 사용할만한 부분이 있지는 않음

[3] 기타사항
- 추후에 이미지 로그가 필요하다면 그때 추가하기로 함

---

### 4. 실행 결과

[1] 유저 정보 수정
```text
2023-09-14 14:34:42.417  INFO 5530 --- [nio-8080-exec-4] com.funeat.common.logging.LoggingAspect  : [REQUEST PUT] [PATH /api/members] {"loginInfo":{"id":1},"memberRequest":{"nickname":"logan"}}
2023-09-14 14:34:42.431  INFO 5530 --- [nio-8080-exec-4] com.funeat.common.logging.LoggingAspect  : [RESPONSE 200 OK] null
```

<br/>

[2] 리뷰 생성
```text
2023-09-14 14:39:12.639  INFO 5601 --- [nio-8080-exec-3] com.funeat.common.logging.LoggingAspect  : [REQUEST POST] [PATH /api/products/1/reviews] {"productId":1,"loginInfo":{"id":1},"reviewRequest":{"rating":3,"tagIds":[1,2,3],"content":"test content","rebuy":false}}
2023-09-14 14:39:12.792  INFO 5601 --- [nio-8080-exec-3] com.funeat.common.logging.LoggingAspect  : [RESPONSE 201 CREATED] null
```

<br/>

[3] 리뷰 좋아요
```text
2023-09-14 14:43:08.741  INFO 5601 --- [nio-8080-exec-6] com.funeat.common.logging.LoggingAspect  : [REQUEST PATCH] [PATH /api/products/1/reviews/3] {"loginInfo":{"id":1},"reviewId":3}
2023-09-14 14:43:08.792  INFO 5601 --- [nio-8080-exec-6] com.funeat.common.logging.LoggingAspect  : [RESPONSE 204 NO_CONTENT] null
```

<br/>

[4] 레시피 생성
```text
2023-09-14 14:49:17.438  INFO 5787 --- [nio-8080-exec-4] com.funeat.common.logging.LoggingAspect  : [REQUEST POST] [PATH /api/recipes] {"loginInfo":{"id":1},"recipeRequest":{"title":"test title","productIds":[1,2],"content":"test content"}}
2023-09-14 14:49:17.454  INFO 5787 --- [nio-8080-exec-4] com.funeat.common.logging.LoggingAspect  : [RESPONSE 201 CREATED] null
```

<br/>

[5] 레시피 좋아요
```text
2023-09-14 14:50:37.381  INFO 5787 --- [io-8080-exec-10] com.funeat.common.logging.LoggingAspect  : [REQUEST PATCH] [PATH /api/recipes/2] {"loginInfo":{"id":1},"recipeId":2}
2023-09-14 14:50:37.429  INFO 5787 --- [io-8080-exec-10] com.funeat.common.logging.LoggingAspect  : [RESPONSE 204 NO_CONTENT] null
```

<br/>

[6] 에러가 발생할 경우
`@AfterReturning`을 적용해서 예외가 발생하면 로깅을 하지 않고, `GlobalControllerAdvice` 로그만 보입니다.
```text
2023-09-14 14:50:32.894  INFO 5787 --- [nio-8080-exec-9] com.funeat.common.logging.LoggingAspect  : [REQUEST PATCH] [PATH /api/recipes/1] {"loginInfo":{"id":1},"recipeId":1}
2023-09-14 14:50:32.928  WARN 5787 --- [nio-8080-exec-9] c.f.e.p.GlobalControllerAdvice           : source = com.funeat.recipe.application.RecipeService.lambda$likeRecipe$11(RecipeService.java:162) , PATCH = /api/recipes/1 code = 7001 message = 존재하지 않는 꿀조합입니다. 꿀조합 id를 확인하세요. info = 1
```

<br/>

---


## 📢 논의하고 싶은 내용

- 논의하고 싶은 내용을 작성합니다.

## 🎸 기타

- 특이 사항이 있으면 작성합니다.

## ⏰ 일정

- 추정 시간 : 6
- 걸린 시간 : 모름
