### PR TITLE
[BE] refactor: 특정 상품에 대한 리뷰 목록 조회 N+1 문제 완전히 해결

### DIFF
--- a/backend/src/main/java/com/funeat/review/persistence/ReviewTagRepository.java
+++ b/backend/src/main/java/com/funeat/review/persistence/ReviewTagRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReviewTagRepository extends JpaRepository<ReviewTag, Long> {
 
@@ -21,4 +22,11 @@ public interface ReviewTagRepository extends JpaRepository<ReviewTag, Long> {
     void deleteByReview(final Review review);
 
     List<ReviewTag> findByReview(final Review review);
+
+    @Query("SELECT rt "
+            + "FROM ReviewTag rt "
+            + "JOIN FETCH rt.review "
+            + "JOIN FETCH rt.tag "
+            + "WHERE rt.review.id IN :reviewIds")
+    List<ReviewTag> findReviewTagByReviewIds(@Param("reviewIds") final List<Long> reviewIds);
 }

--- a/backend/src/test/java/com/funeat/acceptance/review/ReviewSteps.java
+++ b/backend/src/test/java/com/funeat/acceptance/review/ReviewSteps.java
@@ -61,10 +61,10 @@ public class ReviewSteps {
                 .cookie("SESSION", loginCookie)
                 .queryParam("sort", sort)
                 .queryParam("page", page)
-                .queryParam("lastReviewId", lastReviewId).log().all()
+                .queryParam("lastReviewId", lastReviewId)
                 .when()
                 .get("/api/products/{product_id}/reviews", productId)
-                .then().log().all()
+                .then()
                 .extract();
     }
 
@@ -80,7 +80,7 @@ public class ReviewSteps {
         return given()
                 .when()
                 .get("/api/ranks/products/{product_id}/reviews", productId)
-                .then().log().all()
+                .then()
                 .extract();
     }
 


### PR DESCRIPTION
## Issue

- close #837 

## ✨ 구현한 기능

#607 에서 해결하지 못한 태그 N+1 문제를 해결했습니다.

최종적으로 날아가는 쿼리: 92개 → 14개 → 3개

![](https://user-images.githubusercontent.com/79046106/278415378-566248f5-5a5f-4ad9-b6f9-360adbcce7bd.png)

이전 PR에서는 `Review`에서 출발해서 `List<Tag>`를 한 번에 가져오는 방법이  아무리봐도 없어서 이 부분은 해결하지 못한채 남겼는데요.

생각해보니 굳이 한 개의 쿼리로 모든걸 다 얻으려고 생각하지말고, `ReviewTag`를 통해 `Tag`들을 가져오는 쿼리 1개를 날려서 `Review`랑 `List<Tag>`를 조립해주면 될 것 같더라구요

그랬더니 해결했습니다.


## 📢 논의하고 싶은 내용

- x

## 🎸 기타

끝

## ⏰ 일정

- 추정 시간 : 2
- 걸린 시간 : 2
