### PR TITLE
[ALL] Github Actions workflows 버전 관리

### DIFF
--- a/.github/workflows/test-fe.yml
+++ b/.github/workflows/test-fe.yml
@@ -47,7 +47,7 @@ jobs:
         continue-on-error: true
 
       - name: 테스트 결과 PR에 코멘트 등록
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: '**/frontend/test-results/results.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         run: ./gradlew --info test
 
       - name: 테스트 결과 PR에 코멘트 등록
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: '**/backend/build/test-results/test/TEST-*.xml'


### PR DESCRIPTION
## Issue

- close #651

## ✨ 구현한 기능

- 회의한 내용대로 노드 20 버전이 필요한 버전까지 안올렸습니다.
  - [올라간 버전]
  - `EnricoMi/publish-unit-test-result-action@v1` → `EnricoMi/publish-unit-test-result-action@v2`
- 참고 (노드 20 버전으로 업데이트할 때)
  - [공통]
  - `actions/checkout@v3` → `actions/checkout@v4`
  - `mikepenz/action-junit-report@v3` → `mikepenz/action-junit-report@v4`
  - [프론트]
  - `node-version: '18.16.1'` → `node-version: '20.x.x' (그때 버전에 맞게 수정)`
  - [기타]
  - 시간이 지나면 나중에 다른 곳들도 버전이 올라갈 수도 있음

`actions/checkout@v4`의 경우엔 현재 노드 20 미만의 버전을 지원하지 않는다고 합니다 ([참고](https://github.com/actions/checkout/issues/1385))

## 📢 논의하고 싶은 내용

-x

## 🎸 기타

- x

## ⏰ 일정

- 추정 시간 : 0.5
- 걸린 시간 : 1
