### PR TITLE
[BE] feat: 리뷰 삭제시 상품 정보 업데이트 로직 추가

### DIFF
--- a/backend/src/main/java/com/funeat/product/application/ProductService.java
+++ b/backend/src/main/java/com/funeat/product/application/ProductService.java
@@ -113,10 +113,9 @@ public class ProductService {
     public ProductResponse findProductDetail(final Long productId) {
         final Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new ProductNotFoundException(PRODUCT_NOT_FOUND, productId));
-        final Long reviewCount = reviewRepository.countByProduct(product);
         final List<Tag> tags = reviewTagRepository.findTop3TagsByReviewIn(productId, PageRequest.of(TOP, THREE));
 
-        return ProductResponse.toResponse(product, reviewCount, tags);
+        return ProductResponse.toResponse(product, tags);
     }
 
     public RankingProductsResponse getTop3Products() {

--- a/backend/src/main/java/com/funeat/product/domain/Product.java
+++ b/backend/src/main/java/com/funeat/product/domain/Product.java
@@ -71,13 +71,33 @@ public class Product {
         this.category = category;
         this.reviewCount = reviewCount;
     }
-  
+
+    public Product(final String name, final Long price, final String image, final String content,
+                   final Double averageRating, final Category category, final Long reviewCount) {
+        this.name = name;
+        this.price = price;
+        this.image = image;
+        this.content = content;
+        this.averageRating = averageRating;
+        this.category = category;
+        this.reviewCount = reviewCount;
+    }
+
     public static Product create(final String name, final Long price, final String content, final Category category) {
         return new Product(name, price, null, content, category);
     }
 
-    public void updateAverageRating(final Long rating, final Long count) {
+    public void updateAverageRatingForInsert(final Long count, final Long rating) {
         final double calculatedRating = ((count - 1) * averageRating + rating) / count;
+        this.averageRating = Math.round(calculatedRating * 10.0) / 10.0;
+    }
+
+    public void updateAverageRatingForDelete(final Long deletedRating) {
+        if (reviewCount == 1) {
+            this.averageRating = 0.0;
+            return;
+        }
+        final double calculatedRating = (reviewCount * averageRating - deletedRating) / (reviewCount - 1);
         this.averageRating = Math.round(calculatedRating * 10.0) / 10.0;
     }
 
@@ -132,5 +152,9 @@ public class Product {
 
     public void addReviewCount() {
         reviewCount++;
+    }
+
+    public void minusReviewCount() {
+        reviewCount--;
     }
 }

--- a/backend/src/main/java/com/funeat/product/dto/ProductResponse.java
+++ b/backend/src/main/java/com/funeat/product/dto/ProductResponse.java
@@ -29,13 +29,13 @@ public class ProductResponse {
         this.tags = tags;
     }
 
-    public static ProductResponse toResponse(final Product product, final Long reviewCount, final List<Tag> tags) {
+    public static ProductResponse toResponse(final Product product, final List<Tag> tags) {
         List<TagDto> tagDtos = new ArrayList<>();
         for (Tag tag : tags) {
             tagDtos.add(TagDto.toDto(tag));
         }
         return new ProductResponse(product.getId(), product.getName(), product.getPrice(), product.getImage(),
-                product.getContent(), product.getAverageRating(), reviewCount, tagDtos);
+                product.getContent(), product.getAverageRating(), product.getReviewCount(), tagDtos);
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/funeat/review/application/ReviewService.java
+++ b/backend/src/main/java/com/funeat/review/application/ReviewService.java
@@ -111,7 +111,7 @@ public class ReviewService {
 
         final Long countByProduct = reviewRepository.countByProduct(findProduct);
 
-        findProduct.updateAverageRating(savedReview.getRating(), countByProduct);
+        findProduct.updateAverageRatingForInsert(countByProduct, savedReview.getRating());
         findProduct.addReviewCount();
         reviewTagRepository.saveAll(reviewTags);
     }
@@ -247,11 +247,17 @@ public class ReviewService {
 
         if (review.checkAuthor(member)) {
             eventPublisher.publishEvent(new ReviewDeleteEvent(image));
+            updateProduct(product, review.getRating());
             deleteThingsRelatedToReview(review);
-            updateProductImage(product.getId());
             return;
         }
         throw new NotAuthorOfReviewException(NOT_AUTHOR_OF_REVIEW, memberId);
+    }
+
+    private void updateProduct(final Product product, final Long deletedRating) {
+        updateProductImage(product.getId());
+        product.updateAverageRatingForDelete(deletedRating);
+        product.minusReviewCount();
     }
 
     private void deleteThingsRelatedToReview(final Review review) {

--- a/backend/src/test/java/com/funeat/product/domain/ProductTest.java
+++ b/backend/src/test/java/com/funeat/product/domain/ProductTest.java
@@ -1,7 +1,6 @@
 package com.funeat.product.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -14,17 +13,17 @@ import org.junit.jupiter.api.Test;
 class ProductTest {
 
     @Nested
-    class updateAverageRating_성공_테스트 {
+    class updateAverageRatingForInsert_성공_테스트 {
 
         @Test
         void 평균_평점을_업데이트_할_수_있다() {
             // given
             final var product = new Product("testName", 1000L, "testImage", "testContent", null);
-            final var reviewRating = 4L;
             final var reviewCount = 1L;
+            final var reviewRating = 4L;
 
             // when
-            product.updateAverageRating(reviewRating, reviewCount);
+            product.updateAverageRatingForInsert(reviewCount, reviewRating);
             final var actual = product.getAverageRating();
 
             // then
@@ -35,16 +34,16 @@ class ProductTest {
         void 평균_평점을_여러번_업데이트_할_수_있다() {
             // given
             final var product = new Product("testName", 1000L, "testImage", "testContent", null);
-            final var reviewRating1 = 4L;
-            final var reviewRating2 = 2L;
             final var reviewCount1 = 1L;
             final var reviewCount2 = 2L;
+            final var reviewRating1 = 4L;
+            final var reviewRating2 = 2L;
 
             // when
-            product.updateAverageRating(reviewRating1, reviewCount1);
+            product.updateAverageRatingForInsert(reviewCount1, reviewRating1);
             final var actual1 = product.getAverageRating();
 
-            product.updateAverageRating(reviewRating2, reviewCount2);
+            product.updateAverageRatingForInsert(reviewCount2, reviewRating2);
             final var actual2 = product.getAverageRating();
 
             // then
@@ -58,39 +57,34 @@ class ProductTest {
     }
 
     @Nested
-    class updateAverageRating_실패_테스트 {
+    class updateAverageRatingForDelete_성공_테스트 {
 
         @Test
-        void 리뷰_평점에_null_값이_들어오면_예외가_발생한다() {
+        void 리뷰가_하나인_상품의_리뷰를_삭제하면_평균평점은_0점이_된다() {
             // given
-            final var product = new Product("testName", 1000L, "testImage", "testContent", null);
-            final var reviewCount = 1L;
+            final var product = new Product("testName", 1000L, "testImage", "testContent", 4.0, null, 1L);
+            final var reviewRating = 4L;
 
             // when
-            assertThatThrownBy(() -> product.updateAverageRating(null, reviewCount))
-                    .isInstanceOf(NullPointerException.class);
+            product.updateAverageRatingForDelete(reviewRating);
+            final var actual = product.getAverageRating();
+
+            // then
+            assertThat(actual).isEqualTo(0.0);
         }
 
         @Test
-        void 리뷰_평점이_0점이라면_예외가_발생해야하는데_관련_로직이_없어_통과하고_있다() {
+        void 리뷰가_여러개인_상품의_리뷰를_삭제하면_평균평점이_갱신된다() {
             // given
-            final var product = new Product("testName", 1000L, "testImage", "testContent", null);
-            final var reviewRating = 0L;
-            final var reviewCount = 1L;
+            final var product = new Product("testName", 1000L, "testImage", "testContent", 4.0, null, 4L);
+            final var reviewRating = 5L;
 
             // when
-            product.updateAverageRating(reviewRating, reviewCount);
-        }
+            product.updateAverageRatingForDelete(reviewRating);
+            final var actual = product.getAverageRating();
 
-        @Test
-        void 리뷰_개수가_0개라면_예외가_발생해야하는데_calculatedRating값이_infinity가_나와_통과하고_있다() {
-            // given
-            final var product = new Product("testName", 1000L, "testImage", "testContent", null);
-            final var reviewRating = 3L;
-            final var reviewCount = 0L;
-
-            // when
-            product.updateAverageRating(reviewRating, reviewCount);
+            // then
+            assertThat(actual).isEqualTo(3.7);
         }
     }
 


### PR DESCRIPTION
## Issue

- close #797 

## ✨ 구현한 기능

- 리뷰 삭제시 상품 속 (반정규화된) 리뷰 관련 데이터 갱신 로직 추가
  - averageRating
  - reviewCount
- 상품 상세 조회시 count 쿼리 날리는 대신 reviewCount 사용하도록 수정

## 📢 논의하고 싶은 내용

- X

## 🎸 기타

- X

## ⏰ 일정

- 추정 시간 : 1
- 걸린 시간 : 1