### PR TITLE
[BE] hotfix: id, key Session 에 따로 저장

### DIFF
--- a/backend/src/main/java/com/funeat/admin/presentation/AdminLoginController.java
+++ b/backend/src/main/java/com/funeat/admin/presentation/AdminLoginController.java
@@ -21,10 +21,12 @@ public class AdminLoginController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<Void> login(@RequestBody final AdminAuthInfo adminAuthInfo, final HttpServletRequest request) {
+    public ResponseEntity<Void> login(@RequestBody final AdminAuthInfo adminAuthInfo,
+                                      final HttpServletRequest request) {
         adminChecker.check(adminAuthInfo);
 
-        request.getSession().setAttribute("authInfo", adminAuthInfo);
+        request.getSession().setAttribute("authId", adminAuthInfo.getId());
+        request.getSession().setAttribute("authKey", adminAuthInfo.getKey());
 
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/funeat/admin/util/AdminCheckInterceptor.java
+++ b/backend/src/main/java/com/funeat/admin/util/AdminCheckInterceptor.java
@@ -30,12 +30,13 @@ public class AdminCheckInterceptor implements HandlerInterceptor {
             throw new NotLoggedInException(LOGIN_ADMIN_NOT_FOUND);
         }
 
-        final AdminAuthInfo adminAuthInfo = (AdminAuthInfo) session.getAttribute("authInfo");
+        final String authId = String.valueOf(session.getAttribute("authId"));
+        final String authKey = String.valueOf(session.getAttribute("authKey"));
 
-        if (Objects.isNull(adminAuthInfo)) {
+        if (Objects.isNull(authId) || Objects.isNull(authKey)) {
             throw new NotLoggedInException(LOGIN_ADMIN_NOT_FOUND);
         }
 
-        return adminChecker.check(adminAuthInfo);
+        return adminChecker.check(new AdminAuthInfo(authId, authKey));
     }
 }


### PR DESCRIPTION
## Issue

- close #750 

## ✨ 구현한 기능

- Session 에 id, key를 따로 저장하는 방식으로 바꿨습니다.

## 📢 논의하고 싶은 내용

- x

## 🎸 기타

- x

## ⏰ 일정

- 추정 시간 : 1
- 걸린 시간 : 1
