### PR TITLE
[BE] fix: LocalDateTime이 들어간 Response도 로깅할 수 있도록 설정

### DIFF
--- a/backend/src/main/java/com/funeat/common/logging/LoggingAspect.java
+++ b/backend/src/main/java/com/funeat/common/logging/LoggingAspect.java
@@ -2,6 +2,7 @@ package com.funeat.common.logging;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -26,7 +27,7 @@ public class LoggingAspect {
 
     private static final List<String> excludeNames = Arrays.asList("image", "images", "request");
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
     private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @Pointcut("execution(public * com.funeat.*.presentation.*.*(..))")


### PR DESCRIPTION
## Issue

- close #656

## ✨ 구현한 기능

- `LocalDateTime`은 `Serializable`을 가지고 있지만,  Jackson이 직렬화를 못해서 에러가 나옵니다.
- 그래서 직렬화를 할 수 있도록 `LoggingAspect.java`의 `ObjectMapper`에 `JavaTimeModule`을 추가했습니다.

Jackson이 직렬화하지 못하는 이유는 `LocalDateTime`이 Java 8 신규 기능이라 하위 호환성으로 인해 지원을 못하게 됐다고 하네요. 그래서 따로 모듈을 추가했다고 합니다.
그런데 라이브러리 찾아보면 `jackson-datatype-jdk8`도 있고, `jackson-datatype-jsr310`도 있어서 `LocalDateTime`은 `jdk8`에 있어야 하는거 아닌가 생각이 드는데요.
대충 찾아보니 Jackson이 만들어진 이후로 `java.time`처럼 완전히 새로운 패키지로 분리한건 Java 8에서 처음 발생한거라고 하네요
추가로 `jdk8`은 새로운 데이터 타입(`Optional`, `Stream`)이 추가되어서 만들어진 거라고 합니다.

## 📢 논의하고 싶은 내용

- `Jdk8Module`도 있는데, 이건 `Optional`이나, `Stream` 같은걸 직렬화할 수 있다고 합니다. 이것도 추가하는게 좋을까요?

## 🎸 기타

- AS-IS

```
2023-09-18 01:16:02.000  INFO 39019 --- [nio-8080-exec-3] com.funeat.common.logging.LoggingAspect  : [REQUEST GET] [PATH /api/products/1/reviews] {"productId":1,"loginInfo":{"id":1},"pageable":{"sort":{"empty":false,"sorted":true,"unsorted":false},"offset":4123460,"pageNumber":412346,"pageSize":10,"paged":true,"unpaged":false}}
2023-09-18 01:16:25.148  WARN 39019 --- [nio-8080-exec-3] com.funeat.common.logging.LoggingAspect  : [LOGGING ERROR] Response 로깅에 실패했습니다
```

- TO-BE

```
2023-09-18 01:10:27.367  INFO 36232 --- [nio-8080-exec-3] com.funeat.common.logging.LoggingAspect  : [REQUEST GET] [PATH /api/products/1/reviews] {"productId":1,"loginInfo":{"id":1},"pageable":{"sort":{"empty":false,"sorted":true,"unsorted":false},"offset":4123460,"pageNumber":412346,"pageSize":10,"paged":true,"unpaged":false}}
2023-09-18 01:10:54.490  INFO 36232 --- [nio-8080-exec-3] com.funeat.common.logging.LoggingAspect  : [RESPONSE 200 OK] {"page":{"totalDataCount":5001805,"totalPages":500181,"firstPage":false,"lastPage":false,"requestPage":412346,"requestSize":10},"reviews":[{"id":1018749,"userName":"member26431","profileImage":"image26431","image":"review_image1018749","rating":0,"tags":[{"id":23,"name":"🍡 쫄깃쫄깃","tagType":"ETC"},{"id":2,"name":"🍩 단짠단짠","tagType":"TASTE"},{"id":7,"name":"💧 싱거워요","tagType":"TASTE"}],"content":"review_content1018749","rebuy":true,"favoriteCount":0,"favorite":false,"createdAt":[2023,9,5,17,9,53]},{"id":1018748,"userName":"member84047","profileImage":"image84047","image":"review_image1018748","rating":0,"tags":[{"id":7,"name":"💧 싱거워요","tagType":"TASTE"},{"id":22,"name":"🍪 바삭바삭","tagType":"ETC"},{"id":23,"name":"🍡 쫄깃쫄깃","tagType":"ETC"}],"content":"review_content1018748","rebuy":false,"favoriteCount":0,"favorite":false,"createdAt":[2023,9,5,17,9,53]},{"id":1018747,"userName":"member30050","profileImage":"image30050","image":"review_image1018747","rating":0,"tags":[{"id":22,"name":"🍪 바삭바삭","tagType":"ETC"},{"id":19,"name":"🍺 속이 풀려요","tagType":"ETC"},{"id":3,"name":"👶 어린이입맛","tagType":"TASTE"}],"content":"review_content1018747","rebuy":false,"favoriteCount":0,"favorite":false,"createdAt":[2023,9,5,17,9,53]},{"id":1018746,"userName":"member76323","profileImage":"image76323","image":"review_image1018746","rating":0,"tags":[{"id":23,"name":"🍡 쫄깃쫄깃","tagType":"ETC"},{"id":23,"name":"🍡 쫄깃쫄깃","tagType":"ETC"},{"id":23,"name":"🍡 쫄깃쫄깃","tagType":"ETC"}],"content":"review_content1018746","rebuy":true,"favoriteCount":0,"favorite":false,"createdAt":[2023,9,5,17,9,53]},{"id":1018745,"userName":"member57787","profileImage":"image57787","image":"review_image1018745","rating":0,"tags":[{"id":3,"name":"👶 어린이입맛","tagType":"TASTE"},{"id":12,"name":"😎 푸짐해요","tagType":"QUANTITY"},{"id":8,"name":"🍋 새콤해요","tagType":"TASTE"}],"content":"review_content1018745","rebuy":false,"favoriteCount":0,"favorite":false,"createdAt":[2023,9,5,17,9,53]},{"id":1018744,"userName":"member69069","profileImage":"image69069","image":"review_image1018744","rating":0,"tags":[{"id":18,"name":"💪 건강해요","tagType":"ETC"},{"id":9,"name":"🧈 느끼해요","tagType":"TASTE"},{"id":15,"name":"🍫 간식","tagType":"ETC"}],"content":"review_content1018744","rebuy":false,"favoriteCount":0,"favorite":false,"createdAt":[2023,9,5,17,9,53]},{"id":1018743,"userName":"member17170","profileImage":"image17170","image":"review_image1018743","rating":0,"tags":[{"id":22,"name":"🍪 바삭바삭","tagType":"ETC"},{"id":20,"name":"👀 신기해요","tagType":"ETC"},{"id":11,"name":"💸 갓성비","tagType":"QUANTITY"}],"content":"review_content1018743","rebuy":false,"favoriteCount":0,"favorite":false,"createdAt":[2023,9,5,17,9,53]},{"id":1018742,"userName":"member73017","profileImage":"image73017","image":"review_image1018742","rating":0,"tags":[{"id":6,"name":"🧂 짭짤해요","tagType":"TASTE"},{"id":22,"name":"🍪 바삭바삭","tagType":"ETC"},{"id":22,"name":"🍪 바삭바삭","tagType":"ETC"}],"content":"review_content1018742","rebuy":false,"favoriteCount":0,"favorite":false,"createdAt":[2023,9,5,17,9,53]},{"id":1018741,"userName":"member63350","profileImage":"image63350","image":"review_image1018741","rating":0,"tags":[{"id":17,"name":"🥬 저칼로리","tagType":"ETC"},{"id":5,"name":"🍭 달달해요","tagType":"TASTE"},{"id":18,"name":"💪 건강해요","tagType":"ETC"}],"content":"review_content1018741","rebuy":false,"favoriteCount":0,"favorite":false,"createdAt":[2023,9,5,17,9,53]},{"id":1018740,"userName":"member47847","profileImage":"image47847","image":"review_image1018740","rating":0,"tags":[{"id":20,"name":"👀 신기해요","tagType":"ETC"},{"id":5,"name":"🍭 달달해요","tagType":"TASTE"},{"id":11,"name":"💸 갓성비","tagType":"QUANTITY"}],"content":"review_content1018740","rebuy":false,"favoriteCount":0,"favorite":false,"createdAt":[2023,9,5,17,9,53]}]}
```

## ⏰ 일정

- 추정 시간 : 0.5
- 걸린 시간 : 0.5
