### PR TITLE
[BE] fix: 테스트 컨텍스트가 초기화될 때,  새로운 테스트 환경에서 테스트하도록 설정

### DIFF
--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -4,7 +4,7 @@ spring:
 
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:test;MODE=MySQL
+    url: jdbc:h2:mem:test${random.uuid};MODE=MySQL
     username: sa
 
   jpa:


### PR DESCRIPTION
## Issue

- close #652

## ✨ 구현한 기능

- test 패키지에 `appliation.yml`에서 h2 데이터베이스 주소를 uuid로 하여 테스트 컨텍스트가 초기화 되어도 h2 데이터베이스 주소가 겹치지 않도록 합니다.

## 📢 논의하고 싶은 내용

h2 코드 까봤는데

![스크린샷 2023-09-19 오전 2 34 14](https://github.com/woowacourse-teams/2023-fun-eat/assets/79046106/b8b649c0-0000-44fc-b97d-55460d636fc8)

저기서 result를 얻는 과정에서 에러가 나옵니다.

### [에러 발생할 때]

![스크린샷 2023-09-19 오전 3 19 02](https://github.com/woowacourse-teams/2023-fun-eat/assets/79046106/e086690f-8e40-4e23-9991-1f94cabec434)

### [정상 작동할 때]

![스크린샷 2023-09-19 오전 3 19 42](https://github.com/woowacourse-teams/2023-fun-eat/assets/79046106/f8b30728-cd6a-4f9c-930c-7edc80b95d2f)

- 계속 테스트해보니 메모리 사용량이 많을 경우 발생하는 것으로 보입니다. 제대로 된 원인은 아무리 봐도 모르겠어요.
- 추정되는건 테스트 컨택스트가 초기화 될 때, 다시 디비를 연결하던데 이 과정에서 이상이 았는 것 같습니다.
- 그래서 테스트 컨텍스트가 초기화 될 때마다 새로운 디비 주소로 연결할 수 있도록 합니다.
- 이후엔 메모리 사용량이 많은 상태에서 계속 테스트를 돌려봐도 에러가 나오질 않습니다.

## 🎸 기타


## ⏰ 일정

- 추정 시간 : 0.5
- 걸린 시간 : 6
