### PR TITLE
[FE] feat: 꿀조합 페이지 디자인 수정

### DIFF
--- a/frontend/src/pages/RecipePage.tsx
+++ b/frontend/src/pages/RecipePage.tsx
@@ -50,17 +50,17 @@ const RecipePage = () => {
           <SvgIcon variant="search" />
         </Link>
       </TitleWrapper>
+      <Spacing size={12} />
       <ErrorBoundary fallback={ErrorComponent} handleReset={reset}>
         <Suspense fallback={<Loading />}>
-          <SortButtonWrapper>
-            <SortButton option={selectedOption} onClick={handleOpenSortOptionSheet} />
-          </SortButtonWrapper>
           <RecipeListWrapper ref={recipeRef}>
+            <SortButtonWrapper>
+              <SortButton option={selectedOption} onClick={handleOpenSortOptionSheet} />
+            </SortButtonWrapper>
             <RecipeList selectedOption={selectedOption} />
           </RecipeListWrapper>
         </Suspense>
       </ErrorBoundary>
-      <Spacing size={80} />
       <RecipeRegisterButtonWrapper>
         <RegisterButton
           activeLabel={REGISTER_RECIPE}
@@ -103,11 +103,10 @@ const Title = styled(Heading)`
 const SortButtonWrapper = styled.div`
   display: flex;
   justify-content: flex-end;
-  margin: 20px 0;
 `;
 
 const RecipeListWrapper = styled.div`
-  height: calc(100% - 190px);
+  height: calc(100% - 130px);
   overflow-y: auto;
 `;
 


### PR DESCRIPTION
## Issue

- close #688

## ✨ 구현한 기능

- 꿀조합 페이지 디자인 수정
<img width="357" alt="스크린샷 2023-09-21 오후 1 49 22" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/55427367/8ae44bc9-5368-4495-9704-2ba9e41147b6">

스크롤 내릴 때 정렬버튼은 안내려오게 수정

## 📢 논의하고 싶은 내용

x

## 🎸 기타

x

## ⏰ 일정

- 추정 시간 : 
- 걸린 시간 : 10분
