### PR TITLE
[BE] test: 테스트 환경에 영향받는 비동기 로직 작동 검증 테스트 제거

### DIFF
--- a/backend/src/test/java/com/funeat/review/application/ReviewDeleteEventListenerTest.java
+++ b/backend/src/test/java/com/funeat/review/application/ReviewDeleteEventListenerTest.java
@@ -6,14 +6,10 @@ import static com.funeat.fixture.MemberFixture.멤버_멤버2_생성;
 import static com.funeat.fixture.ProductFixture.상품_삼각김밥_가격1000원_평점2점_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test1_평점1점_재구매O_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test2_평점2점_재구매O_생성;
-import static com.funeat.fixture.ReviewFixture.리뷰_이미지test3_평점3점_재구매O_생성;
 import static com.funeat.fixture.ReviewFixture.리뷰_이미지test4_평점4점_재구매O_생성;
-import static com.funeat.fixture.ReviewFixture.리뷰_이미지없음_평점1점_재구매X_생성;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
 
 import com.funeat.common.EventTest;
 import com.funeat.common.ImageUploader;
@@ -85,48 +81,6 @@ class ReviewDeleteEventListenerTest extends EventTest {
 
     @Nested
     class 이미지_삭제_로직_작동 {
-
-        @Test
-        void 리뷰_삭제가_정상적으로_커밋되고_이미지가_존재하면_이미지_삭제_로직이_작동한다() {
-            // given
-            final var author = 멤버_멤버1_생성();
-            final var authorId = 단일_멤버_저장(author);
-
-            final var category = 카테고리_즉석조리_생성();
-            단일_카테고리_저장(category);
-
-            final var product = 상품_삼각김밥_가격1000원_평점2점_생성(category);
-            단일_상품_저장(product);
-
-            final var review = reviewRepository.save(리뷰_이미지test3_평점3점_재구매O_생성(author, product, 0L));
-
-            // when
-            reviewService.deleteReview(review.getId(), authorId);
-
-            // then
-            verify(uploader, timeout(1000).times(1)).delete(any());
-        }
-
-        @Test
-        void 리뷰_삭제가_정상적으로_커밋되었지만_이미지가_존재하지_않으면_이미지_삭제_로직이_작동하지않는다() {
-            // given
-            final var author = 멤버_멤버1_생성();
-            final var authorId = 단일_멤버_저장(author);
-
-            final var category = 카테고리_즉석조리_생성();
-            단일_카테고리_저장(category);
-
-            final var product = 상품_삼각김밥_가격1000원_평점2점_생성(category);
-            단일_상품_저장(product);
-
-            final var review = reviewRepository.save(리뷰_이미지없음_평점1점_재구매X_생성(author, product, 0L));
-
-            // when
-            reviewService.deleteReview(review.getId(), authorId);
-
-            // then
-            verify(uploader, timeout(1000).times(0)).delete(any());
-        }
 
         @Test
         void 이미지_삭제_로직이_실패해도_메인로직까지_롤백되어서는_안된다() {


### PR DESCRIPTION
## Issue

- close #787 

## ✨ 구현한 기능
<img width="510" alt="image" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/91522259/daca6e06-9c21-4a5e-9cc2-b2fde4dcd02d">
<img width="510" alt="image" src="https://github.com/woowacourse-teams/2023-fun-eat/assets/91522259/d363c8fb-0d7e-4f32-89c9-4b4dbc2f6cdb">

ReviewDeleteEventListenerTest의
`리뷰_삭제가_정상적으로_커밋되었지만_이미지가_존재하지_않으면_이미지_삭제_로직이_작동하지않는다()` 테스트가
테스트 환경에 따라 성공 실패 번갈아 발생

- 로컬에서 성공
- 깃허브액션에서 성공
- 젠킨스 빌드시 성공 실패 번갈아 발생

실패하는 이유 추정 1
- reviewDeleteEventListener의 deleteReviewImageInS3는 비동기로 동작
- 테스트 실행 환경(스레드 개수?)에 따라 전 테스트에서 사용된 이벤트가 다음 테스트에서 잡히는 경우 생김
- ""인 이미지를 가지는 event를 사용하는 테스트에서 자꾸 "test3" 이미지(전 테스트에서 사용되는 이미지)를 가지는 event가 잡힘 -> ""여서 작동하지 않아야 하는 delete 메소드가 "test3"을 읽고 작동 -> 실패
- 해결 시도: 테스트 이후 event 비워주기 events.clear()
=> 근데 젠킨스에서 가끔 실패하는 것으로 보아 아닌듯 ..

실패하는 이유 추정 2
- events.clear로 event를 비워주더라도 이미 앞 테스트에서 uploader.delete는 비동기적으로 작동되었기 때문에 delete 작동 여부 검증에 걸리는듯

정확한 이유는 젠킨스 브랜치 매핑 따로 해서 로그 하나하나 찍어봐야 할 것 같은데
당장 내일 운영 배포해야하기 때문에.. 우선 테스트 삭제 결정

## 📢 논의하고 싶은 내용

- X

## 🎸 기타
- 비동기를 통합테스트하는게 맞을까?
  - 그냥 1) service에서 event 발행하는지 2) eventlistener의 작동(uploader.delete)을 따로따로 테스트하는게 나을까?

## ⏰ 일정

- 추정 시간 : 0.1
- 걸린 시간 : 0.1
