### PR TITLE
[BE] refactor: Product의 reviewCount 자료형을 Long으로 변경

### DIFF
--- a/backend/src/main/java/com/funeat/product/domain/Product.java
+++ b/backend/src/main/java/com/funeat/product/domain/Product.java
@@ -44,7 +44,7 @@ public class Product {
     @OneToMany(mappedBy = "product")
     private List<ProductBookmark> productBookmarks;
 
-    private AtomicLong reviewCount = new AtomicLong(0);
+    private Long reviewCount = 0L;
 
     protected Product() {
     }
@@ -112,10 +112,10 @@ public class Product {
     }
 
     public Long getReviewCount() {
-        return reviewCount.get();
+        return reviewCount;
     }
 
     public void addReviewCount() {
-        reviewCount.incrementAndGet();
+        reviewCount++;
     }
 }


### PR DESCRIPTION
## Issue

- close #659

## ✨ 구현한 기능

- Product의 reviewCount 자료형을 Long으로 변경

## 📢 논의하고 싶은 내용

- 추후 동시성 처리 관련 논의 필요

## 🎸 기타

AtomicLong의 경우 jpa를 이용해 영속화 하기 위해서는 
[AttributeConverter](https://docs.jboss.org/hibernate/orm/5.6/userguide/html_single/Hibernate_User_Guide.html#basic-jpa-convert)를 만들거나, [Custom Type](https://docs.jboss.org/hibernate/orm/5.6/userguide/html_single/Hibernate_User_Guide.html#basic-custom-type)을 만들어야 한다.

ReviewCount에 AtomicLong을 도입했던 이유는 임시 동시성 제어를 위해서였는데,
해당 사항은 아직 논의가 끝나지 않았기 때문에
우선 Long으로 처리 후 논의가 끝나면 본격적인 동시성 처리를 할 예정

## ⏰ 일정

- 추정 시간 : 0.1
- 걸린 시간 : 0.1
