### PR TITLE
[BE] feat: 이미지 업로드 확장자 추가

### DIFF
--- a/backend/src/main/java/com/funeat/common/s3/S3Uploader.java
+++ b/backend/src/main/java/com/funeat/common/s3/S3Uploader.java
@@ -21,7 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Profile("!test")
 public class S3Uploader implements ImageUploader {
 
-    private static final List<String> INCLUDE_EXTENSIONS = List.of("image/jpeg", "image/png");
+    private static final List<String> INCLUDE_EXTENSIONS = List.of("image/jpeg", "image/png", "image/webp");
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -55,7 +55,7 @@ public class S3Uploader implements ImageUploader {
 
     private void validateExtension(final MultipartFile image) {
         final String contentType = image.getContentType();
-        if (!INCLUDE_EXTENSIONS.contains(contentType)){
+        if (!INCLUDE_EXTENSIONS.contains(contentType)) {
             throw new NotAllowedFileExtensionException(IMAGE_EXTENSION_ERROR_CODE, contentType);
         }
     }


### PR DESCRIPTION
## Issue

- close #686 

## ✨ 구현한 기능

- 이미지 업로드 할 때 jpeg, png 만 가능했는데 webp 도 추가했습니다.

## 📢 논의하고 싶은 내용

- 이미지 업로드 할 때 jpeg, png 만 가능했는데 webp 도 추가했습니다.

## 🎸 기타

- x

## ⏰ 일정

- 추정 시간 : 0.1
- 걸린 시간 : 0.1
