### PR TITLE
[BE] fix: 이미지가 없는 리뷰는 상품 이미지 변경 대상에 제외

### DIFF
--- a/backend/src/main/java/com/funeat/review/persistence/ReviewRepository.java
+++ b/backend/src/main/java/com/funeat/review/persistence/ReviewRepository.java
@@ -31,7 +31,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("SELECT r "
             + "FROM Review r "
             + "LEFT JOIN r.product p "
-            + "WHERE p.id = :id AND r.image IS NOT NULL "
+            + "WHERE p.id = :id AND r.image != '' "
             + "ORDER BY r.favoriteCount DESC, r.id DESC")
     List<Review> findPopularReviewWithImage(@Param("id") final Long productId, final Pageable pageable);
 }

--- a/backend/src/test/java/com/funeat/fixture/ReviewFixture.java
+++ b/backend/src/test/java/com/funeat/fixture/ReviewFixture.java
@@ -15,7 +15,7 @@ public class ReviewFixture {
     }
 
     public static Review 리뷰_이미지없음_평점1점_재구매O_생성(final Member member, final Product product, final Long count) {
-        return new Review(member, product, null, 1L, "test", true, count);
+        return new Review(member, product, "", 1L, "test", true, count);
     }
 
     public static Review 리뷰_이미지test1_평점1점_재구매X_생성(final Member member, final Product product, final Long count) {

--- a/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
+++ b/backend/src/test/java/com/funeat/review/application/ReviewServiceTest.java
@@ -738,6 +738,35 @@ class ReviewServiceTest extends ServiceTest {
             // then
             assertThat(actual).isEqualTo(expected);
         }
+
+        @Test
+        void 이미지가_존재하지_않는_리뷰들만_있으면_상품_이미지는_바뀌지_않는다() {
+            // given
+            final var member = 멤버_멤버1_생성();
+            단일_멤버_저장(member);
+
+            final var category = 카테고리_즉석조리_생성();
+            단일_카테고리_저장(category);
+
+            final var product = 상품_삼각김밥_가격1000원_평점2점_생성(category);
+            단일_상품_저장(product);
+
+            final var firstReview = 리뷰_이미지없음_평점1점_재구매O_생성(member, product, 3L);
+            final var firstReviewId = 단일_리뷰_저장(firstReview);
+            reviewService.updateProductImage(firstReviewId);
+
+            final var secondReview = 리뷰_이미지없음_평점1점_재구매O_생성(member, product, 2L);
+            final var secondReviewId = 단일_리뷰_저장(secondReview);
+
+            final var expected = secondReview.getImage();
+
+            // when
+            reviewService.updateProductImage(secondReviewId);
+            final var actual = product.getImage();
+
+            // then
+            assertThat(actual).isNotEqualTo(expected);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Issue

- close #666 

## ✨ 구현한 기능

- 이미지가 없는 리뷰는 좋아요가 눌러서 제일 많은 리뷰가 되어도 상품 이미지가 변경되지 않습니다.

## 📢 논의하고 싶은 내용

- S3를 도입하면서 `null`로 저장되던 이미지 경로가 이후엔 `""`로 저장되어서 발생하는 문제
- 현재 디비에는 `""`로 되어서 에러가 발생해하는 부분을 `image = null`로 변경해두었습니다.
- ~~생각해보니 프론트에서도 `null`일 때 기본 이미지를 처리할 것 같은데, `""`로 같이 변경해야할 것 같아요~~ (어차피 변경 대상에 제외되어서 고려할 필요 없음)

## 🎸 기타

- x

## ⏰ 일정

- 추정 시간 : 0.5
- 걸린 시간 : 0.5
