### PR TITLE
[BE] 상품 목록 조회 api 성능 개선

### DIFF
--- a/backend/src/main/java/com/funeat/product/application/ProductService.java
+++ b/backend/src/main/java/com/funeat/product/application/ProductService.java
@@ -32,11 +32,11 @@ import com.funeat.review.persistence.ReviewTagRepository;
 import com.funeat.tag.domain.Tag;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -75,20 +75,10 @@ public class ProductService {
         final Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new CategoryNotFoundException(CATEGORY_NOT_FOUND, categoryId));
 
-        final Page<ProductInCategoryDto> pages = getAllProductsInCategory(pageable, category);
-
-        final PageDto pageDto = PageDto.toDto(pages);
+        final Slice<ProductInCategoryDto> pages = productRepository.findAllByCategory(category, pageable);
         final List<ProductInCategoryDto> productDtos = pages.getContent();
 
-        return ProductsInCategoryResponse.toResponse(pageDto, productDtos);
-    }
-
-    private Page<ProductInCategoryDto> getAllProductsInCategory(final Pageable pageable, final Category category) {
-        if (Objects.nonNull(pageable.getSort().getOrderFor(REVIEW_COUNT))) {
-            final PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-            return productRepository.findAllByCategoryOrderByReviewCountDesc(category, pageRequest);
-        }
-        return productRepository.findAllByCategory(category, pageable);
+        return ProductsInCategoryResponse.toResponse(pages.hasNext(), productDtos);
     }
 
     public ProductResponse findProductDetail(final Long productId) {

--- a/backend/src/main/java/com/funeat/product/domain/Product.java
+++ b/backend/src/main/java/com/funeat/product/domain/Product.java
@@ -68,6 +68,16 @@ public class Product {
         this.category = category;
     }
 
+    public Product(final String name, final Long price, final String image, final String content,
+                   final Category category, final Long reviewCount) {
+        this.name = name;
+        this.price = price;
+        this.image = image;
+        this.content = content;
+        this.category = category;
+        this.reviewCount = reviewCount;
+    }
+
     public void updateAverageRating(final Long rating, final Long count) {
         final double calculatedRating = ((count - 1) * averageRating + rating) / count;
         this.averageRating = Math.round(calculatedRating * 10.0) / 10.0;

--- a/backend/src/main/java/com/funeat/product/dto/ProductInCategoryDto.java
+++ b/backend/src/main/java/com/funeat/product/dto/ProductInCategoryDto.java
@@ -54,16 +54,4 @@ public class ProductInCategoryDto {
     public Long getReviewCount() {
         return reviewCount;
     }
-
-    @Override
-    public String toString() {
-        return "ProductInCategoryDto{" +
-                "id=" + id +
-                ", name='" + name + '\'' +
-                ", price=" + price +
-                ", image='" + image + '\'' +
-                ", averageRating=" + averageRating +
-                ", reviewCount=" + reviewCount +
-                '}';
-    }
 }

--- a/backend/src/main/java/com/funeat/product/dto/ProductInCategoryDto.java
+++ b/backend/src/main/java/com/funeat/product/dto/ProductInCategoryDto.java
@@ -21,6 +21,11 @@ public class ProductInCategoryDto {
         this.reviewCount = reviewCount;
     }
 
+    public static ProductInCategoryDto toDto(final Product product) {
+        return new ProductInCategoryDto(product.getId(), product.getName(), product.getPrice(), product.getImage(),
+                product.getAverageRating(), product.getReviewCount());
+    }
+
     public static ProductInCategoryDto toDto(final Product product, final Long reviewCount) {
         return new ProductInCategoryDto(product.getId(), product.getName(), product.getPrice(), product.getImage(),
                 product.getAverageRating(), reviewCount);
@@ -48,5 +53,17 @@ public class ProductInCategoryDto {
 
     public Long getReviewCount() {
         return reviewCount;
+    }
+
+    @Override
+    public String toString() {
+        return "ProductInCategoryDto{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", price=" + price +
+                ", image='" + image + '\'' +
+                ", averageRating=" + averageRating +
+                ", reviewCount=" + reviewCount +
+                '}';
     }
 }

--- a/backend/src/main/java/com/funeat/product/dto/ProductsInCategoryResponse.java
+++ b/backend/src/main/java/com/funeat/product/dto/ProductsInCategoryResponse.java
@@ -1,24 +1,24 @@
 package com.funeat.product.dto;
 
-import com.funeat.common.dto.PageDto;
 import java.util.List;
 
 public class ProductsInCategoryResponse {
 
-    private final PageDto page;
+    private final boolean hasNext;
     private final List<ProductInCategoryDto> products;
 
-    public ProductsInCategoryResponse(final PageDto page, final List<ProductInCategoryDto> products) {
-        this.page = page;
+    public ProductsInCategoryResponse(final boolean hasNext, final List<ProductInCategoryDto> products) {
+        this.hasNext = hasNext;
         this.products = products;
     }
 
-    public static ProductsInCategoryResponse toResponse(final PageDto page, final List<ProductInCategoryDto> products) {
-        return new ProductsInCategoryResponse(page, products);
+    public static ProductsInCategoryResponse toResponse(final boolean hasNext,
+                                                        final List<ProductInCategoryDto> products) {
+        return new ProductsInCategoryResponse(hasNext, products);
     }
 
-    public PageDto getPage() {
-        return page;
+    public boolean isHasNext() {
+        return hasNext;
     }
 
     public List<ProductInCategoryDto> getProducts() {

--- a/backend/src/main/java/com/funeat/product/persistence/ProductInCategoryRepository.java
+++ b/backend/src/main/java/com/funeat/product/persistence/ProductInCategoryRepository.java
@@ -1,0 +1,177 @@
+package com.funeat.product.persistence;
+
+import com.funeat.product.domain.Category;
+import com.funeat.product.dto.ProductInCategoryDto;
+import java.util.List;
+import javax.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ProductInCategoryRepository {
+
+    private final EntityManager entityManager;
+
+    public ProductInCategoryRepository(final EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    public List<ProductInCategoryDto> findProductByPriceAscFirst(Category category) {
+        String jpqlQuery =
+                "SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, p.reviewCount) "
+                        + "FROM Product p "
+                        + "WHERE p.category = :category "
+                        + "ORDER BY p.price asc, p.id DESC ";
+
+        return entityManager.createQuery(jpqlQuery, ProductInCategoryDto.class)
+                .setParameter("category", category)
+                .setMaxResults(11)
+                .getResultList();
+    }
+
+    public List<ProductInCategoryDto> findProductByPriceAsc(Category category, Long lastProductId) {
+        String jpqlQuery =
+                "SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, p.reviewCount) "
+                        + "FROM Product p "
+                        + "JOIN Product p2 ON p2.id =:lastProductId "
+                        + "WHERE p.category = :category AND "
+                        + "( "
+                        + "  (p.price = p2.price AND p.id<:lastProductId)"
+                        + "or p.price >p2.price "
+                        + ") "
+                        + "ORDER BY p.price asc, p.id DESC ";
+
+        return entityManager.createQuery(jpqlQuery, ProductInCategoryDto.class)
+                .setParameter("lastProductId", lastProductId)
+                .setParameter("category", category)
+                .setMaxResults(11)
+                .getResultList();
+    }
+
+    public List<ProductInCategoryDto> findProductByPriceDescFirst(Category category) {
+        String jpqlQuery =
+                "SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, p.reviewCount) "
+                        + "FROM Product p "
+                        + "WHERE p.category = :category "
+                        + "ORDER BY p.price desc, p.id DESC ";
+
+        return entityManager.createQuery(jpqlQuery, ProductInCategoryDto.class)
+                .setParameter("category", category)
+                .setMaxResults(11)
+                .getResultList();
+    }
+
+    public List<ProductInCategoryDto> findProductByPriceDesc(Category category, Long lastProductId) {
+        String jpqlQuery =
+                "SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, p.reviewCount) "
+                        + "FROM Product p "
+                        + "JOIN Product p2 ON p2.id =:lastProductId "
+                        + "WHERE p.category = :category AND "
+                        + "( "
+                        + "  (p.price = p2.price AND p.id<:lastProductId)"
+                        + "or p.price < p2.price "
+                        + ") "
+                        + "ORDER BY p.price desc, p.id DESC ";
+
+        return entityManager.createQuery(jpqlQuery, ProductInCategoryDto.class)
+                .setParameter("lastProductId", lastProductId)
+                .setParameter("category", category)
+                .setMaxResults(11)
+                .getResultList();
+    }
+
+    public List<ProductInCategoryDto> findProductByAverageRatingAscFirst(Category category) {
+        String jpqlQuery =
+                "SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, p.reviewCount) "
+                        + "FROM Product p "
+                        + "WHERE p.category = :category "
+                        + "ORDER BY p.averageRating asc, p.id DESC ";
+
+        return entityManager.createQuery(jpqlQuery, ProductInCategoryDto.class)
+                .setParameter("category", category)
+                .setMaxResults(11)
+                .getResultList();
+    }
+
+    public List<ProductInCategoryDto> findProductByAverageRatingAsc(Category category, Long lastProductId) {
+        String jpqlQuery =
+                "SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, p.reviewCount) "
+                        + "FROM Product p "
+                        + "JOIN Product p2 ON p2.id =:lastProductId "
+                        + "WHERE p.category = :category AND "
+                        + "( "
+                        + "  (p.averageRating = p2.averageRating AND p.id<:lastProductId)"
+                        + "or p.averageRating > p2.averageRating "
+                        + ") "
+                        + "ORDER BY p.averageRating asc, p.id DESC ";
+
+        return entityManager.createQuery(jpqlQuery, ProductInCategoryDto.class)
+                .setParameter("lastProductId", lastProductId)
+                .setParameter("category", category)
+                .setMaxResults(11)
+                .getResultList();
+    }
+
+    public List<ProductInCategoryDto> findProductByAverageRatingDescFirst(Category category) {
+        String jpqlQuery =
+                "SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, p.reviewCount) "
+                        + "FROM Product p "
+                        + "WHERE p.category = :category "
+                        + "ORDER BY p.averageRating desc, p.id DESC ";
+
+        return entityManager.createQuery(jpqlQuery, ProductInCategoryDto.class)
+                .setParameter("category", category)
+                .setMaxResults(11)
+                .getResultList();
+    }
+
+    public List<ProductInCategoryDto> findProductByAverageRatingDesc(Category category, Long lastProductId) {
+        String jpqlQuery =
+                "SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, p.reviewCount) "
+                        + "FROM Product p "
+                        + "JOIN Product p2 ON p2.id =:lastProductId "
+                        + "WHERE p.category = :category AND "
+                        + "( "
+                        + "  (p.averageRating = p2.averageRating AND p.id<:lastProductId)"
+                        + "or p.averageRating < p2.averageRating "
+                        + ") "
+                        + "ORDER BY p.averageRating desc, p.id DESC ";
+
+        return entityManager.createQuery(jpqlQuery, ProductInCategoryDto.class)
+                .setParameter("lastProductId", lastProductId)
+                .setParameter("category", category)
+                .setMaxResults(11)
+                .getResultList();
+    }
+
+    public List<ProductInCategoryDto> findProductByReviewCountDescFirst(Category category) {
+        String jpqlQuery =
+                "SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, p.reviewCount) "
+                        + "FROM Product p "
+                        + "WHERE p.category = :category "
+                        + "ORDER BY p.reviewCount desc, p.id DESC ";
+
+        return entityManager.createQuery(jpqlQuery, ProductInCategoryDto.class)
+                .setParameter("category", category)
+                .setMaxResults(11)
+                .getResultList();
+    }
+
+    public List<ProductInCategoryDto> findProductByReviewCountDesc(Category category, Long lastProductId) {
+        String jpqlQuery =
+                "SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, p.reviewCount) "
+                        + "FROM Product p "
+                        + "JOIN Product p2 ON p2.id =:lastProductId "
+                        + "WHERE p.category = :category AND "
+                        + "( "
+                        + "  (p.reviewCount = p2.reviewCount AND p.id<:lastProductId)"
+                        + "or p.reviewCount < p2.reviewCount "
+                        + ") "
+                        + "ORDER BY p.averageRating desc, p.id DESC ";
+
+        return entityManager.createQuery(jpqlQuery, ProductInCategoryDto.class)
+                .setParameter("lastProductId", lastProductId)
+                .setParameter("category", category)
+                .setMaxResults(11)
+                .getResultList();
+    }
+}

--- a/backend/src/main/java/com/funeat/product/persistence/ProductRepository.java
+++ b/backend/src/main/java/com/funeat/product/persistence/ProductRepository.java
@@ -7,29 +7,17 @@ import com.funeat.product.dto.ProductReviewCountDto;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
-    @Query(value = "SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, COUNT(r)) "
+    @Query(value = "SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, p.reviewCount) "
             + "FROM Product p "
-            + "LEFT JOIN p.reviews r "
-            + "WHERE p.category = :category "
-            + "GROUP BY p ",
-            countQuery = "SELECT COUNT(p) FROM Product p WHERE p.category = :category")
-    Page<ProductInCategoryDto> findAllByCategory(@Param("category") final Category category, final Pageable pageable);
-
-    @Query(value = "SELECT new com.funeat.product.dto.ProductInCategoryDto(p.id, p.name, p.price, p.image, p.averageRating, COUNT(r)) "
-                    + "FROM Product p "
-                    + "LEFT JOIN p.reviews r "
-                    + "WHERE p.category = :category "
-                    + "GROUP BY p "
-                    + "ORDER BY COUNT(r) DESC, p.id DESC ",
-            countQuery = "SELECT COUNT(p) FROM Product p WHERE p.category = :category")
-    Page<ProductInCategoryDto> findAllByCategoryOrderByReviewCountDesc(@Param("category") final Category category,
-                                                                       final Pageable pageable);
+            + "WHERE p.category = :category ")
+    Slice<ProductInCategoryDto> findAllByCategory(@Param("category") final Category category, final Pageable pageable);
 
     @Query("SELECT new com.funeat.product.dto.ProductReviewCountDto(p, COUNT(r.id)) "
             + "FROM Product p "

--- a/backend/src/main/java/com/funeat/product/presentation/ProductApiController.java
+++ b/backend/src/main/java/com/funeat/product/presentation/ProductApiController.java
@@ -29,8 +29,9 @@ public class ProductApiController implements ProductController {
 
     @GetMapping("/categories/{categoryId}/products")
     public ResponseEntity<ProductsInCategoryResponse> getAllProductsInCategory(@PathVariable final Long categoryId,
-                                                                               @PageableDefault final Pageable pageable) {
-        final ProductsInCategoryResponse response = productService.getAllProductsInCategory(categoryId, pageable);
+                                                                               @RequestParam(name = "id") Long lastId,
+                                                                               @RequestParam(name = "sort") String sort) {
+        final ProductsInCategoryResponse response = productService.getAllProductsInCategory(categoryId, lastId, sort);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/funeat/product/presentation/ProductController.java
+++ b/backend/src/main/java/com/funeat/product/presentation/ProductController.java
@@ -26,7 +26,9 @@ public interface ProductController {
     )
     @GetMapping
     ResponseEntity<ProductsInCategoryResponse> getAllProductsInCategory(
-            @PathVariable(name = "category_id") final Long categoryId, @PageableDefault final Pageable pageable
+            @PathVariable final Long categoryId,
+            @RequestParam(name = "id") Long lastId,
+            @RequestParam(name = "sort") String sort
     );
 
     @Operation(summary = "해당 상품 상세 조회", description = "해당 상품 상세정보를 조회한다.")

--- a/backend/src/test/java/com/funeat/acceptance/common/CommonSteps.java
+++ b/backend/src/test/java/com/funeat/acceptance/common/CommonSteps.java
@@ -74,4 +74,11 @@ public class CommonSteps {
         assertThat(actual).usingRecursiveComparison()
                 .isEqualTo(expected);
     }
+
+    public static void 다음_페이지_유무를_검증한다(final ExtractableResponse<Response> response, final boolean expected) {
+        final var actual = response.jsonPath().getBoolean("hasNext");
+
+        assertThat(actual)
+                .isEqualTo(expected);
+    }
 }

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
@@ -126,7 +126,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 final var 상품3 = 단일_상품_저장(상품_삼각김밥_가격4000원_평점4점_생성(카테고리));
 
                 // when
-                final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 가격_내림차순, FIRST_PAGE);
+                final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 가격_내림차순, 0L);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
@@ -144,7 +144,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 final var 상품3 = 단일_상품_저장(상품_삼각김밥_가격1000원_평점1점_생성(카테고리));
 
                 // when
-                final var 응답 = 카테고리별_상품_목록_조회_요청(카테고리_아이디, 가격_내림차순, FIRST_PAGE);
+                final var 응답 = 카테고리별_상품_목록_조회_요청(카테고리_아이디, 가격_내림차순, 0L);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
@@ -166,7 +166,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 final var 상품3 = 단일_상품_저장(상품_삼각김밥_가격2000원_평점3점_생성(카테고리));
 
                 // when
-                final var 응답 = 카테고리별_상품_목록_조회_요청(카테고리_아이디, 가격_오름차순, FIRST_PAGE);
+                final var 응답 = 카테고리별_상품_목록_조회_요청(카테고리_아이디, 가격_오름차순, 0L);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
@@ -184,7 +184,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 단일_상품_저장(상품_삼각김밥_가격1000원_평점1점_생성(카테고리));
 
                 // when
-                final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 가격_오름차순, FIRST_PAGE);
+                final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 가격_오름차순, 0L);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
@@ -206,7 +206,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 단일_상품_저장(상품_삼각김밥_가격2000원_평점1점_생성(카테고리));
 
                 // when
-                final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 평균_평점_내림차순, FIRST_PAGE);
+                final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 평균_평점_내림차순, 0L);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
@@ -224,7 +224,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 단일_상품_저장(상품_삼각김밥_가격2000원_평점1점_생성(카테고리));
 
                 // when
-                final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 평균_평점_내림차순, FIRST_PAGE);
+                final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 평균_평점_내림차순, 0L);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
@@ -246,7 +246,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 단일_상품_저장(상품_삼각김밥_가격2000원_평점3점_생성(카테고리));
 
                 // when
-                final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 평균_평점_오름차순, FIRST_PAGE);
+                final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 평균_평점_오름차순, 0L);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
@@ -264,7 +264,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 단일_상품_저장(상품_삼각김밥_가격2000원_평점1점_생성(카테고리));
 
                 // when
-                final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 평균_평점_오름차순, FIRST_PAGE);
+                final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 평균_평점_오름차순, 0L);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
@@ -291,7 +291,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 리뷰_작성_요청(로그인_쿠키_획득(멤버2), 상품2, 사진_명세_요청(이미지3), 리뷰추가요청_재구매O_생성(점수_2점, List.of(태그)));
 
                 // when
-                final var 응답 = 카테고리별_상품_목록_조회_요청(카테고리_아이디, 리뷰수_내림차순, FIRST_PAGE);
+                final var 응답 = 카테고리별_상품_목록_조회_요청(카테고리_아이디, 리뷰수_내림차순, 0L);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
@@ -309,7 +309,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 final var 상품3 = 단일_상품_저장(상품_삼각김밥_가격3000원_평점1점_생성(카테고리));
 
                 // when
-                final var 응답 = 카테고리별_상품_목록_조회_요청(카테고리_아이디, 리뷰수_내림차순, FIRST_PAGE);
+                final var 응답 = 카테고리별_상품_목록_조회_요청(카테고리_아이디, 리뷰수_내림차순, 0L);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
@@ -325,7 +325,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
         @Test
         void 상품을_정렬할때_카테고리가_존재하지_않으면_예외가_발생한다() {
             // given && when
-            final var 응답 = 카테고리별_상품_목록_조회_요청(존재하지_않는_카테고리, 가격_내림차순, FIRST_PAGE);
+            final var 응답 = 카테고리별_상품_목록_조회_요청(존재하지_않는_카테고리, 가격_내림차순, 0L);
 
             // then
             STATUS_CODE를_검증한다(응답, 찾을수_없음);

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.funeat.acceptance.product;
 
 import static com.funeat.acceptance.auth.LoginSteps.로그인_쿠키_획득;
 import static com.funeat.acceptance.common.CommonSteps.STATUS_CODE를_검증한다;
+import static com.funeat.acceptance.common.CommonSteps.다음_페이지_유무를_검증한다;
 import static com.funeat.acceptance.common.CommonSteps.사진_명세_요청;
 import static com.funeat.acceptance.common.CommonSteps.여러개_사진_명세_요청;
 import static com.funeat.acceptance.common.CommonSteps.정상_처리;
@@ -124,14 +125,12 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 final var 상품2 = 단일_상품_저장(상품_삼각김밥_가격2000원_평점3점_생성(카테고리));
                 final var 상품3 = 단일_상품_저장(상품_삼각김밥_가격4000원_평점4점_생성(카테고리));
 
-                final var 예상_응답_페이지 = 응답_페이지_생성(총_데이터_개수(3L), 총_페이지(1L), 첫페이지O, 마지막페이지O, FIRST_PAGE, PAGE_SIZE);
-
                 // when
                 final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 가격_내림차순, FIRST_PAGE);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
-                페이지를_검증한다(응답, 예상_응답_페이지);
+                다음_페이지_유무를_검증한다(응답, false);
                 카테고리별_상품_목록_조회_결과를_검증한다(응답, List.of(상품3, 상품1, 상품2));
             }
 
@@ -144,14 +143,12 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 final var 상품2 = 단일_상품_저장(상품_삼각김밥_가격1000원_평점3점_생성(카테고리));
                 final var 상품3 = 단일_상품_저장(상품_삼각김밥_가격1000원_평점1점_생성(카테고리));
 
-                final var 예상_응답_페이지 = 응답_페이지_생성(총_데이터_개수(3L), 총_페이지(1L), 첫페이지O, 마지막페이지O, FIRST_PAGE, PAGE_SIZE);
-
                 // when
                 final var 응답 = 카테고리별_상품_목록_조회_요청(카테고리_아이디, 가격_내림차순, FIRST_PAGE);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
-                페이지를_검증한다(응답, 예상_응답_페이지);
+                다음_페이지_유무를_검증한다(응답, false);
                 카테고리별_상품_목록_조회_결과를_검증한다(응답, List.of(상품3, 상품2, 상품1));
             }
         }
@@ -168,14 +165,12 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 final var 상품2 = 단일_상품_저장(상품_삼각김밥_가격4000원_평점4점_생성(카테고리));
                 final var 상품3 = 단일_상품_저장(상품_삼각김밥_가격2000원_평점3점_생성(카테고리));
 
-                final var 예상_응답_페이지 = 응답_페이지_생성(총_데이터_개수(3L), 총_페이지(1L), 첫페이지O, 마지막페이지O, FIRST_PAGE, PAGE_SIZE);
-
                 // when
                 final var 응답 = 카테고리별_상품_목록_조회_요청(카테고리_아이디, 가격_오름차순, FIRST_PAGE);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
-                페이지를_검증한다(응답, 예상_응답_페이지);
+                다음_페이지_유무를_검증한다(응답, false);
                 카테고리별_상품_목록_조회_결과를_검증한다(응답, List.of(상품1, 상품3, 상품2));
             }
 
@@ -188,14 +183,12 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 단일_상품_저장(상품_삼각김밥_가격1000원_평점3점_생성(카테고리));
                 단일_상품_저장(상품_삼각김밥_가격1000원_평점1점_생성(카테고리));
 
-                final var 예상_응답_페이지 = 응답_페이지_생성(3L, 1L, true, true, FIRST_PAGE, PAGE_SIZE);
-
                 // when
                 final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 가격_오름차순, FIRST_PAGE);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
-                페이지를_검증한다(응답, 예상_응답_페이지);
+                다음_페이지_유무를_검증한다(응답, false);
                 카테고리별_상품_목록_조회_결과를_검증한다(응답, List.of(3L, 2L, 1L));
             }
         }
@@ -212,14 +205,12 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 단일_상품_저장(상품_삼각김밥_가격2000원_평점5점_생성(카테고리));
                 단일_상품_저장(상품_삼각김밥_가격2000원_평점1점_생성(카테고리));
 
-                final var 예상_응답_페이지 = 응답_페이지_생성(3L, 1L, true, true, FIRST_PAGE, PAGE_SIZE);
-
                 // when
                 final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 평균_평점_내림차순, FIRST_PAGE);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
-                페이지를_검증한다(응답, 예상_응답_페이지);
+                다음_페이지_유무를_검증한다(응답, false);
                 카테고리별_상품_목록_조회_결과를_검증한다(응답, List.of(2L, 1L, 3L));
             }
 
@@ -232,14 +223,12 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 단일_상품_저장(상품_삼각김밥_가격2000원_평점1점_생성(카테고리));
                 단일_상품_저장(상품_삼각김밥_가격2000원_평점1점_생성(카테고리));
 
-                final var 예상_응답_페이지 = 응답_페이지_생성(3L, 1L, true, true, FIRST_PAGE, PAGE_SIZE);
-
                 // when
                 final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 평균_평점_내림차순, FIRST_PAGE);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
-                페이지를_검증한다(응답, 예상_응답_페이지);
+                다음_페이지_유무를_검증한다(응답, false);
                 카테고리별_상품_목록_조회_결과를_검증한다(응답, List.of(3L, 2L, 1L));
             }
         }
@@ -256,14 +245,12 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 단일_상품_저장(상품_삼각김밥_가격1000원_평점5점_생성(카테고리));
                 단일_상품_저장(상품_삼각김밥_가격2000원_평점3점_생성(카테고리));
 
-                final var 예상_응답_페이지 = 응답_페이지_생성(3L, 1L, true, true, FIRST_PAGE, PAGE_SIZE);
-
                 // when
                 final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 평균_평점_오름차순, FIRST_PAGE);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
-                페이지를_검증한다(응답, 예상_응답_페이지);
+                다음_페이지_유무를_검증한다(응답, false);
                 카테고리별_상품_목록_조회_결과를_검증한다(응답, List.of(1L, 3L, 2L));
             }
 
@@ -276,14 +263,12 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 단일_상품_저장(상품_삼각김밥_가격2000원_평점1점_생성(카테고리));
                 단일_상품_저장(상품_삼각김밥_가격2000원_평점1점_생성(카테고리));
 
-                final var 예상_응답_페이지 = 응답_페이지_생성(3L, 1L, true, true, FIRST_PAGE, PAGE_SIZE);
-
                 // when
                 final var 응답 = 카테고리별_상품_목록_조회_요청(1L, 평균_평점_오름차순, FIRST_PAGE);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
-                페이지를_검증한다(응답, 예상_응답_페이지);
+                다음_페이지_유무를_검증한다(응답, false);
                 카테고리별_상품_목록_조회_결과를_검증한다(응답, List.of(3L, 2L, 1L));
             }
         }
@@ -305,14 +290,12 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 리뷰_작성_요청(로그인_쿠키_획득(멤버1), 상품2, 사진_명세_요청(이미지2), 리뷰추가요청_재구매X_생성(점수_3점, List.of(태그)));
                 리뷰_작성_요청(로그인_쿠키_획득(멤버2), 상품2, 사진_명세_요청(이미지3), 리뷰추가요청_재구매O_생성(점수_2점, List.of(태그)));
 
-                final var 예상_응답_페이지 = 응답_페이지_생성(총_데이터_개수(3L), 총_페이지(1L), 첫페이지O, 마지막페이지O, FIRST_PAGE, PAGE_SIZE);
-
                 // when
                 final var 응답 = 카테고리별_상품_목록_조회_요청(카테고리_아이디, 리뷰수_내림차순, FIRST_PAGE);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
-                페이지를_검증한다(응답, 예상_응답_페이지);
+                다음_페이지_유무를_검증한다(응답, false);
                 카테고리별_상품_목록_조회_결과를_검증한다(응답, List.of(상품2, 상품1, 상품3));
             }
 
@@ -325,14 +308,12 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 final var 상품2 = 단일_상품_저장(상품_삼각김밥_가격5000원_평점3점_생성(카테고리));
                 final var 상품3 = 단일_상품_저장(상품_삼각김밥_가격3000원_평점1점_생성(카테고리));
 
-                final var 예상_응답_페이지 = 응답_페이지_생성(총_데이터_개수(3L), 총_페이지(1L), 첫페이지O, 마지막페이지O, FIRST_PAGE, PAGE_SIZE);
-
                 // when
                 final var 응답 = 카테고리별_상품_목록_조회_요청(카테고리_아이디, 리뷰수_내림차순, FIRST_PAGE);
 
                 // then
                 STATUS_CODE를_검증한다(응답, 정상_처리);
-                페이지를_검증한다(응답, 예상_응답_페이지);
+                다음_페이지_유무를_검증한다(응답, false);
                 카테고리별_상품_목록_조회_결과를_검증한다(응답, List.of(상품3, 상품2, 상품1));
             }
         }

--- a/backend/src/test/java/com/funeat/acceptance/product/ProductSteps.java
+++ b/backend/src/test/java/com/funeat/acceptance/product/ProductSteps.java
@@ -10,10 +10,10 @@ import io.restassured.response.Response;
 public class ProductSteps {
 
     public static ExtractableResponse<Response> 카테고리별_상품_목록_조회_요청(final Long categoryId, final String sort,
-                                                                  final Long page) {
+                                                                  final Long lastId) {
         return given()
                 .queryParam("sort", sort)
-                .queryParam("page", page)
+                .queryParam("id", lastId)
                 .when()
                 .get("/api/categories/{category_id}/products", categoryId)
                 .then()

--- a/backend/src/test/java/com/funeat/fixture/ProductFixture.java
+++ b/backend/src/test/java/com/funeat/fixture/ProductFixture.java
@@ -130,6 +130,22 @@ public class ProductFixture {
         return new Product("애플망고", 3000L, "image.png", "맛있는 애플망고", 5.0, category);
     }
 
+    public static Product 상품_삼각김밥_가격5000원_리뷰0개_생성(final Category category) {
+        return new Product("삼각김밥", 5000L, "image.png", "맛있는 삼각김밥", category, 0L);
+    }
+
+    public static Product 상품_삼각김밥_가격2000원_리뷰1개_생성(final Category category) {
+        return new Product("삼각김밥", 2000L, "image.png", "맛있는 삼각김밥", category, 1L);
+    }
+
+    public static Product 상품_삼각김밥_가격1000원_리뷰3개_생성(final Category category) {
+        return new Product("삼각김밥", 1000L, "image.png", "맛있는 삼각김밥", category, 3L);
+    }
+
+    public static Product 상품_삼각김밥_가격3000원_리뷰5개_생성(final Category category) {
+        return new Product("삼각김밥", 3000L, "image.png", "맛있는 삼각김밥", category, 5L);
+    }
+
     public static ProductRecipe 레시피_안에_들어가는_상품_생성(final Product product, final Recipe recipe) {
         return new ProductRecipe(product, recipe);
     }

--- a/backend/src/test/java/com/funeat/product/persistence/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/funeat/product/persistence/ProductRepositoryTest.java
@@ -6,28 +6,31 @@ import static com.funeat.fixture.MemberFixture.멤버_멤버2_생성;
 import static com.funeat.fixture.MemberFixture.멤버_멤버3_생성;
 import static com.funeat.fixture.PageFixture.가격_내림차순;
 import static com.funeat.fixture.PageFixture.가격_오름차순;
+import static com.funeat.fixture.PageFixture.리뷰수_내림차순;
 import static com.funeat.fixture.PageFixture.페이지요청_기본_생성;
 import static com.funeat.fixture.PageFixture.페이지요청_생성;
 import static com.funeat.fixture.PageFixture.평균_평점_내림차순;
 import static com.funeat.fixture.PageFixture.평균_평점_오름차순;
 import static com.funeat.fixture.ProductFixture.상품_망고빙수_가격5000원_평점4점_생성;
+import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000원_리뷰3개_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000원_평점1점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000원_평점2점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000원_평점3점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000원_평점4점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000원_평점5점_생성;
+import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격2000원_리뷰1개_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격2000원_평점1점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격2000원_평점4점_생성;
+import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격3000원_리뷰5개_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격3000원_평점1점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격3000원_평점5점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격4000원_평점1점_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격4000원_평점2점_생성;
+import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격5000원_리뷰0개_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격5000원_평점1점_생성;
 import static com.funeat.fixture.ProductFixture.상품_애플망고_가격3000원_평점5점_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test1_평점1점_재구매X_생성;
-import static com.funeat.fixture.ReviewFixture.리뷰_이미지test2_평점2점_재구매X_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test3_평점3점_재구매O_생성;
-import static com.funeat.fixture.ReviewFixture.리뷰_이미지test4_평점4점_재구매O_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test4_평점4점_재구매X_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test5_평점5점_재구매O_생성;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,7 +46,7 @@ import org.junit.jupiter.api.Test;
 class ProductRepositoryTest extends RepositoryTest {
 
     @Nested
-    class findByAllCategory_성공_테스트 {
+    class findAllByCategory_성공_테스트 {
 
         @Test
         void 카테고리별_상품을_평점이_높은_순으로_정렬한다() {
@@ -156,10 +159,6 @@ class ProductRepositoryTest extends RepositoryTest {
             assertThat(actual).usingRecursiveComparison()
                     .isEqualTo(expected);
         }
-    }
-
-    @Nested
-    class findAllByCategoryOrderByReviewCountDesc_성공_테스트 {
 
         @Test
         void 카테고리별_상품을_리뷰수가_많은_순으로_정렬한다() {
@@ -167,10 +166,10 @@ class ProductRepositoryTest extends RepositoryTest {
             final var category = 카테고리_간편식사_생성();
             단일_카테고리_저장(category);
 
-            final var product1 = 상품_삼각김밥_가격1000원_평점1점_생성(category);
-            final var product2 = 상품_삼각김밥_가격2000원_평점1점_생성(category);
-            final var product3 = 상품_삼각김밥_가격3000원_평점1점_생성(category);
-            final var product4 = 상품_삼각김밥_가격4000원_평점1점_생성(category);
+            final var product1 = 상품_삼각김밥_가격5000원_리뷰0개_생성(category);
+            final var product2 = 상품_삼각김밥_가격1000원_리뷰3개_생성(category);
+            final var product3 = 상품_삼각김밥_가격2000원_리뷰1개_생성(category);
+            final var product4 = 상품_삼각김밥_가격3000원_리뷰5개_생성(category);
             복수_상품_저장(product1, product2, product3, product4);
 
             final var member1 = 멤버_멤버1_생성();
@@ -178,23 +177,15 @@ class ProductRepositoryTest extends RepositoryTest {
             final var member3 = 멤버_멤버3_생성();
             복수_멤버_저장(member1, member2, member3);
 
-            final var review1_1 = 리뷰_이미지test1_평점1점_재구매X_생성(member1, product1, 0L);
-            final var review1_2 = 리뷰_이미지test3_평점3점_재구매O_생성(member2, product1, 0L);
-            final var review2_1 = 리뷰_이미지test4_평점4점_재구매O_생성(member3, product2, 0L);
-            final var review2_2 = 리뷰_이미지test2_평점2점_재구매X_생성(member1, product2, 0L);
-            final var review2_3 = 리뷰_이미지test3_평점3점_재구매O_생성(member2, product2, 0L);
-            final var review3_1 = 리뷰_이미지test3_평점3점_재구매O_생성(member1, product3, 0L);
-            복수_리뷰_저장(review1_1, review1_2, review2_1, review2_2, review2_3, review3_1);
+            final var page = 페이지요청_생성(0, 3, 리뷰수_내림차순);
 
-            final var page = 페이지요청_기본_생성(0, 3);
-
-            final var productInCategoryDto1 = ProductInCategoryDto.toDto(product2, 3L);
-            final var productInCategoryDto2 = ProductInCategoryDto.toDto(product1, 2L);
-            final var productInCategoryDto3 = ProductInCategoryDto.toDto(product3, 1L);
+            final var productInCategoryDto1 = ProductInCategoryDto.toDto(product4);
+            final var productInCategoryDto2 = ProductInCategoryDto.toDto(product2);
+            final var productInCategoryDto3 = ProductInCategoryDto.toDto(product3);
             final var expected = List.of(productInCategoryDto1, productInCategoryDto2, productInCategoryDto3);
 
             // when
-            final var actual = productRepository.findAllByCategoryOrderByReviewCountDesc(category, page)
+            final var actual = productRepository.findAllByCategory(category, page)
                     .getContent();
 
             // then


### PR DESCRIPTION
## Issue

- close #669

## ✨ 구현한 기능
상품 목록 조회 Api 성능 개선

(기존) 
- ReviewCount를 위해 Product와 Review Join
- Page반환
- reviewCount 기준 정렬로 인해 service에 분기 + repository에 메소드 2개

(1차 개선) 
- ReviewCount 반정규화
- Page 대신 Slice 반환
  - 펀잇은 무한스크롤 방식이기 때문에 페이징에 대한 자세한 정보(ex. 총 페이지 수)가 필요없다.
  - Slice를 반환하여 hasNext(다음 페이지가 존재하는지)값만 넘기도록 수정 
- 오프셋 페이징 -> 커서 페이징
```sql
SELECT
    p.id,
    p.name,
    p.price,
    p.image,
    p.average_rating,
    p.review_count
FROM product p
JOIN product p2
    ON p2.id = :lastReviewId
WHERE
        p.category_id = 2 AND
        (
            (p.price = p2.price AND p.id < :lastReviewId) OR
            p.price > p2.price
        )
ORDER BY p.price, p.id DESC
LIMIT 11;
```

(2차 개선) 인덱스

(3차 개선) 동적 쿼리 ???

## 📢 논의하고 싶은 내용

Pageable을 걷어내다보니 정렬조건에 따라 메소드가 무려 10개가 나옵니다.
동적쿼리를 위한 QueryDsl 도입이 시급!

## 🎸 기타

- X

## ⏰ 일정

- 추정 시간 :
- 걸린 시간 :
