### PR TITLE
[BE] fix: 상품의 썸네일이었던 리뷰를 삭제했을 경우 썸네일이 업데이트 되지 않는 문제 해결

### DIFF
--- a/backend/src/main/java/com/funeat/review/application/ReviewService.java
+++ b/backend/src/main/java/com/funeat/review/application/ReviewService.java
@@ -247,17 +247,11 @@ public class ReviewService {
 
         if (review.checkAuthor(member)) {
             eventPublisher.publishEvent(new ReviewDeleteEvent(image));
-            updateProduct(product, review.getRating());
             deleteThingsRelatedToReview(review);
+            updateProduct(product, review.getRating());
             return;
         }
         throw new NotAuthorOfReviewException(NOT_AUTHOR_OF_REVIEW, memberId);
-    }
-
-    private void updateProduct(final Product product, final Long deletedRating) {
-        updateProductImage(product.getId());
-        product.updateAverageRatingForDelete(deletedRating);
-        product.minusReviewCount();
     }
 
     private void deleteThingsRelatedToReview(final Review review) {
@@ -280,6 +274,12 @@ public class ReviewService {
                 .map(ReviewFavorite::getId)
                 .collect(Collectors.toList());
         reviewFavoriteRepository.deleteAllByIdInBatch(ids);
+    }
+
+    private void updateProduct(final Product product, final Long deletedRating) {
+        product.updateAverageRatingForDelete(deletedRating);
+        product.minusReviewCount();
+        updateProductImage(product.getId());
     }
 
     public Optional<MostFavoriteReviewResponse> getMostFavoriteReview(final Long productId) {


### PR DESCRIPTION
## Issue

- close #813

## ✨ 구현한 기능

- 리뷰 삭제시 썸네일 업데이트가 제대로 되지 않는 문제 해결

## 📢 논의하고 싶은 내용

- X

## 🎸 기타

- X

## ⏰ 일정

- 추정 시간 : 0.5
- 걸린 시간 : 0.5
