### PR TITLE
[FE] feat: SEO 개선을 위한 robots.txt, sitemap 추가

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,12 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>펀잇</title>
-    <meta name="description" content="궁금해? 맛있을걸? 먹어봐 🥄" />
+    <meta name="description" content="펀잇은 모든 편의점 음식, 리뷰, 꿀조합을 한눈에 확인할 수 있는 서비스입니다." />
     <meta property="og:title" content="펀잇" />
     <meta property="og:description" content="궁금해? 맛있을걸? 먹어봐 🥄" />
     <meta property="og:url" content="https://funeat.site" />
     <meta property="og:site_name" content="펀잇" />
-    <meta property="og:type" content="website" />
     <meta property="og:image" content="/assets/og-image.png" />
     <meta property="og:image:alt" content="펀잇" />
     <meta property="og:type" content="website" />
@@ -25,7 +24,6 @@
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/variable/pretendardvariable-dynamic-subset.css"
       onload="this.onload=null; this.rel='stylesheet'"
     />
-    <title>펀잇</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,9 @@
+User-agent: *
+Disallow: /404
+Allow: /
+
+# Host
+Host: https://funeat.site/
+
+# Sitemaps
+Sitemap: https://funeat.site/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+  <url>
+    <loc>https://funeat.site</loc>
+    <lastmod>2023-09-25T05:39:39+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://funeat.site/products/food</loc>
+    <lastmod>2023-09-25T05:39:39+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://funeat.site/products/store</loc>
+    <lastmod>2023-09-25T05:39:39+00:00</lastmod>
+  </url>
+  <url>
+    <loc>https://funeat.site/recipes</loc>
+    <lastmod>2023-09-25T05:39:39+00:00</lastmod>
+  </url>
+</urlset>

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -19,6 +19,8 @@ module.exports = merge(common, {
       patterns: [
         { from: 'public/assets', to: 'assets' },
         { from: 'public/manifest.json', to: 'manifest.json' },
+        { from: 'public/robots.txt', to: 'robots.txt' },
+        { from: 'public/sitemap.xml', to: 'sitemap.xml' },
       ],
     }),
   ],


### PR DESCRIPTION
## Issue

- close #712

## ✨ 구현한 기능

- robots.txt와 sitemap.xml 파일 추가
- index.html 메타 태그 수정

## 📢 논의하고 싶은 내용

- 일단 라이브러리 사용 안 하고 저 두개랑 구글 서치 콘솔에 사이트 등록 해뒀습니다. 만약 이래도 개선 안되면 helmet같은 라이브러리 사용해보는 것 고려해봐야 할 것 같습니다. (아마 메인 머지되어야 알 수 있을듯)

## 🎸 기타

- 참고: https://fe-developers.kakaoent.com/2022/221208-basic-seo-guide/

## ⏰ 일정

- 추정 시간 :
- 걸린 시간 : 1시간
